### PR TITLE
The ACME spec says that http validation should be done via http, not …

### DIFF
--- a/nginx/nginx.conf.default
+++ b/nginx/nginx.conf.default
@@ -26,8 +26,19 @@ http {
 
     server {
       listen 80;
-      listen 443 ssl;
       listen [::]:80;
+
+      location /.well-known/acme-challenge {
+        proxy_pass http://admin:8081;
+      }
+
+      location / {
+        return 301 https://$host$request_uri;
+      }
+    }
+
+    server {
+      listen 443 ssl;
       listen [::]:443 ssl;
 
       # TLS configuration hardened according to:
@@ -42,10 +53,6 @@ http {
       ssl_dhparam /etc/nginx/dhparam.pem;
 
       add_header Strict-Transport-Security max-age=15768000;
-
-      if ($scheme = http) {
-    		return 301 https://$host$request_uri;
-    	}
 
       # Load Lua variables
       set_by_lua $webmail 'return os.getenv("WEBMAIL")';
@@ -92,10 +99,6 @@ http {
         if ($webdav = none) {
           return 403;
         }
-      }
-
-      location /.well-known/acme-challenge {
-        proxy_pass http://admin:8081;
       }
     }
 }


### PR DESCRIPTION
…https.

Plus, it seems that the "if" directive in nginx is quite unpredictable (https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/), so I replaced the redirect with a declarative version. We should consider removing the other "if" directives too.

My understanding is that the ACME validation was happening after the redirect to HTTPS, and thus using the self-signed certificate. This seems to contradict the ACME spec (which states that HTTP should be used, not HTTPS), and also relies on the remote library accepting invalid certificates, which is rarely the case (so might break in the future).