### PR TITLE
Fix Nginx entrypoint

### DIFF
--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [[ -z ENABLE_CERTBOT || -f /certs/cert.pem ]]
+if [[ -z $ENABLE_CERTBOT || -f /certs/cert.pem ]]
 then
   cp /etc/nginx/nginx.conf.default /etc/nginx/nginx.conf
 else


### PR DESCRIPTION
Right now the Nginx entrypoint is checking if the string `ENABLE_CERTBOT` is not null, instead of checking if the environment variable `$ENABLE_CERTBOT` is not null.

This was making Nginx always start using the default config and never using the fallback config, and then it was breaking because it couldn't find the certificate with the Let's Encrypt names (instead of `snakeoil.pem`).

And as the Nginx server was breaking, the Let's Encrypt certificate was not being created.

---

**Note**: this is just to fix the current installation. I will make another PR to handle #167