### PR TITLE
Added parameter for antivirus solution to be more flexible (see #183)

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -51,6 +51,9 @@ EXPOSE_ADMIN=no
 # Dav server implementation (value: radicale, none)
 WEBDAV=none
 
+# Antivirus solution (value: none, clamav)
+ANTIVIRUS=clamav
+
 ###################################
 # Mail settings
 ###################################

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -70,7 +70,7 @@ services:
 
   antivirus:
     # build: clamav
-    image: mailu/clamav:$VERSION
+    image: mailu/$ANTIVIRUS:$VERSION
     restart: always
     env_file: .env
     volumes:

--- a/rmilter/Dockerfile
+++ b/rmilter/Dockerfile
@@ -4,6 +4,7 @@ RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/re
  && apk add --no-cache rmilter@testing rsyslog
 
 COPY rmilter.conf /etc/rmilter.conf
+COPY rmilter-clamav.conf /etc/rmilter-clamav.conf
 COPY rsyslog.conf /etc/rsyslog.conf
 
 COPY start.sh /start.sh

--- a/rmilter/rmilter-clamav.conf
+++ b/rmilter/rmilter-clamav.conf
@@ -1,0 +1,18 @@
+clamav {
+	# servers - clamav socket definitions in format:
+	servers = antivirus:3310;
+	# connect_timeout - timeout in miliseconds for connecting to clamav
+	connect_timeout = 1s;
+	# port_timeout - timeout in miliseconds for waiting for clamav port response
+	port_timeout = 4s;
+	# results_timeout - timeout in miliseconds for waiting for clamav response
+	results_timeout = 20s;
+	# error_time - time in seconds during which we are counting errors
+	error_time = 10;
+	# dead_time - time in seconds during which we are thinking that server is down
+	dead_time = 300;
+	# maxerrors - maximum number of errors that can occur during error_time to make us thinking that
+	# Default: 10
+	maxerrors = 10;
+};
+

--- a/rmilter/rmilter.conf
+++ b/rmilter/rmilter.conf
@@ -20,24 +20,6 @@ strict_auth = no;
 use_dcc = no;
 use_redis = yes;
 
-clamav {
-	# servers - clamav socket definitions in format:
-	servers = antivirus:3310;
-	# connect_timeout - timeout in miliseconds for connecting to clamav
-	connect_timeout = 1s;
-	# port_timeout - timeout in miliseconds for waiting for clamav port response
-	port_timeout = 4s;
-	# results_timeout - timeout in miliseconds for waiting for clamav response
-	results_timeout = 20s;
-	# error_time - time in seconds during which we are counting errors
-	error_time = 10;
-	# dead_time - time in seconds during which we are thinking that server is down
-	dead_time = 300;
-	# maxerrors - maximum number of errors that can occur during error_time to make us thinking that
-	# Default: 10
-	maxerrors = 10;
-};
-
 spamd {
 	# servers - spamd socket definitions in format:
 	servers = r:antispam:11333;

--- a/rmilter/start.sh
+++ b/rmilter/start.sh
@@ -1,5 +1,9 @@
 #!/bin/sh
 
 rm -f /var/run/rsyslogd.pid
+if [ "$ANTIVIRUS" == "clamav" ];
+then
+	echo "# .try_include /etc/rmilter-clamav.conf" >>  /etc/rmilter.conf
+fi
 rmilter -c /etc/rmilter.conf
 rsyslogd -n


### PR DESCRIPTION
Simple new parameter to use images clamav or none as antivirus solution plus in- or exclusion of clamav configuration in rmilter.