### PR TITLE
Adding fetchmail keep option to .env file

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -65,6 +65,8 @@ RELAYHOST=
 
 # Fetchmail delay
 FETCHMAIL_DELAY=600
+# Set this to True when you want to keep the mail on remote server as well.
+FETCHMAIL_KEEP=False
 
 ###################################
 # Developers

--- a/admin/mailu/translations/nl/LC_MESSAGES/messages.po
+++ b/admin/mailu/translations/nl/LC_MESSAGES/messages.po
@@ -1,0 +1,513 @@
+# English translations for PROJECT.
+# Copyright (C) 2016 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: m.bertens@pe2mbs.nl\n"
+"POT-Creation-Date: 2016-11-10 10:52+0100\n"
+"PO-Revision-Date: 2016-10-02 15:02+0200\n"
+"Last-Translator: Marc Bertens-Nguyen <m.bertens@pe2mbs.nl>\n"
+"Language: nl\n"
+"Language-Team: en <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Marc Bertens-Nguyen\n"
+
+#: mailu/admin/forms.py:32
+msgid "Invalid email address."
+msgstr "Incorrect email adres"
+
+#: mailu/admin/forms.py:36
+msgid "Confirm"
+msgstr "Bevestigen"
+
+#: mailu/admin/forms.py:40 mailu/admin/forms.py:54
+msgid "E-mail"
+msgstr "E-mail"
+
+#: mailu/admin/forms.py:41 mailu/admin/forms.py:55 mailu/admin/forms.py:72
+#: mailu/admin/forms.py:120
+msgid "Password"
+msgstr "Wachtwoord"
+
+#: mailu/admin/forms.py:42 mailu/admin/templates/login.html:9
+#: mailu/admin/templates/login.html:17
+msgid "Sign in"
+msgstr "Aanmelden"
+
+#: mailu/admin/forms.py:46 mailu/admin/templates/domain/details.html:21
+#: mailu/admin/templates/domain/list.html:19
+msgid "Domain name"
+msgstr "Domein naam"
+
+#: mailu/admin/forms.py:47
+msgid "Maximum user count"
+msgstr "Maximal gebruikers aantal"
+
+#: mailu/admin/forms.py:48
+msgid "Maximum alias count"
+msgstr "Maximal alias aantal"
+
+#: mailu/admin/forms.py:49 mailu/admin/forms.py:60 mailu/admin/forms.py:98
+#: mailu/admin/templates/alias/list.html:22
+#: mailu/admin/templates/domain/list.html:22
+#: mailu/admin/templates/user/list.html:24
+msgid "Comment"
+msgstr "Opmerking"
+
+#: mailu/admin/forms.py:50 mailu/admin/forms.py:99
+msgid "Create"
+msgstr "Aanmaken"
+
+#: mailu/admin/forms.py:56
+msgid "Confirm password"
+msgstr "Bevestigen wachtwoord"
+
+#: mailu/admin/forms.py:57 mailu/admin/templates/user/list.html:23
+msgid "Quota"
+msgstr "Quota"
+
+#: mailu/admin/forms.py:58
+msgid "Allow IMAP access"
+msgstr "IMAP toegang toegestaan"
+
+#: mailu/admin/forms.py:59
+msgid "Allow POP3 access"
+msgstr "POP3 toegang toegestaan"
+
+#: mailu/admin/forms.py:61
+msgid "Save"
+msgstr "Opslaan"
+
+#: mailu/admin/forms.py:65
+msgid "Displayed name"
+msgstr "Weergegave naam"
+
+#: mailu/admin/forms.py:66
+msgid "Enable spam filter"
+msgstr "Activeer spam filter"
+
+#: mailu/admin/forms.py:67
+msgid "Spam filter drempel"
+msgstr "Spam filter "
+
+#: mailu/admin/forms.py:68
+msgid "Save settings"
+msgstr "Opslaan instellingen"
+
+#: mailu/admin/forms.py:73
+msgid "Password check"
+msgstr "Wachtwoord controle"
+
+#: mailu/admin/forms.py:74 mailu/admin/templates/sidebar.html:13
+msgid "Update password"
+msgstr "Bijwerken wachtwoord"
+
+#: mailu/admin/forms.py:78
+msgid "Enable forwarding"
+msgstr "Activeer doorsturen"
+
+#: mailu/admin/forms.py:80 mailu/admin/forms.py:97
+#: mailu/admin/templates/alias/list.html:21
+msgid "Destination"
+msgstr "Bestemming"
+
+#: mailu/admin/forms.py:82 mailu/admin/forms.py:90
+msgid "Update"
+msgstr "Bijwerken"
+
+#: mailu/admin/forms.py:86
+msgid "Enable automatic reply"
+msgstr "Activeer automatisch antwoord"
+
+#: mailu/admin/forms.py:87
+msgid "Reply subject"
+msgstr "Reageer onderwerp"
+
+#: mailu/admin/forms.py:88
+msgid "Reply body"
+msgstr "Antwoord tekst"
+
+#: mailu/admin/forms.py:94
+msgid "Alias"
+msgstr "Alias"
+
+#: mailu/admin/forms.py:96
+msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
+msgstr "Gebruik SQL-achtige syntax (bijvoorbeeld voor catch-all aliassen)"
+
+#: mailu/admin/forms.py:103
+msgid "Admin email"
+msgstr "Beheerder email"
+
+#: mailu/admin/forms.py:104 mailu/admin/forms.py:109 mailu/admin/forms.py:121
+msgid "Submit"
+msgstr "Toepassen"
+
+#: mailu/admin/forms.py:108
+msgid "Manager email"
+msgstr "Manager email"
+
+#: mailu/admin/forms.py:113
+msgid "Protocol"
+msgstr "Protocol"
+
+#: mailu/admin/forms.py:116
+msgid "Hostname or IP"
+msgstr "hostnaam of IP"
+
+#: mailu/admin/forms.py:117
+msgid "TCP port"
+msgstr "TCP poort"
+
+#: mailu/admin/forms.py:118
+msgid "Enable TLS"
+msgstr "Activeer TLS"
+
+#: mailu/admin/forms.py:119 mailu/admin/templates/fetch/list.html:21
+msgid "Username"
+msgstr "Gebruikers naam"
+
+#: mailu/admin/forms.py:125
+msgid "Announcement subject"
+msgstr "Aankondigingsonderwerp"
+
+#: mailu/admin/forms.py:127
+msgid "Announcement body"
+msgstr "Aankondigingstekst"
+
+#: mailu/admin/forms.py:129
+msgid "Send"
+msgstr "Verstuur"
+
+#: mailu/admin/templates/announcement.html:4
+msgid "Public announcement"
+msgstr "Publieke aankondiging"
+
+#: mailu/admin/templates/announcement.html:8
+msgid "from"
+msgstr "van"
+
+#: mailu/admin/templates/confirm.html:4
+msgid "Confirm action"
+msgstr "Bevestig actie"
+
+#: mailu/admin/templates/confirm.html:12
+#, python-format
+msgid "You are about to %(action)s. Please confirm your action."
+msgstr "Je staat op het punt om %(action)s. Bevestig actie."
+
+#: mailu/admin/templates/docker-error.html:4
+msgid "Docker error"
+msgstr "Docker fout"
+
+#: mailu/admin/templates/docker-error.html:12
+msgid "An error occurred while talking to the Docker server."
+msgstr "Er is een fout opgetreden tijdens het communiseren met de Docker server."
+
+#: mailu/admin/templates/login.html:6
+msgid "Your account"
+msgstr "Uw account"
+
+#: mailu/admin/templates/login.html:21
+msgid "to access the administration tools"
+msgstr "voor toegang tot de beheertools"
+
+#: mailu/admin/templates/services.html:4 mailu/admin/templates/sidebar.html:40
+msgid "Services status"
+msgstr "Diensten status"
+
+#: mailu/admin/templates/services.html:11
+msgid "Services"
+msgstr "Diensten"
+
+#: mailu/admin/templates/fetch/list.html:23
+#: mailu/admin/templates/services.html:12
+msgid "Status"
+msgstr "Status"
+
+#: mailu/admin/templates/services.html:13
+msgid "PID"
+msgstr "PID"
+
+#: mailu/admin/templates/services.html:14
+msgid "Image"
+msgstr "Afbeelding"
+
+#: mailu/admin/templates/services.html:15
+msgid "Started"
+msgstr "Gestart"
+
+#: mailu/admin/templates/services.html:16
+msgid "Last update"
+msgstr "Laatste bewerking"
+
+#: mailu/admin/templates/sidebar.html:5
+msgid "My account"
+msgstr "Mijn account"
+
+#: mailu/admin/templates/sidebar.html:8 mailu/admin/templates/user/list.html:35
+msgid "Settings"
+msgstr "Instellingen"
+
+#: mailu/admin/templates/sidebar.html:18
+#: mailu/admin/templates/user/list.html:36
+msgid "Auto-forward"
+msgstr "Automatisch doorsturen"
+
+#: mailu/admin/templates/sidebar.html:23
+#: mailu/admin/templates/user/list.html:37
+msgid "Auto-reply"
+msgstr "Automatisch antwoord"
+
+#: mailu/admin/templates/fetch/list.html:4
+#: mailu/admin/templates/sidebar.html:28
+#: mailu/admin/templates/user/list.html:38
+msgid "Fetched accounts"
+msgstr "Ophalen externe account"
+
+#: mailu/admin/templates/sidebar.html:33
+msgid "Sign out"
+msgstr "Afmelden"
+
+#: mailu/admin/templates/sidebar.html:36
+msgid "Administration"
+msgstr "Administratie"
+
+#: mailu/admin/templates/sidebar.html:45
+msgid "Announcement"
+msgstr "Aankondiging"
+
+#: mailu/admin/templates/sidebar.html:50
+msgid "Administrators"
+msgstr "Beheerders"
+
+#: mailu/admin/templates/sidebar.html:57
+msgid "Mail domains"
+msgstr "Mail domeinen"
+
+#: mailu/admin/templates/sidebar.html:64
+msgid "Help"
+msgstr "Help"
+
+#: mailu/admin/templates/working.html:4
+msgid "We are still working on this feature!"
+msgstr ""
+
+#: mailu/admin/templates/admin/create.html:4
+msgid "Add a global administrator"
+msgstr "Voeg een algemene beheerder"
+
+#: mailu/admin/templates/admin/list.html:4
+msgid "Global administrators"
+msgstr "Algemene beheerder"
+
+#: mailu/admin/templates/admin/list.html:9
+msgid "Add administrator"
+msgstr "Toevoegen beheerder"
+
+#: mailu/admin/templates/admin/list.html:17
+#: mailu/admin/templates/alias/list.html:19
+#: mailu/admin/templates/domain/list.html:17
+#: mailu/admin/templates/fetch/list.html:19
+#: mailu/admin/templates/manager/list.html:19
+#: mailu/admin/templates/user/list.html:19
+msgid "Actions"
+msgstr "Acties"
+
+#: mailu/admin/templates/admin/list.html:18
+#: mailu/admin/templates/alias/list.html:20
+#: mailu/admin/templates/manager/list.html:20
+#: mailu/admin/templates/user/list.html:21
+msgid "Email"
+msgstr "Email"
+
+#: mailu/admin/templates/admin/list.html:23
+#: mailu/admin/templates/alias/list.html:30
+#: mailu/admin/templates/domain/list.html:32
+#: mailu/admin/templates/fetch/list.html:31
+#: mailu/admin/templates/manager/list.html:25
+#: mailu/admin/templates/user/list.html:32
+msgid "Delete"
+msgstr "Verwijderen"
+
+#: mailu/admin/templates/alias/create.html:4
+msgid "Create alias"
+msgstr "Aanmaken alias"
+
+#: mailu/admin/templates/alias/edit.html:4
+msgid "Edit alias"
+msgstr "Wijzigen alias"
+
+#: mailu/admin/templates/alias/list.html:4
+msgid "Alias list"
+msgstr "Lijst aliassen"
+
+#: mailu/admin/templates/alias/list.html:12
+msgid "Add alias"
+msgstr "Toevoegen alias"
+
+#: mailu/admin/templates/alias/list.html:23
+#: mailu/admin/templates/domain/list.html:23
+#: mailu/admin/templates/fetch/list.html:24
+#: mailu/admin/templates/user/list.html:25
+msgid "Created"
+msgstr "Aangemaakt"
+
+#: mailu/admin/templates/alias/list.html:24
+#: mailu/admin/templates/domain/list.html:24
+#: mailu/admin/templates/fetch/list.html:25
+#: mailu/admin/templates/user/list.html:26
+msgid "Last edit"
+msgstr "Laatste wijziging"
+
+#: mailu/admin/templates/alias/list.html:29
+#: mailu/admin/templates/domain/list.html:31
+#: mailu/admin/templates/fetch/list.html:30
+#: mailu/admin/templates/user/list.html:31
+msgid "Edit"
+msgstr "Wijzigen"
+
+#: mailu/admin/templates/domain/create.html:4
+#: mailu/admin/templates/domain/list.html:9
+msgid "New domain"
+msgstr "Nieuw domein"
+
+#: mailu/admin/templates/domain/details.html:4
+msgid "Domain details"
+msgstr "Domein gegevens"
+
+#: mailu/admin/templates/domain/details.html:13
+msgid "Regenerate keys"
+msgstr "Op nieuw aanmaken sleutels"
+
+#: mailu/admin/templates/domain/details.html:25
+msgid "DNS MX entry"
+msgstr "DNS MX vermelding"
+
+#: mailu/admin/templates/domain/details.html:29
+msgid "DNS SPF entries"
+msgstr "DNS SPF vermeldingen"
+
+#: mailu/admin/templates/domain/details.html:36
+msgid "DKIM public key"
+msgstr "DKIM publieke sleutel"
+
+#: mailu/admin/templates/domain/details.html:40
+msgid "DNS DKIM entry"
+msgstr "DNS DKIM vermelding"
+
+#: mailu/admin/templates/domain/details.html:44
+msgid "DNS DMARC entry"
+msgstr "DNS DMARC vermelding"
+
+#: mailu/admin/templates/domain/edit.html:4
+msgid "Edit domain"
+msgstr "Wijzigen domein"
+
+#: mailu/admin/templates/domain/list.html:4
+msgid "Domain list"
+msgstr "Lijst domeinen"
+
+#: mailu/admin/templates/domain/list.html:18
+msgid "Manage"
+msgstr "Beheer"
+
+#: mailu/admin/templates/domain/list.html:20
+msgid "Mailbox count"
+msgstr "Mailbox aantal"
+
+#: mailu/admin/templates/domain/list.html:21
+msgid "Alias count"
+msgstr "Alias aantal"
+
+#: mailu/admin/templates/domain/list.html:29
+msgid "Details"
+msgstr "Gegevens"
+
+#: mailu/admin/templates/domain/list.html:36
+msgid "Users"
+msgstr "Gebruikers"
+
+#: mailu/admin/templates/domain/list.html:37
+msgid "Aliases"
+msgstr "Aliassen"
+
+#: mailu/admin/templates/domain/list.html:38
+msgid "Managers"
+msgstr "Beheerders"
+
+#: mailu/admin/templates/fetch/create.html:4
+msgid "Add a fetched account"
+msgstr "Toevoegen externe account"
+
+#: mailu/admin/templates/fetch/edit.html:4
+msgid "Update a fetched account"
+msgstr "Wijzigen externe account"
+
+#: mailu/admin/templates/fetch/list.html:12
+msgid "Add an account"
+msgstr "Toevoegen van een account"
+
+#: mailu/admin/templates/fetch/list.html:20
+msgid "Endpoint"
+msgstr "Eind punt"
+
+#: mailu/admin/templates/fetch/list.html:22
+msgid "Last check"
+msgstr "Laatste controle"
+
+#: mailu/admin/templates/manager/create.html:4
+msgid "Add a manager"
+msgstr "Toevoegen beheerder"
+
+#: mailu/admin/templates/manager/list.html:4
+msgid "Manager list"
+msgstr "Lijst beheerders"
+
+#: mailu/admin/templates/manager/list.html:12
+msgid "Add manager"
+msgstr "Toevoegen beheerder"
+
+#: mailu/admin/templates/user/create.html:4
+msgid "New user"
+msgstr "Niewe gebruiker"
+
+#: mailu/admin/templates/user/edit.html:4
+msgid "Edit user"
+msgstr "Wijzigen gebruiker"
+
+#: mailu/admin/templates/user/forward.html:4
+msgid "Forward emails"
+msgstr "Doorsturen email berichten"
+
+#: mailu/admin/templates/user/list.html:4
+msgid "User list"
+msgstr "List gebruikers"
+
+#: mailu/admin/templates/user/list.html:12
+msgid "Add user"
+msgstr "Toevoegen gebruiker"
+
+#: mailu/admin/templates/user/list.html:20
+#: mailu/admin/templates/user/settings.html:4
+msgid "User settings"
+msgstr "Gebruikersinstellingen"
+
+#: mailu/admin/templates/user/list.html:22
+msgid "Features"
+msgstr "Kenmerken"
+
+#: mailu/admin/templates/user/password.html:4
+msgid "Password update"
+msgstr "Wachtwoord bijwerken"
+
+#: mailu/admin/templates/user/reply.html:4
+msgid "Automatic reply"
+msgstr "Automatisch antwoord"
+

--- a/fetchmail/fetchmail.py
+++ b/fetchmail/fetchmail.py
@@ -36,7 +36,7 @@ def fetchmail(fetchmailrc):
         return output
 
 
-def run(connection, cursor, debug):
+def run(connection, cursor, keep, debug):
     cursor.execute("""
         SELECT user_email, protocol, host, port, tls, username, password
         FROM fetch
@@ -88,7 +88,7 @@ if __name__ == "__main__":
     connection = sqlite3.connect(db_path)
     while True:
         cursor = connection.cursor()
-        run(connection, cursor, debug)
+        run(connection, cursor, keep, debug)
         cursor.close()
         time.sleep(int(os.environ.get("FETCHMAIL_DELAY", 60)))
 


### PR DESCRIPTION
Here is the a simple patch to make fetchmail keep the e-mails on the server, its done through the .env file setting FETCHMAIL_KEEP=True. This patch until fetchmail options are supported in the web mail admin panel.