### PR TITLE
Add alternative frontend nginx-no-https

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -36,7 +36,7 @@ COMPOSE_PROJECT_NAME=mailu
 # Optional features
 ###################################
 
-# Choose which frontend Web server to run if any (value: nginx, none)
+# Choose which frontend Web server to run if any (value: nginx, nginx-no-https, none)
 FRONTEND=none
 
 # Choose which webmail to run if any (values: roundcube, rainloop, none)

--- a/nginx-no-https/Dockerfile
+++ b/nginx-no-https/Dockerfile
@@ -1,0 +1,9 @@
+FROM nginx:alpine
+
+RUN apk add --no-cache nginx-lua openssl
+
+COPY nginx.conf.default /etc/nginx/nginx.conf.default
+
+COPY start.sh /start.sh
+
+CMD ["/start.sh"]

--- a/nginx-no-https/README.md
+++ b/nginx-no-https/README.md
@@ -1,0 +1,14 @@
+Mailu NGINX container
+=====================
+
+NGINX is a popular and highly efficient webserver and reverse proxy server
+commonly used to power high performance websites. In the Mailu stack it is
+used as the HTTP frontend tunneling requests to the public web services
+provided by other containers.
+
+Resources
+---------
+
+ * [Report issues](https://github.com/Mailu/Mailu/issues) and
+    [send Pull Requests](https://github.com/Mailu/Mailu/pulls)
+    in the [main Mailu repository](https://github.com/Mailu/Mailu)

--- a/nginx-no-https/nginx.conf.default
+++ b/nginx-no-https/nginx.conf.default
@@ -1,0 +1,79 @@
+#  Basic configuration
+user nginx;
+worker_processes  1;
+error_log /dev/stderr info;
+pid /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+# Environment variables used in the configuration
+env WEBMAIL;
+env WEBDAV;
+env EXPOSE_ADMIN;
+
+http {
+    # Standard HTTP configuration with slight hardening
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+    access_log /dev/stdout;
+    sendfile on;
+    keepalive_timeout  65;
+    server_tokens off;
+
+    server {
+      listen 80;
+
+      # Load Lua variables
+      set_by_lua $webmail 'return os.getenv("WEBMAIL")';
+      set_by_lua $webdav 'return os.getenv("WEBDAV")';
+      set_by_lua $expose_admin 'return os.getenv("EXPOSE_ADMIN")';
+
+      # Actual logic
+
+      location / {
+        if ($webmail != none) {
+          return 301 $scheme://$host/webmail/;
+        }
+
+        if ($webmail = none) {
+          return 403;
+        }
+      }
+
+      location /webmail {
+        if ($webmail != none) {
+          proxy_pass http://webmail;
+        }
+
+        if ($webmail = none) {
+          return 403;
+        }
+      }
+
+      location /admin {
+        if ($expose_admin = yes) {
+          proxy_pass http://admin;
+        }
+
+        if ($expose_admin != yes) {
+          return 403;
+        }
+      }
+
+      location /webdav {
+        if ($webdav != none) {
+          proxy_pass http://webdav:5232;
+        }
+
+        if ($webdav = none) {
+          return 403;
+        }
+      }
+
+      location /.well-known/acme-challenge {
+        proxy_pass http://admin:8081;
+      }
+    }
+}

--- a/nginx-no-https/start.sh
+++ b/nginx-no-https/start.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cp /etc/nginx/nginx.conf.default /etc/nginx/nginx.conf
+
+nginx -g 'daemon off;'


### PR DESCRIPTION
As commented in #167, here's the alternative frontend without HTTPS.

If everything is OK, I will submit a PR to the Mailu/Rancher repo updating the template and another PR updating the documentation.

BTW, the `docker-compose.yml` won't work "as is" right now, as it assumes a new Docker image that doesn't exist yet. But to test it is possible to build the image locally tagging it with the corresponding name.