### PR TITLE
Add dulwich for git support

### DIFF
--- a/radicale/Dockerfile
+++ b/radicale/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
- && apk add --no-cache radicale@testing
+ && apk add --no-cache radicale@testing py-dulwich@testing
 
 COPY radicale.conf /radicale.conf
 


### PR DESCRIPTION
Radicale supports automatic versioning of calendar event changes if a git repository was initialized in the data directory. For this to work, Radicale needs dulwich as an interface to the git repository.

http://radicale.org/user_documentation/#idgit-support