### PR TITLE
add clamav-libunrar

### DIFF
--- a/clamav/Dockerfile
+++ b/clamav/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine
 
-RUN apk add --no-cache clamav rsyslog wget
+RUN apk add --no-cache clamav rsyslog wget clamav-libunrar
 
 COPY conf /etc/clamav
 COPY start.sh /start.sh


### PR DESCRIPTION
Correction
LibClamAV Warning: Cannot dlopen libclamunrar_iface: file not found - unrar support unavailable