### PR TITLE
Create and use SSL dhparam file if not mounted, NGINX_SSL_DHPARAM_BITS variable in .env.dist file

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -70,6 +70,13 @@ RELAYHOST=
 FETCHMAIL_DELAY=600
 
 ###################################
+# Nginx settings
+###################################
+
+# SSL DHPARAM Bits
+NGINX_SSL_DHPARAM_BITS=2048
+
+###################################
 # Developers
 ###################################
 

--- a/nginx/nginx.conf.default
+++ b/nginx/nginx.conf.default
@@ -35,6 +35,7 @@ http {
       ssl_session_cache shared:SSL:50m;
       ssl_certificate /certs/cert.pem;
       ssl_certificate_key /certs/key.pem;
+      ssl_dhparam /etc/nginx/dhparam.pem;
 
       add_header Strict-Transport-Security max-age=15768000;
 

--- a/nginx/nginx.conf.fallback
+++ b/nginx/nginx.conf.fallback
@@ -30,6 +30,7 @@ http {
       ssl_session_cache shared:SSL:50m;
       ssl_certificate /tmp/snakeoil.pem;
       ssl_certificate_key /tmp/snakeoil.pem;
+      ssl_dhparam /etc/nginx/dhparam.pem;
 
       add_header Strict-Transport-Security max-age=15768000;
 

--- a/nginx/start.sh
+++ b/nginx/start.sh
@@ -9,4 +9,8 @@ L=None/O=None/CN=$DOMAIN"
   cp /etc/nginx/nginx.conf.fallback /etc/nginx/nginx.conf
 fi
 
+if [ ! -r /etc/nginx/dhparam.pem ]; then
+  openssl dhparam -out /etc/nginx/dhparam.pem $NGINX_SSL_DHPARAM_BITS
+fi
+
 nginx -g 'daemon off;'


### PR DESCRIPTION
Will result in A+ rating on Qualys ssltest (https://www.ssllabs.com/ssltest/)
