### PR TITLE
Use exec to start rsyslogd

### DIFF
--- a/postfix/start.sh
+++ b/postfix/start.sh
@@ -32,4 +32,4 @@ rm -f /var/run/rsyslogd.pid
 chown -R postfix: /queue
 /usr/lib/postfix/post-install meta_directory=/etc/postfix create-missing
 /usr/lib/postfix/master &
-rsyslogd -n
+exec rsyslogd -n


### PR DESCRIPTION
I use exec to start rsyslog in start.sh for postfix container. The rsyslog process optain PID 1, it's better when you stop the container.