### PR TITLE
Admin: Switch to alpine for smaller image size

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,10 +1,12 @@
-FROM python:3
+FROM python:3-alpine
 
 RUN mkdir -p /app
 WORKDIR /app
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN apk --update add --virtual build-dep openssl-dev libffi-dev python-dev build-base \
+	&& pip install -r requirements.txt \
+	&& apk del build-dep
 
 COPY mailu ./mailu
 COPY migrations ./migrations


### PR DESCRIPTION
The admin image is very large. With a switch to alpine, its size can be reduced from 783MB to 186MB. The modified Dockerfile also removes build dependencies from the image. I have tested the resulting image - it work.