### PR TITLE
Add README documents for clamav and nginx

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Mailu
 =====
 
 *This project used to be named Freeposte.io, the name was change back in
-octobre 2016.*
+October 2016.*
 
 Simple yet full-featured mail server as a set of Docker images.
 The idea behing Mailu is identical to motivations that led to poste.io:

--- a/clamav/README.md
+++ b/clamav/README.md
@@ -1,0 +1,12 @@
+Mailu ClamAV container
+======================
+
+ClamAV is an open source antivirus engine for detecting trojans, viruses,
+malware & other malicious threats.
+
+Resources
+---------
+
+ * [Report issues](https://github.com/Mailu/Mailu/issues) and
+    [send Pull Requests](https://github.com/Mailu/Mailu/pulls)
+    in the [main Mailu repository](https://github.com/Mailu/Mailu)

--- a/nginx/README.md
+++ b/nginx/README.md
@@ -1,0 +1,14 @@
+Mailu NGINX container
+=====================
+
+NGINX is a popular and highly efficient webserver and reverse proxy server
+commonly used to power high performance websites. In the Mailu stack it is
+used as the HTTP frontend tunneling requests to the public web services
+provided by other containers.
+
+Resources
+---------
+
+ * [Report issues](https://github.com/Mailu/Mailu/issues) and
+    [send Pull Requests](https://github.com/Mailu/Mailu/pulls)
+    in the [main Mailu repository](https://github.com/Mailu/Mailu)


### PR DESCRIPTION
Picked these 2 to set up split repositories, this gives them a README in the standalone ones as well.