### PR TITLE
User import routine (and selector for ecryption hashing algorithm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pip-selfcheck.json
 /docker-compose.mac.yml
 /docker-compose.yml
 /.idea
+/.vscode

--- a/admin/.gitignore
+++ b/admin/.gitignore
@@ -1,0 +1,4 @@
+.fg/
+lib64
+.vscode
+tags

--- a/admin/manage.py
+++ b/admin/manage.py
@@ -135,6 +135,22 @@ def config_update(delete_objects=False):
     db.session.commit()
 
 @manager.command
+def user_delete(email):
+    """delete user"""
+    user = models.User.query.get(email)
+    if user:
+        db.session.delete(user)
+    db.session.commit()
+
+@manager.command
+def alias_delete(email):
+    """delete alias"""
+    alias = models.Alias.query.get(email)
+    if alias:
+        db.session.delete(alias)
+    db.session.commit()
+
+@manager.command
 def alias(localpart, domain_name, destination):
     """ Create an alias
     """

--- a/admin/manage.py
+++ b/admin/manage.py
@@ -72,6 +72,54 @@ def user_import(localpart, domain_name, password_hash, hash_scheme='SHA512-CRYPT
     db.session.add(user)
     db.session.commit()
 
+@manager.command
+def config_update():
+    """sync configuration with data from stdin"""
+    import yaml, sys
+    new_config=yaml.load(sys.stdin)
+    # print new_config
+    users=new_config['users']
+    for user_config in users:
+        localpart=user_config['localpart']
+        domain_name=user_config['domain']
+        password_hash=user_config['password_hash']
+        hash_scheme=user_config['hash_scheme']
+        domain = models.Domain.query.get(domain_name)
+        if not domain:
+            domain = models.Domain(name=domain_name)
+            db.session.add(domain)
+        user = models.User.query.get('{0}@{1}'.format(localpart,domain_name))
+        if not user:
+            user = models.User(
+                localpart=localpart,
+                domain=domain,
+                global_admin=False
+            )
+        user.set_password(password_hash, hash_scheme=hash_scheme, raw=True)
+        db.session.add(user)
+
+    aliases=new_config['aliases']
+    for alias_config in aliases:
+        localpart=alias_config['localpart']
+        domain_name=alias_config['domain']
+        destination=alias_config['destination']
+        domain = models.Domain.query.get(domain_name)
+        if not domain:
+            domain = models.Domain(name=domain_name)
+            db.session.add(domain)
+        alias = models.Alias.query.get('{0}@{1}'.format(localpart, domain_name))
+        if not alias:
+            alias = models.Alias(
+                localpart=localpart,
+                domain=domain,
+                destination=destination.split(','),
+                email="%s@%s" % (localpart, domain_name)
+            )
+        else:
+            alias.destination = destination.split(',')
+        db.session.add(alias)
+    
+    db.session.commit()
 
 @manager.command
 def alias(localpart, domain_name, destination):

--- a/admin/manage.py
+++ b/admin/manage.py
@@ -36,7 +36,7 @@ def admin(localpart, domain_name, password):
 
 @manager.command
 def user(localpart, domain_name, password, hash_scheme='SHA512-CRYPT'):
-    """ Create an user
+    """ Create a user
     """
     domain = models.Domain.query.get(domain_name)
     if not domain:
@@ -52,8 +52,12 @@ def user(localpart, domain_name, password, hash_scheme='SHA512-CRYPT'):
     db.session.commit()
 
 @manager.command
-def user_raw(localpart, domain_name, password, hash_scheme='SHA512-CRYPT'):
-    """ Create an user
+def user_import(localpart, domain_name, password_hash, hash_scheme='SHA512-CRYPT'):
+    """ Import a user along with password hash. Available hashes:
+                   'SHA512-CRYPT'
+                   'SHA256-CRYPT'
+                   'MD5-CRYPT'
+                   'CRYPT'
     """
     domain = models.Domain.query.get(domain_name)
     if not domain:
@@ -64,7 +68,7 @@ def user_raw(localpart, domain_name, password, hash_scheme='SHA512-CRYPT'):
         domain=domain,
         global_admin=False
     )
-    user.set_password(password, hash_scheme=hash_scheme)
+    user.set_password(password_hash, hash_scheme=hash_scheme, raw=True)
     db.session.add(user)
     db.session.commit()
 

--- a/admin/manage.py
+++ b/admin/manage.py
@@ -35,7 +35,7 @@ def admin(localpart, domain_name, password):
 
 
 @manager.command
-def user(localpart, domain_name, password):
+def user(localpart, domain_name, password, hash_scheme='SHA512-CRYPT'):
     """ Create an user
     """
     domain = models.Domain.query.get(domain_name)
@@ -47,7 +47,24 @@ def user(localpart, domain_name, password):
         domain=domain,
         global_admin=False
     )
-    user.set_password(password)
+    user.set_password(password, hash_scheme=hash_scheme)
+    db.session.add(user)
+    db.session.commit()
+
+@manager.command
+def user_raw(localpart, domain_name, password, hash_scheme='SHA512-CRYPT'):
+    """ Create an user
+    """
+    domain = models.Domain.query.get(domain_name)
+    if not domain:
+        domain = models.Domain(name=domain_name)
+        db.session.add(domain)
+    user = models.User(
+        localpart=localpart,
+        domain=domain,
+        global_admin=False
+    )
+    user.set_password(password, hash_scheme=hash_scheme)
     db.session.add(user)
     db.session.commit()
 

--- a/admin/requirements.txt
+++ b/admin/requirements.txt
@@ -14,3 +14,4 @@ docker-py
 tabulate
 apscheduler
 certbot
+PyYAML


### PR DESCRIPTION
We have a number of users we need to migrate into Mailu setup and since we already have hashes for their passwords we needed some way of adding passwords as hashes vs plaintext like it is done in "user()" command. This adds hashing algorithm selection to old user() as well as new user_import() commands.