### PR TITLE
Rename .env to .env.dist and fix freeposte refs

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,4 +1,4 @@
-# Freeposte.io main configuration file
+# Mailu main configuration file
 #
 # Most configuration variables can be modified through the Web interface,
 # these few settings must however be configured before starting the mail
@@ -8,10 +8,10 @@
 # Common configuration variables
 ###################################
 
-# Set this to the path where Freeposte data and configuration is stored
-ROOT=/freeposte
+# Set this to the path where Mailu data and configuration is stored
+ROOT=/mailu
 
-# Freeposte version to run (stable, 1.0, 1.1, etc. or latest)
+# Mailu version to run (stable, 1.0, 1.1, etc. or latest)
 VERSION=stable
 
 # Set to a randomly generated 16 bytes string
@@ -21,16 +21,16 @@ SECRET_KEY=ChangeMeChangeMe
 BIND_ADDRESS=127.0.0.1
 
 # Main mail domain
-DOMAIN=freeposte.io
+DOMAIN=mailu.io
 
 # Exposed mail-server hostname
-HOSTNAME=mail.freeposte.io
+HOSTNAME=mail.mailu.io
 
 # Postmaster local part (will append the main mail domain)
 POSTMASTER=admin
 
 # Docker-compose project name, this will prepended to containers names.
-COMPOSE_PROJECT_NAME=freeposte
+COMPOSE_PROJECT_NAME=mailu
 
 ###################################
 # Optional features


### PR DESCRIPTION
Ensure people can have their own config and adopt the new name in the default settings.