### PR TITLE
Feature keep forward

### DIFF
--- a/admin/mailu/admin/forms.py
+++ b/admin/mailu/admin/forms.py
@@ -77,6 +77,7 @@ class UserPasswordForm(flask_wtf.FlaskForm):
 
 class UserForwardForm(flask_wtf.FlaskForm):
     forward_enabled = fields.BooleanField(_('Enable forwarding'))
+    forward_keep = fields.BooleanField(_('Keep a copy of the emails'))
     forward_destination = fields.StringField(
         _('Destination'), [validators.Optional(), validators.Email()]
     )

--- a/admin/mailu/admin/models.py
+++ b/admin/mailu/admin/models.py
@@ -146,6 +146,7 @@ class User(Base, Email):
     # Filters
     forward_enabled = db.Column(db.Boolean(), nullable=False, default=False)
     forward_destination = db.Column(db.String(255), nullable=True, default=None)
+    forward_keep = db.Column(db.Boolean(), nullable=False, default=True)
     reply_enabled = db.Column(db.Boolean(), nullable=False, default=False)
     reply_subject = db.Column(db.String(255), nullable=True, default=None)
     reply_body = db.Column(db.Text(), nullable=True, default=None)

--- a/admin/mailu/admin/templates/user/forward.html
+++ b/admin/mailu/admin/templates/user/forward.html
@@ -12,8 +12,10 @@
 <form class="form" method="post" role="form">
   {{ form.hidden_tag() }}
   {{ macros.form_field(form.forward_enabled,
-      onchange="if(this.checked){$('#forward_destination').removeAttr('disabled')}
-                else{$('#forward_destination').attr('disabled', '')}") }}
+      onchange="if(this.checked){$('#forward_destination,#forward_keep').removeAttr('disabled')}
+                else{$('#forward_destination,#forward_keep').attr('disabled', '')}") }}
+  {{ macros.form_field(form.forward_keep,
+      **{("enabled" if user.forward_enabled else "disabled"): ""}) }}
   {{ macros.form_field(form.forward_destination,
       **{("enabled" if user.forward_enabled else "disabled"): ""}) }}
   {{ macros.form_field(form.submit) }}

--- a/admin/mailu/translations/de/LC_MESSAGES/messages.po
+++ b/admin/mailu/translations/de/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: stefan.auditor@erdfisch.de\n"
-"POT-Creation-Date: 2016-11-10 10:52+0100\n"
+"POT-Creation-Date: 2017-09-03 15:30+0200\n"
 "PO-Revision-Date: 2016-11-09 21:43+0100\n"
 "Last-Translator: Stefan Auditor <stefan.auditor@erdfisch.de>\n"
 "Language: de\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.5.0\n"
 
 #: mailu/admin/forms.py:32
 msgid "Invalid email address."
@@ -26,12 +26,12 @@ msgstr "Ungültige E-Mail-Adresse."
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: mailu/admin/forms.py:40 mailu/admin/forms.py:54
+#: mailu/admin/forms.py:40 mailu/admin/forms.py:55
 msgid "E-mail"
 msgstr "E-Mail"
 
-#: mailu/admin/forms.py:41 mailu/admin/forms.py:55 mailu/admin/forms.py:72
-#: mailu/admin/forms.py:120
+#: mailu/admin/forms.py:41 mailu/admin/forms.py:56 mailu/admin/forms.py:73
+#: mailu/admin/forms.py:122
 msgid "Password"
 msgstr "Passwort"
 
@@ -53,131 +53,164 @@ msgstr "Maximale Anzahl Benutzer"
 msgid "Maximum alias count"
 msgstr "Maximale Anzahl Aliase"
 
-#: mailu/admin/forms.py:49 mailu/admin/forms.py:60 mailu/admin/forms.py:98
+#: mailu/admin/forms.py:49
+msgid "Maximum user quota"
+msgstr ""
+
+#: mailu/admin/forms.py:50 mailu/admin/forms.py:61 mailu/admin/forms.py:100
 #: mailu/admin/templates/alias/list.html:22
 #: mailu/admin/templates/domain/list.html:22
 #: mailu/admin/templates/user/list.html:24
 msgid "Comment"
 msgstr "Kommentar"
 
-#: mailu/admin/forms.py:50 mailu/admin/forms.py:99
+#: mailu/admin/forms.py:51 mailu/admin/forms.py:101
 msgid "Create"
 msgstr "Erstellen"
 
-#: mailu/admin/forms.py:56
+#: mailu/admin/forms.py:57
 msgid "Confirm password"
 msgstr "Passwort bestätigen"
 
-#: mailu/admin/forms.py:57 mailu/admin/templates/user/list.html:23
+#: mailu/admin/forms.py:58 mailu/admin/templates/user/list.html:23
 msgid "Quota"
 msgstr "Quota"
 
-#: mailu/admin/forms.py:58
+#: mailu/admin/forms.py:59
 msgid "Allow IMAP access"
 msgstr "Zugriff via IMAP erlauben"
 
-#: mailu/admin/forms.py:59
+#: mailu/admin/forms.py:60
 msgid "Allow POP3 access"
 msgstr "Zugriff via POP3 erlauben"
 
-#: mailu/admin/forms.py:61
+#: mailu/admin/forms.py:62
 msgid "Save"
 msgstr "Speichern"
 
-#: mailu/admin/forms.py:65
+#: mailu/admin/forms.py:66
 msgid "Displayed name"
 msgstr "Angezeigter Name"
 
-#: mailu/admin/forms.py:66
+#: mailu/admin/forms.py:67
 msgid "Enable spam filter"
 msgstr "Spam-Filter aktivieren"
 
-#: mailu/admin/forms.py:67
+#: mailu/admin/forms.py:68
 msgid "Spam filter threshold"
 msgstr "Spam-Filter Schwellenwert"
 
-#: mailu/admin/forms.py:68
+#: mailu/admin/forms.py:69
 msgid "Save settings"
 msgstr "Einstellungen speichern"
 
-#: mailu/admin/forms.py:73
+#: mailu/admin/forms.py:74
 msgid "Password check"
 msgstr "Passwort prüfen"
 
-#: mailu/admin/forms.py:74 mailu/admin/templates/sidebar.html:13
+#: mailu/admin/forms.py:75 mailu/admin/templates/sidebar.html:13
 msgid "Update password"
 msgstr "Passwort aktualisieren"
 
-#: mailu/admin/forms.py:78
+#: mailu/admin/forms.py:79
 msgid "Enable forwarding"
 msgstr "Weiterleitung aktivieren"
 
-#: mailu/admin/forms.py:80 mailu/admin/forms.py:97
+#: mailu/admin/forms.py:80
+msgid "Keep a copy of the emails"
+msgstr ""
+
+#: mailu/admin/forms.py:82 mailu/admin/forms.py:99
 #: mailu/admin/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Ziel"
 
-#: mailu/admin/forms.py:82 mailu/admin/forms.py:90
+#: mailu/admin/forms.py:84 mailu/admin/forms.py:92
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: mailu/admin/forms.py:86
+#: mailu/admin/forms.py:88
 msgid "Enable automatic reply"
 msgstr "Automatische Antwort aktivieren"
 
-#: mailu/admin/forms.py:87
+#: mailu/admin/forms.py:89
 msgid "Reply subject"
 msgstr "Antwort Betreff"
 
-#: mailu/admin/forms.py:88
+#: mailu/admin/forms.py:90
 msgid "Reply body"
 msgstr "Antwort Text"
 
-#: mailu/admin/forms.py:94
+#: mailu/admin/forms.py:96
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/admin/forms.py:96
+#: mailu/admin/forms.py:98
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "SQL LIKE Syntax nutzen (z.B. für Catch-All Aliase)"
 
-#: mailu/admin/forms.py:103
+#: mailu/admin/forms.py:105
 msgid "Admin email"
 msgstr "Administrator E-Mail"
 
-#: mailu/admin/forms.py:104 mailu/admin/forms.py:109 mailu/admin/forms.py:121
+#: mailu/admin/forms.py:106 mailu/admin/forms.py:111 mailu/admin/forms.py:124
 msgid "Submit"
 msgstr "Absenden"
 
-#: mailu/admin/forms.py:108
+#: mailu/admin/forms.py:110
 msgid "Manager email"
 msgstr "Manager E-Mail"
 
-#: mailu/admin/forms.py:113
+#: mailu/admin/forms.py:115
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: mailu/admin/forms.py:116
+#: mailu/admin/forms.py:118
 msgid "Hostname or IP"
 msgstr "Hostname oder IP"
 
-#: mailu/admin/forms.py:117
+#: mailu/admin/forms.py:119
 msgid "TCP port"
 msgstr "Port"
 
-#: mailu/admin/forms.py:118
+#: mailu/admin/forms.py:120
 msgid "Enable TLS"
 msgstr "Verschlüsselung aktivieren"
 
-#: mailu/admin/forms.py:119 mailu/admin/templates/fetch/list.html:21
+#: mailu/admin/forms.py:121 mailu/admin/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Benutzername"
+
+#: mailu/admin/forms.py:123
+msgid "Keep emails on the server"
+msgstr ""
+
+#: mailu/admin/forms.py:128
+msgid "Announcement subject"
+msgstr "Bekanntmachung Betreff"
+
+#: mailu/admin/forms.py:130
+msgid "Announcement body"
+msgstr "Bekanntmachung Text"
+
+#: mailu/admin/forms.py:132
+msgid "Send"
+msgstr "Absenden"
+
+#: mailu/admin/templates/announcement.html:4
+msgid "Public announcement"
+msgstr "Öffentliche Bekanntmachung"
+
+#: mailu/admin/templates/announcement.html:8
+msgid "from"
+msgstr "von"
 
 #: mailu/admin/templates/confirm.html:4
 msgid "Confirm action"
 msgstr "Aktion bestätigen"
 
 #: mailu/admin/templates/confirm.html:12
+#, python-format
 msgid "You are about to %(action)s. Please confirm your action."
 msgstr "Bitte bestätigen: %(action)s."
 
@@ -187,7 +220,9 @@ msgstr "Docker Fehler"
 
 #: mailu/admin/templates/docker-error.html:12
 msgid "An error occurred while talking to the Docker server."
-msgstr "Während der Kommunikation mit dem Docker Server ist ein Fehler aufgetreten."
+msgstr ""
+"Während der Kommunikation mit dem Docker Server ist ein Fehler "
+"aufgetreten."
 
 #: mailu/admin/templates/login.html:6
 msgid "Your account"
@@ -205,7 +240,7 @@ msgstr "Dienst-Status"
 msgid "Service"
 msgstr "Dienst"
 
-#: mailu/admin/templates/fetch/list.html:23
+#: mailu/admin/templates/fetch/list.html:24
 #: mailu/admin/templates/services.html:12
 msgid "Status"
 msgstr "Status"
@@ -258,6 +293,10 @@ msgstr "Abmelden"
 msgid "Administration"
 msgstr "Administration"
 
+#: mailu/admin/templates/sidebar.html:45
+msgid "Announcement"
+msgstr "Bekanntmachung"
+
 #: mailu/admin/templates/sidebar.html:50
 msgid "Administrators"
 msgstr "Administratoren"
@@ -305,7 +344,7 @@ msgstr "E-Mail"
 #: mailu/admin/templates/admin/list.html:23
 #: mailu/admin/templates/alias/list.html:30
 #: mailu/admin/templates/domain/list.html:32
-#: mailu/admin/templates/fetch/list.html:31
+#: mailu/admin/templates/fetch/list.html:32
 #: mailu/admin/templates/manager/list.html:25
 #: mailu/admin/templates/user/list.html:32
 msgid "Delete"
@@ -329,21 +368,21 @@ msgstr "Alias hinzufügen"
 
 #: mailu/admin/templates/alias/list.html:23
 #: mailu/admin/templates/domain/list.html:23
-#: mailu/admin/templates/fetch/list.html:24
+#: mailu/admin/templates/fetch/list.html:25
 #: mailu/admin/templates/user/list.html:25
 msgid "Created"
 msgstr "Erstellt"
 
 #: mailu/admin/templates/alias/list.html:24
 #: mailu/admin/templates/domain/list.html:24
-#: mailu/admin/templates/fetch/list.html:25
+#: mailu/admin/templates/fetch/list.html:26
 #: mailu/admin/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Zuletzt bearbeitet"
 
 #: mailu/admin/templates/alias/list.html:29
 #: mailu/admin/templates/domain/list.html:31
-#: mailu/admin/templates/fetch/list.html:30
+#: mailu/admin/templates/fetch/list.html:31
 #: mailu/admin/templates/user/list.html:31
 msgid "Edit"
 msgstr "Bearbeiten"
@@ -434,8 +473,20 @@ msgid "Endpoint"
 msgstr "Endpunkt"
 
 #: mailu/admin/templates/fetch/list.html:22
+msgid "Keep emails"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:23
 msgid "Last check"
 msgstr "Letzte Prüfung"
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "yes"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "no"
+msgstr ""
 
 #: mailu/admin/templates/manager/create.html:4
 msgid "Add a manager"
@@ -448,30 +499,6 @@ msgstr "Manager Liste"
 #: mailu/admin/templates/manager/list.html:12
 msgid "Add manager"
 msgstr "Manager hinzufügen"
-
-#: mailu/admin/forms.py:125
-msgid "Announcement subject"
-msgstr "Bekanntmachung Betreff"
-
-#: mailu/admin/forms.py:127
-msgid "Announcement body"
-msgstr "Bekanntmachung Text"
-
-#: mailu/admin/forms.py:129
-msgid "Send"
-msgstr "Absenden"
-
-#: mailu/admin/templates/announcement.html:4
-msgid "Public announcement"
-msgstr "Öffentliche Bekanntmachung"
-
-#: mailu/admin/templates/announcement.html:8
-msgid "from"
-msgstr "von"
-
-#: mailu/admin/templates/sidebar.html:45
-msgid "Announcement"
-msgstr "Bekanntmachung"
 
 #: mailu/admin/templates/user/create.html:4
 msgid "New user"

--- a/admin/mailu/translations/en/LC_MESSAGES/messages.po
+++ b/admin/mailu/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-11-10 10:52+0100\n"
+"POT-Creation-Date: 2017-09-03 15:30+0200\n"
 "PO-Revision-Date: 2016-10-02 15:02+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: en\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.5.0\n"
 
 #: mailu/admin/forms.py:32
 msgid "Invalid email address."
@@ -26,12 +26,12 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-#: mailu/admin/forms.py:40 mailu/admin/forms.py:54
+#: mailu/admin/forms.py:40 mailu/admin/forms.py:55
 msgid "E-mail"
 msgstr ""
 
-#: mailu/admin/forms.py:41 mailu/admin/forms.py:55 mailu/admin/forms.py:72
-#: mailu/admin/forms.py:120
+#: mailu/admin/forms.py:41 mailu/admin/forms.py:56 mailu/admin/forms.py:73
+#: mailu/admin/forms.py:122
 msgid "Password"
 msgstr ""
 
@@ -53,135 +53,147 @@ msgstr ""
 msgid "Maximum alias count"
 msgstr ""
 
-#: mailu/admin/forms.py:49 mailu/admin/forms.py:60 mailu/admin/forms.py:98
+#: mailu/admin/forms.py:49
+msgid "Maximum user quota"
+msgstr ""
+
+#: mailu/admin/forms.py:50 mailu/admin/forms.py:61 mailu/admin/forms.py:100
 #: mailu/admin/templates/alias/list.html:22
 #: mailu/admin/templates/domain/list.html:22
 #: mailu/admin/templates/user/list.html:24
 msgid "Comment"
 msgstr ""
 
-#: mailu/admin/forms.py:50 mailu/admin/forms.py:99
+#: mailu/admin/forms.py:51 mailu/admin/forms.py:101
 msgid "Create"
 msgstr ""
 
-#: mailu/admin/forms.py:56
+#: mailu/admin/forms.py:57
 msgid "Confirm password"
 msgstr ""
 
-#: mailu/admin/forms.py:57 mailu/admin/templates/user/list.html:23
+#: mailu/admin/forms.py:58 mailu/admin/templates/user/list.html:23
 msgid "Quota"
 msgstr ""
 
-#: mailu/admin/forms.py:58
+#: mailu/admin/forms.py:59
 msgid "Allow IMAP access"
 msgstr ""
 
-#: mailu/admin/forms.py:59
+#: mailu/admin/forms.py:60
 msgid "Allow POP3 access"
 msgstr ""
 
-#: mailu/admin/forms.py:61
+#: mailu/admin/forms.py:62
 msgid "Save"
 msgstr ""
 
-#: mailu/admin/forms.py:65
+#: mailu/admin/forms.py:66
 msgid "Displayed name"
 msgstr ""
 
-#: mailu/admin/forms.py:66
+#: mailu/admin/forms.py:67
 msgid "Enable spam filter"
 msgstr ""
 
-#: mailu/admin/forms.py:67
+#: mailu/admin/forms.py:68
 msgid "Spam filter threshold"
 msgstr ""
 
-#: mailu/admin/forms.py:68
+#: mailu/admin/forms.py:69
 msgid "Save settings"
 msgstr ""
 
-#: mailu/admin/forms.py:73
+#: mailu/admin/forms.py:74
 msgid "Password check"
 msgstr ""
 
-#: mailu/admin/forms.py:74 mailu/admin/templates/sidebar.html:13
+#: mailu/admin/forms.py:75 mailu/admin/templates/sidebar.html:13
 msgid "Update password"
 msgstr ""
 
-#: mailu/admin/forms.py:78
+#: mailu/admin/forms.py:79
 msgid "Enable forwarding"
 msgstr ""
 
-#: mailu/admin/forms.py:80 mailu/admin/forms.py:97
+#: mailu/admin/forms.py:80
+msgid "Keep a copy of the emails"
+msgstr ""
+
+#: mailu/admin/forms.py:82 mailu/admin/forms.py:99
 #: mailu/admin/templates/alias/list.html:21
 msgid "Destination"
 msgstr ""
 
-#: mailu/admin/forms.py:82 mailu/admin/forms.py:90
+#: mailu/admin/forms.py:84 mailu/admin/forms.py:92
 msgid "Update"
 msgstr ""
 
-#: mailu/admin/forms.py:86
+#: mailu/admin/forms.py:88
 msgid "Enable automatic reply"
 msgstr ""
 
-#: mailu/admin/forms.py:87
+#: mailu/admin/forms.py:89
 msgid "Reply subject"
 msgstr ""
 
-#: mailu/admin/forms.py:88
+#: mailu/admin/forms.py:90
 msgid "Reply body"
 msgstr ""
 
-#: mailu/admin/forms.py:94
+#: mailu/admin/forms.py:96
 msgid "Alias"
 msgstr ""
 
-#: mailu/admin/forms.py:96
+#: mailu/admin/forms.py:98
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr ""
 
-#: mailu/admin/forms.py:103
+#: mailu/admin/forms.py:105
 msgid "Admin email"
 msgstr ""
 
-#: mailu/admin/forms.py:104 mailu/admin/forms.py:109 mailu/admin/forms.py:121
+#: mailu/admin/forms.py:106 mailu/admin/forms.py:111 mailu/admin/forms.py:124
 msgid "Submit"
 msgstr ""
 
-#: mailu/admin/forms.py:108
+#: mailu/admin/forms.py:110
 msgid "Manager email"
 msgstr ""
 
-#: mailu/admin/forms.py:113
+#: mailu/admin/forms.py:115
 msgid "Protocol"
 msgstr ""
 
-#: mailu/admin/forms.py:116
+#: mailu/admin/forms.py:118
 msgid "Hostname or IP"
 msgstr ""
 
-#: mailu/admin/forms.py:117
+#: mailu/admin/forms.py:119
 msgid "TCP port"
 msgstr ""
 
-#: mailu/admin/forms.py:118
+#: mailu/admin/forms.py:120
 msgid "Enable TLS"
 msgstr ""
 
-#: mailu/admin/forms.py:119 mailu/admin/templates/fetch/list.html:21
+#: mailu/admin/forms.py:121 mailu/admin/templates/fetch/list.html:21
 msgid "Username"
 msgstr ""
 
-#: mailu/admin/forms.py:125
+#: mailu/admin/forms.py:123
+msgid "Keep emails on the server"
+msgstr ""
+
+#: mailu/admin/forms.py:128
 msgid "Announcement subject"
 msgstr ""
 
-#: mailu/admin/forms.py:127
+#: mailu/admin/forms.py:130
 msgid "Announcement body"
 msgstr ""
 
-#: mailu/admin/forms.py:129
+#: mailu/admin/forms.py:132
 msgid "Send"
 msgstr ""
 
@@ -226,7 +238,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: mailu/admin/templates/fetch/list.html:23
+#: mailu/admin/templates/fetch/list.html:24
 #: mailu/admin/templates/services.html:12
 msgid "Status"
 msgstr ""
@@ -330,7 +342,7 @@ msgstr ""
 #: mailu/admin/templates/admin/list.html:23
 #: mailu/admin/templates/alias/list.html:30
 #: mailu/admin/templates/domain/list.html:32
-#: mailu/admin/templates/fetch/list.html:31
+#: mailu/admin/templates/fetch/list.html:32
 #: mailu/admin/templates/manager/list.html:25
 #: mailu/admin/templates/user/list.html:32
 msgid "Delete"
@@ -354,21 +366,21 @@ msgstr ""
 
 #: mailu/admin/templates/alias/list.html:23
 #: mailu/admin/templates/domain/list.html:23
-#: mailu/admin/templates/fetch/list.html:24
+#: mailu/admin/templates/fetch/list.html:25
 #: mailu/admin/templates/user/list.html:25
 msgid "Created"
 msgstr ""
 
 #: mailu/admin/templates/alias/list.html:24
 #: mailu/admin/templates/domain/list.html:24
-#: mailu/admin/templates/fetch/list.html:25
+#: mailu/admin/templates/fetch/list.html:26
 #: mailu/admin/templates/user/list.html:26
 msgid "Last edit"
 msgstr ""
 
 #: mailu/admin/templates/alias/list.html:29
 #: mailu/admin/templates/domain/list.html:31
-#: mailu/admin/templates/fetch/list.html:30
+#: mailu/admin/templates/fetch/list.html:31
 #: mailu/admin/templates/user/list.html:31
 msgid "Edit"
 msgstr ""
@@ -459,7 +471,19 @@ msgid "Endpoint"
 msgstr ""
 
 #: mailu/admin/templates/fetch/list.html:22
+msgid "Keep emails"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:23
 msgid "Last check"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "yes"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "no"
 msgstr ""
 
 #: mailu/admin/templates/manager/create.html:4

--- a/admin/mailu/translations/fr/LC_MESSAGES/messages.po
+++ b/admin/mailu/translations/fr/LC_MESSAGES/messages.po
@@ -1,11 +1,18 @@
+
 msgid ""
 msgstr ""
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
-"X-Generator: POEditor.com\n"
-"Project-Id-Version: Mailu\n"
+"Project-Id-Version:  Mailu\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2017-09-03 15:30+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
+"Language-Team: fr <LL@li.org>\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.5.0\n"
 
 #: mailu/admin/forms.py:32
 msgid "Invalid email address."
@@ -15,12 +22,12 @@ msgstr "Adresse e-mail invalide"
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: mailu/admin/forms.py:40 mailu/admin/forms.py:54
+#: mailu/admin/forms.py:40 mailu/admin/forms.py:55
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/admin/forms.py:41 mailu/admin/forms.py:55 mailu/admin/forms.py:72
-#: mailu/admin/forms.py:120
+#: mailu/admin/forms.py:41 mailu/admin/forms.py:56 mailu/admin/forms.py:73
+#: mailu/admin/forms.py:122
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -42,131 +49,164 @@ msgstr "Nombre maximum d'utilisateurs"
 msgid "Maximum alias count"
 msgstr "Nombre maximum d'alias"
 
-#: mailu/admin/forms.py:49 mailu/admin/forms.py:60 mailu/admin/forms.py:98
+#: mailu/admin/forms.py:49
+msgid "Maximum user quota"
+msgstr ""
+
+#: mailu/admin/forms.py:50 mailu/admin/forms.py:61 mailu/admin/forms.py:100
 #: mailu/admin/templates/alias/list.html:22
 #: mailu/admin/templates/domain/list.html:22
 #: mailu/admin/templates/user/list.html:24
 msgid "Comment"
 msgstr "Commentaire"
 
-#: mailu/admin/forms.py:50 mailu/admin/forms.py:99
+#: mailu/admin/forms.py:51 mailu/admin/forms.py:101
 msgid "Create"
 msgstr "Créer"
 
-#: mailu/admin/forms.py:56
+#: mailu/admin/forms.py:57
 msgid "Confirm password"
 msgstr "Confirmer le mot de passe"
 
-#: mailu/admin/forms.py:57 mailu/admin/templates/user/list.html:23
+#: mailu/admin/forms.py:58 mailu/admin/templates/user/list.html:23
 msgid "Quota"
 msgstr "Quota"
 
-#: mailu/admin/forms.py:58
+#: mailu/admin/forms.py:59
 msgid "Allow IMAP access"
 msgstr "Autoriser l'accès IMAP"
 
-#: mailu/admin/forms.py:59
+#: mailu/admin/forms.py:60
 msgid "Allow POP3 access"
 msgstr "Autoriser l'accès POP3"
 
-#: mailu/admin/forms.py:61
+#: mailu/admin/forms.py:62
 msgid "Save"
 msgstr "Enregistrer"
 
-#: mailu/admin/forms.py:65
+#: mailu/admin/forms.py:66
 msgid "Displayed name"
 msgstr "Nom affiché"
 
-#: mailu/admin/forms.py:66
+#: mailu/admin/forms.py:67
 msgid "Enable spam filter"
 msgstr "Activer le filtre anti-spam"
 
-#: mailu/admin/forms.py:67
+#: mailu/admin/forms.py:68
 msgid "Spam filter threshold"
 msgstr "Seuil du filtre anti-spam"
 
-#: mailu/admin/forms.py:68
+#: mailu/admin/forms.py:69
 msgid "Save settings"
 msgstr "Enregistrer les préférences"
 
-#: mailu/admin/forms.py:73
+#: mailu/admin/forms.py:74
 msgid "Password check"
 msgstr "Vérifier le mot de passe"
 
-#: mailu/admin/forms.py:74 mailu/admin/templates/sidebar.html:13
+#: mailu/admin/forms.py:75 mailu/admin/templates/sidebar.html:13
 msgid "Update password"
 msgstr "Changer de mot de passe"
 
-#: mailu/admin/forms.py:78
+#: mailu/admin/forms.py:79
 msgid "Enable forwarding"
 msgstr "Activer la redirection"
 
-#: mailu/admin/forms.py:80 mailu/admin/forms.py:97
+#: mailu/admin/forms.py:80
+msgid "Keep a copy of the emails"
+msgstr ""
+
+#: mailu/admin/forms.py:82 mailu/admin/forms.py:99
 #: mailu/admin/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destination"
 
-#: mailu/admin/forms.py:82 mailu/admin/forms.py:90
+#: mailu/admin/forms.py:84 mailu/admin/forms.py:92
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: mailu/admin/forms.py:86
+#: mailu/admin/forms.py:88
 msgid "Enable automatic reply"
 msgstr "Activer les réponses automatique"
 
-#: mailu/admin/forms.py:87
+#: mailu/admin/forms.py:89
 msgid "Reply subject"
 msgstr "Sujet du message"
 
-#: mailu/admin/forms.py:88
+#: mailu/admin/forms.py:90
 msgid "Reply body"
 msgstr "Corps de la réponse"
 
-#: mailu/admin/forms.py:94
+#: mailu/admin/forms.py:96
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/admin/forms.py:96
+#: mailu/admin/forms.py:98
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Utiliser la syntaxe SQL LIKE (par exemple pour les alias catch-all)"
 
-#: mailu/admin/forms.py:103
+#: mailu/admin/forms.py:105
 msgid "Admin email"
 msgstr "Email de l'administrateur"
 
-#: mailu/admin/forms.py:104 mailu/admin/forms.py:109 mailu/admin/forms.py:121
+#: mailu/admin/forms.py:106 mailu/admin/forms.py:111 mailu/admin/forms.py:124
 msgid "Submit"
 msgstr "Valider"
 
-#: mailu/admin/forms.py:108
+#: mailu/admin/forms.py:110
 msgid "Manager email"
 msgstr "E-mail du gérant"
 
-#: mailu/admin/forms.py:113
+#: mailu/admin/forms.py:115
 msgid "Protocol"
 msgstr "Protocole"
 
-#: mailu/admin/forms.py:116
+#: mailu/admin/forms.py:118
 msgid "Hostname or IP"
 msgstr "Nom d'hôte ou adresse IP"
 
-#: mailu/admin/forms.py:117
+#: mailu/admin/forms.py:119
 msgid "TCP port"
 msgstr "Port TCP"
 
-#: mailu/admin/forms.py:118
+#: mailu/admin/forms.py:120
 msgid "Enable TLS"
 msgstr "Activer TLS"
 
-#: mailu/admin/forms.py:119 mailu/admin/templates/fetch/list.html:21
+#: mailu/admin/forms.py:121 mailu/admin/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Nom d'utilisateur"
+
+#: mailu/admin/forms.py:123
+msgid "Keep emails on the server"
+msgstr ""
+
+#: mailu/admin/forms.py:128
+msgid "Announcement subject"
+msgstr "Sujet de l'annonce"
+
+#: mailu/admin/forms.py:130
+msgid "Announcement body"
+msgstr "Corps de l'annonce"
+
+#: mailu/admin/forms.py:132
+msgid "Send"
+msgstr "Envoyer"
+
+#: mailu/admin/templates/announcement.html:4
+msgid "Public announcement"
+msgstr "Annonce globale"
+
+#: mailu/admin/templates/announcement.html:8
+msgid "from"
+msgstr "de"
 
 #: mailu/admin/templates/confirm.html:4
 msgid "Confirm action"
 msgstr "Confirmer"
 
 #: mailu/admin/templates/confirm.html:12
+#, python-format
 msgid "You are about to %(action)s. Please confirm your action."
 msgstr "Vous allez %(action)s. Merci de confirmer votre action."
 
@@ -194,7 +234,7 @@ msgstr "Etat des services"
 msgid "Service"
 msgstr "Service"
 
-#: mailu/admin/templates/fetch/list.html:23
+#: mailu/admin/templates/fetch/list.html:24
 #: mailu/admin/templates/services.html:12
 msgid "Status"
 msgstr "Etat"
@@ -247,6 +287,10 @@ msgstr "Déconnexion"
 msgid "Administration"
 msgstr "Administration"
 
+#: mailu/admin/templates/sidebar.html:45
+msgid "Announcement"
+msgstr "Annonce"
+
 #: mailu/admin/templates/sidebar.html:50
 msgid "Administrators"
 msgstr "Administrateurs"
@@ -294,7 +338,7 @@ msgstr "E-mail"
 #: mailu/admin/templates/admin/list.html:23
 #: mailu/admin/templates/alias/list.html:30
 #: mailu/admin/templates/domain/list.html:32
-#: mailu/admin/templates/fetch/list.html:31
+#: mailu/admin/templates/fetch/list.html:32
 #: mailu/admin/templates/manager/list.html:25
 #: mailu/admin/templates/user/list.html:32
 msgid "Delete"
@@ -318,21 +362,21 @@ msgstr "Ajouter un alias"
 
 #: mailu/admin/templates/alias/list.html:23
 #: mailu/admin/templates/domain/list.html:23
-#: mailu/admin/templates/fetch/list.html:24
+#: mailu/admin/templates/fetch/list.html:25
 #: mailu/admin/templates/user/list.html:25
 msgid "Created"
 msgstr "Création"
 
 #: mailu/admin/templates/alias/list.html:24
 #: mailu/admin/templates/domain/list.html:24
-#: mailu/admin/templates/fetch/list.html:25
+#: mailu/admin/templates/fetch/list.html:26
 #: mailu/admin/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Dernière modification"
 
 #: mailu/admin/templates/alias/list.html:29
 #: mailu/admin/templates/domain/list.html:31
-#: mailu/admin/templates/fetch/list.html:30
+#: mailu/admin/templates/fetch/list.html:31
 #: mailu/admin/templates/user/list.html:31
 msgid "Edit"
 msgstr "Modifier"
@@ -423,8 +467,20 @@ msgid "Endpoint"
 msgstr "Source"
 
 #: mailu/admin/templates/fetch/list.html:22
+msgid "Keep emails"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:23
 msgid "Last check"
 msgstr "Dernier relevé"
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "yes"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "no"
+msgstr ""
 
 #: mailu/admin/templates/manager/create.html:4
 msgid "Add a manager"
@@ -437,30 +493,6 @@ msgstr "Liste des gérants"
 #: mailu/admin/templates/manager/list.html:12
 msgid "Add manager"
 msgstr "Ajouter le gérant"
-
-#: mailu/admin/forms.py:125
-msgid "Announcement subject"
-msgstr "Sujet de l'annonce"
-
-#: mailu/admin/forms.py:127
-msgid "Announcement body"
-msgstr "Corps de l'annonce"
-
-#: mailu/admin/forms.py:129
-msgid "Send"
-msgstr "Envoyer"
-
-#: mailu/admin/templates/announcement.html:4
-msgid "Public announcement"
-msgstr "Annonce globale"
-
-#: mailu/admin/templates/announcement.html:8
-msgid "from"
-msgstr "de"
-
-#: mailu/admin/templates/sidebar.html:45
-msgid "Announcement"
-msgstr "Annonce"
 
 #: mailu/admin/templates/user/create.html:4
 msgid "New user"

--- a/admin/mailu/translations/pt/LC_MESSAGES/messages.po
+++ b/admin/mailu/translations/pt/LC_MESSAGES/messages.po
@@ -1,4 +1,4 @@
-# Translations template for PROJECT.
+# Portuguese (Brazil) translations for PROJECT.
 # Copyright (C) 2016 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
 # FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
@@ -7,18 +7,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2017-03-27 11:37-0300\n"
+"POT-Creation-Date: 2017-09-03 15:30+0200\n"
 "PO-Revision-Date: 2017-03-27 11:43-0300\n"
 "Last-Translator: \n"
-"Language-Team: \n"
 "Language: pt_BR\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
-"X-Generator: Poedit 1.8.9\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"X-Poedit-Basepath: .\n"
+"Generated-By: Babel 2.5.0\n"
 
 #: mailu/admin/forms.py:32
 msgid "Invalid email address."
@@ -28,12 +26,12 @@ msgstr "Endereço de e-mail inválido"
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: mailu/admin/forms.py:40 mailu/admin/forms.py:54
+#: mailu/admin/forms.py:40 mailu/admin/forms.py:55
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/admin/forms.py:41 mailu/admin/forms.py:55 mailu/admin/forms.py:72
-#: mailu/admin/forms.py:120
+#: mailu/admin/forms.py:41 mailu/admin/forms.py:56 mailu/admin/forms.py:73
+#: mailu/admin/forms.py:122
 msgid "Password"
 msgstr "Senha"
 
@@ -55,139 +53,147 @@ msgstr "Quantidade máxima de usuários"
 msgid "Maximum alias count"
 msgstr "Quantidade máxima de alias"
 
-#: mailu/admin/forms.py:49 mailu/admin/forms.py:60 mailu/admin/forms.py:98
+#: mailu/admin/forms.py:49
+msgid "Maximum user quota"
+msgstr ""
+
+#: mailu/admin/forms.py:50 mailu/admin/forms.py:61 mailu/admin/forms.py:100
 #: mailu/admin/templates/alias/list.html:22
 #: mailu/admin/templates/domain/list.html:22
 #: mailu/admin/templates/user/list.html:24
 msgid "Comment"
 msgstr "Comentário"
 
-#: mailu/admin/forms.py:50 mailu/admin/forms.py:99
+#: mailu/admin/forms.py:51 mailu/admin/forms.py:101
 msgid "Create"
 msgstr "Criar"
 
-#: mailu/admin/forms.py:56
+#: mailu/admin/forms.py:57
 msgid "Confirm password"
 msgstr "Confirmar senha"
 
-#: mailu/admin/forms.py:57 mailu/admin/templates/user/list.html:23
+#: mailu/admin/forms.py:58 mailu/admin/templates/user/list.html:23
 msgid "Quota"
 msgstr "Quota"
 
-#: mailu/admin/forms.py:58
+#: mailu/admin/forms.py:59
 msgid "Allow IMAP access"
 msgstr "Permitir acesso IMAP"
 
-#: mailu/admin/forms.py:59
+#: mailu/admin/forms.py:60
 msgid "Allow POP3 access"
 msgstr "Permitir acesso POP3"
 
-#: mailu/admin/forms.py:61
+#: mailu/admin/forms.py:62
 msgid "Save"
 msgstr "Salvar"
 
-#: mailu/admin/forms.py:65
+#: mailu/admin/forms.py:66
 msgid "Displayed name"
 msgstr "Nome de exibição"
 
-#: mailu/admin/forms.py:66
+#: mailu/admin/forms.py:67
 msgid "Enable spam filter"
 msgstr "Habilitar filtro de spam"
 
-#: mailu/admin/forms.py:67
+#: mailu/admin/forms.py:68
 msgid "Spam filter threshold"
 msgstr "Limite de filtro de spam"
 
-#: mailu/admin/forms.py:68
+#: mailu/admin/forms.py:69
 msgid "Save settings"
 msgstr "Salvar configurações"
 
-#: mailu/admin/forms.py:73
+#: mailu/admin/forms.py:74
 msgid "Password check"
 msgstr "Confirmação de senha"
 
-#: mailu/admin/forms.py:74 mailu/admin/templates/sidebar.html:13
+#: mailu/admin/forms.py:75 mailu/admin/templates/sidebar.html:13
 msgid "Update password"
 msgstr "Alterar senha"
 
-#: mailu/admin/forms.py:78
+#: mailu/admin/forms.py:79
 msgid "Enable forwarding"
 msgstr "Habilitar encaminhamento"
 
-#: mailu/admin/forms.py:80 mailu/admin/forms.py:97
+#: mailu/admin/forms.py:80
+msgid "Keep a copy of the emails"
+msgstr ""
+
+#: mailu/admin/forms.py:82 mailu/admin/forms.py:99
 #: mailu/admin/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destinatário"
 
-#: mailu/admin/forms.py:82 mailu/admin/forms.py:90
+#: mailu/admin/forms.py:84 mailu/admin/forms.py:92
 msgid "Update"
 msgstr "Atualizar"
 
-#: mailu/admin/forms.py:86
+#: mailu/admin/forms.py:88
 msgid "Enable automatic reply"
 msgstr "Habilitar resposta automática"
 
-#: mailu/admin/forms.py:87
+#: mailu/admin/forms.py:89
 msgid "Reply subject"
 msgstr "Assunto da resposta"
 
-#: mailu/admin/forms.py:88
+#: mailu/admin/forms.py:90
 msgid "Reply body"
 msgstr "Corpo da resposta"
 
-#: mailu/admin/forms.py:94
+#: mailu/admin/forms.py:96
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/admin/forms.py:96
+#: mailu/admin/forms.py:98
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Usar sintaxe estilo SQL(ex: for catch-all aliases)"
 
-#: mailu/admin/forms.py:103
+#: mailu/admin/forms.py:105
 msgid "Admin email"
 msgstr "E-mail do administrador"
 
-#: mailu/admin/forms.py:104 mailu/admin/forms.py:109 mailu/admin/forms.py:121
+#: mailu/admin/forms.py:106 mailu/admin/forms.py:111 mailu/admin/forms.py:124
 msgid "Submit"
 msgstr "Enviar"
 
-#: mailu/admin/forms.py:108
+#: mailu/admin/forms.py:110
 msgid "Manager email"
 msgstr "E-mail do gerente"
 
-#: mailu/admin/forms.py:113
+#: mailu/admin/forms.py:115
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: mailu/admin/forms.py:116
+#: mailu/admin/forms.py:118
 msgid "Hostname or IP"
 msgstr "Hostname ou IP"
 
-#: mailu/admin/forms.py:117
+#: mailu/admin/forms.py:119
 msgid "TCP port"
 msgstr "Porta TCP"
 
-#: mailu/admin/forms.py:118
+#: mailu/admin/forms.py:120
 msgid "Enable TLS"
 msgstr "Habilitar TLS"
 
-#: mailu/admin/forms.py:119 mailu/admin/templates/fetch/list.html:21
+#: mailu/admin/forms.py:121 mailu/admin/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Usuário"
 
-#: mailu/admin/forms.py:121
+#: mailu/admin/forms.py:123
 msgid "Keep emails on the server"
 msgstr "Manter os e-mails no servidor"
 
-#: mailu/admin/forms.py:125
+#: mailu/admin/forms.py:128
 msgid "Announcement subject"
 msgstr "Título do comunicado"
 
-#: mailu/admin/forms.py:127
+#: mailu/admin/forms.py:130
 msgid "Announcement body"
 msgstr "Corpo do comunicado"
 
-#: mailu/admin/forms.py:129
+#: mailu/admin/forms.py:132
 msgid "Send"
 msgstr "Enviar"
 
@@ -232,7 +238,7 @@ msgstr "Status do serviço"
 msgid "Service"
 msgstr "Serviço"
 
-#: mailu/admin/templates/fetch/list.html:23
+#: mailu/admin/templates/fetch/list.html:24
 #: mailu/admin/templates/services.html:12
 msgid "Status"
 msgstr "Status"
@@ -336,7 +342,7 @@ msgstr "Email"
 #: mailu/admin/templates/admin/list.html:23
 #: mailu/admin/templates/alias/list.html:30
 #: mailu/admin/templates/domain/list.html:32
-#: mailu/admin/templates/fetch/list.html:31
+#: mailu/admin/templates/fetch/list.html:32
 #: mailu/admin/templates/manager/list.html:25
 #: mailu/admin/templates/user/list.html:32
 msgid "Delete"
@@ -360,21 +366,21 @@ msgstr "Adicionar alias"
 
 #: mailu/admin/templates/alias/list.html:23
 #: mailu/admin/templates/domain/list.html:23
-#: mailu/admin/templates/fetch/list.html:24
+#: mailu/admin/templates/fetch/list.html:25
 #: mailu/admin/templates/user/list.html:25
 msgid "Created"
 msgstr "Criado"
 
 #: mailu/admin/templates/alias/list.html:24
 #: mailu/admin/templates/domain/list.html:24
-#: mailu/admin/templates/fetch/list.html:25
+#: mailu/admin/templates/fetch/list.html:26
 #: mailu/admin/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Última edição"
 
 #: mailu/admin/templates/alias/list.html:29
 #: mailu/admin/templates/domain/list.html:31
-#: mailu/admin/templates/fetch/list.html:30
+#: mailu/admin/templates/fetch/list.html:31
 #: mailu/admin/templates/user/list.html:31
 msgid "Edit"
 msgstr "Editar"
@@ -465,8 +471,20 @@ msgid "Endpoint"
 msgstr "Endpoint"
 
 #: mailu/admin/templates/fetch/list.html:22
+msgid "Keep emails"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:23
 msgid "Last check"
 msgstr "Última verificação"
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "yes"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "no"
+msgstr ""
 
 #: mailu/admin/templates/manager/create.html:4
 msgid "Add a manager"
@@ -516,3 +534,4 @@ msgstr "Atualizar senha"
 #: mailu/admin/templates/user/reply.html:4
 msgid "Automatic reply"
 msgstr "Resposta automática"
+

--- a/admin/messages.pot
+++ b/admin/messages.pot
@@ -1,21 +1,21 @@
 # Translations template for PROJECT.
-# Copyright (C) 2016 ORGANIZATION
+# Copyright (C) 2017 ORGANIZATION
 # This file is distributed under the same license as the PROJECT project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2016.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2017.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2016-11-10 10:52+0100\n"
+"POT-Creation-Date: 2017-09-03 15:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.5.0\n"
 
 #: mailu/admin/forms.py:32
 msgid "Invalid email address."
@@ -25,12 +25,12 @@ msgstr ""
 msgid "Confirm"
 msgstr ""
 
-#: mailu/admin/forms.py:40 mailu/admin/forms.py:54
+#: mailu/admin/forms.py:40 mailu/admin/forms.py:55
 msgid "E-mail"
 msgstr ""
 
-#: mailu/admin/forms.py:41 mailu/admin/forms.py:55 mailu/admin/forms.py:72
-#: mailu/admin/forms.py:120
+#: mailu/admin/forms.py:41 mailu/admin/forms.py:56 mailu/admin/forms.py:73
+#: mailu/admin/forms.py:122
 msgid "Password"
 msgstr ""
 
@@ -52,135 +52,147 @@ msgstr ""
 msgid "Maximum alias count"
 msgstr ""
 
-#: mailu/admin/forms.py:49 mailu/admin/forms.py:60 mailu/admin/forms.py:98
+#: mailu/admin/forms.py:49
+msgid "Maximum user quota"
+msgstr ""
+
+#: mailu/admin/forms.py:50 mailu/admin/forms.py:61 mailu/admin/forms.py:100
 #: mailu/admin/templates/alias/list.html:22
 #: mailu/admin/templates/domain/list.html:22
 #: mailu/admin/templates/user/list.html:24
 msgid "Comment"
 msgstr ""
 
-#: mailu/admin/forms.py:50 mailu/admin/forms.py:99
+#: mailu/admin/forms.py:51 mailu/admin/forms.py:101
 msgid "Create"
 msgstr ""
 
-#: mailu/admin/forms.py:56
+#: mailu/admin/forms.py:57
 msgid "Confirm password"
 msgstr ""
 
-#: mailu/admin/forms.py:57 mailu/admin/templates/user/list.html:23
+#: mailu/admin/forms.py:58 mailu/admin/templates/user/list.html:23
 msgid "Quota"
 msgstr ""
 
-#: mailu/admin/forms.py:58
+#: mailu/admin/forms.py:59
 msgid "Allow IMAP access"
 msgstr ""
 
-#: mailu/admin/forms.py:59
+#: mailu/admin/forms.py:60
 msgid "Allow POP3 access"
 msgstr ""
 
-#: mailu/admin/forms.py:61
+#: mailu/admin/forms.py:62
 msgid "Save"
 msgstr ""
 
-#: mailu/admin/forms.py:65
+#: mailu/admin/forms.py:66
 msgid "Displayed name"
 msgstr ""
 
-#: mailu/admin/forms.py:66
+#: mailu/admin/forms.py:67
 msgid "Enable spam filter"
 msgstr ""
 
-#: mailu/admin/forms.py:67
+#: mailu/admin/forms.py:68
 msgid "Spam filter threshold"
 msgstr ""
 
-#: mailu/admin/forms.py:68
+#: mailu/admin/forms.py:69
 msgid "Save settings"
 msgstr ""
 
-#: mailu/admin/forms.py:73
+#: mailu/admin/forms.py:74
 msgid "Password check"
 msgstr ""
 
-#: mailu/admin/forms.py:74 mailu/admin/templates/sidebar.html:13
+#: mailu/admin/forms.py:75 mailu/admin/templates/sidebar.html:13
 msgid "Update password"
 msgstr ""
 
-#: mailu/admin/forms.py:78
+#: mailu/admin/forms.py:79
 msgid "Enable forwarding"
 msgstr ""
 
-#: mailu/admin/forms.py:80 mailu/admin/forms.py:97
+#: mailu/admin/forms.py:80
+msgid "Keep a copy of the emails"
+msgstr ""
+
+#: mailu/admin/forms.py:82 mailu/admin/forms.py:99
 #: mailu/admin/templates/alias/list.html:21
 msgid "Destination"
 msgstr ""
 
-#: mailu/admin/forms.py:82 mailu/admin/forms.py:90
+#: mailu/admin/forms.py:84 mailu/admin/forms.py:92
 msgid "Update"
 msgstr ""
 
-#: mailu/admin/forms.py:86
+#: mailu/admin/forms.py:88
 msgid "Enable automatic reply"
 msgstr ""
 
-#: mailu/admin/forms.py:87
+#: mailu/admin/forms.py:89
 msgid "Reply subject"
 msgstr ""
 
-#: mailu/admin/forms.py:88
+#: mailu/admin/forms.py:90
 msgid "Reply body"
 msgstr ""
 
-#: mailu/admin/forms.py:94
+#: mailu/admin/forms.py:96
 msgid "Alias"
 msgstr ""
 
-#: mailu/admin/forms.py:96
+#: mailu/admin/forms.py:98
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr ""
 
-#: mailu/admin/forms.py:103
+#: mailu/admin/forms.py:105
 msgid "Admin email"
 msgstr ""
 
-#: mailu/admin/forms.py:104 mailu/admin/forms.py:109 mailu/admin/forms.py:121
+#: mailu/admin/forms.py:106 mailu/admin/forms.py:111 mailu/admin/forms.py:124
 msgid "Submit"
 msgstr ""
 
-#: mailu/admin/forms.py:108
+#: mailu/admin/forms.py:110
 msgid "Manager email"
 msgstr ""
 
-#: mailu/admin/forms.py:113
+#: mailu/admin/forms.py:115
 msgid "Protocol"
 msgstr ""
 
-#: mailu/admin/forms.py:116
+#: mailu/admin/forms.py:118
 msgid "Hostname or IP"
 msgstr ""
 
-#: mailu/admin/forms.py:117
+#: mailu/admin/forms.py:119
 msgid "TCP port"
 msgstr ""
 
-#: mailu/admin/forms.py:118
+#: mailu/admin/forms.py:120
 msgid "Enable TLS"
 msgstr ""
 
-#: mailu/admin/forms.py:119 mailu/admin/templates/fetch/list.html:21
+#: mailu/admin/forms.py:121 mailu/admin/templates/fetch/list.html:21
 msgid "Username"
 msgstr ""
 
-#: mailu/admin/forms.py:125
+#: mailu/admin/forms.py:123
+msgid "Keep emails on the server"
+msgstr ""
+
+#: mailu/admin/forms.py:128
 msgid "Announcement subject"
 msgstr ""
 
-#: mailu/admin/forms.py:127
+#: mailu/admin/forms.py:130
 msgid "Announcement body"
 msgstr ""
 
-#: mailu/admin/forms.py:129
+#: mailu/admin/forms.py:132
 msgid "Send"
 msgstr ""
 
@@ -225,7 +237,7 @@ msgstr ""
 msgid "Service"
 msgstr ""
 
-#: mailu/admin/templates/fetch/list.html:23
+#: mailu/admin/templates/fetch/list.html:24
 #: mailu/admin/templates/services.html:12
 msgid "Status"
 msgstr ""
@@ -329,7 +341,7 @@ msgstr ""
 #: mailu/admin/templates/admin/list.html:23
 #: mailu/admin/templates/alias/list.html:30
 #: mailu/admin/templates/domain/list.html:32
-#: mailu/admin/templates/fetch/list.html:31
+#: mailu/admin/templates/fetch/list.html:32
 #: mailu/admin/templates/manager/list.html:25
 #: mailu/admin/templates/user/list.html:32
 msgid "Delete"
@@ -353,21 +365,21 @@ msgstr ""
 
 #: mailu/admin/templates/alias/list.html:23
 #: mailu/admin/templates/domain/list.html:23
-#: mailu/admin/templates/fetch/list.html:24
+#: mailu/admin/templates/fetch/list.html:25
 #: mailu/admin/templates/user/list.html:25
 msgid "Created"
 msgstr ""
 
 #: mailu/admin/templates/alias/list.html:24
 #: mailu/admin/templates/domain/list.html:24
-#: mailu/admin/templates/fetch/list.html:25
+#: mailu/admin/templates/fetch/list.html:26
 #: mailu/admin/templates/user/list.html:26
 msgid "Last edit"
 msgstr ""
 
 #: mailu/admin/templates/alias/list.html:29
 #: mailu/admin/templates/domain/list.html:31
-#: mailu/admin/templates/fetch/list.html:30
+#: mailu/admin/templates/fetch/list.html:31
 #: mailu/admin/templates/user/list.html:31
 msgid "Edit"
 msgstr ""
@@ -458,7 +470,19 @@ msgid "Endpoint"
 msgstr ""
 
 #: mailu/admin/templates/fetch/list.html:22
+msgid "Keep emails"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:23
 msgid "Last check"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "yes"
+msgstr ""
+
+#: mailu/admin/templates/fetch/list.html:36
+msgid "no"
 msgstr ""
 
 #: mailu/admin/templates/manager/create.html:4

--- a/admin/migrations/versions/73e56bad5ec5_.py
+++ b/admin/migrations/versions/73e56bad5ec5_.py
@@ -1,0 +1,24 @@
+""" Add the ability to keep forwarded messages
+
+Revision ID: 73e56bad5ec5
+Revises: 3f6994568962
+Create Date: 2017-09-03 15:36:07.821002
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '73e56bad5ec5'
+down_revision = '3f6994568962'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    with op.batch_alter_table('user') as batch:
+        batch.add_column(sa.Column('forward_keep', sa.Boolean(), nullable=False, server_default=sa.sql.expression.true()))
+
+
+def downgrade():
+    with op.batch_alter_table('user') as batch:
+        batch.drop_column('forward_keep')

--- a/postfix/conf/sqlite-virtual_alias_maps.cf
+++ b/postfix/conf/sqlite-virtual_alias_maps.cf
@@ -4,7 +4,7 @@ query =
    FROM
      (SELECT destination, email, wildcard, localpart FROM alias
       UNION
-      SELECT email||(CASE WHEN forward_enabled=1 THEN ','||forward_destination ELSE '' END) AS destination, email, 0 as wildcard, localpart FROM user)
+      SELECT (CASE WHEN forward_enabled=1 THEN (CASE WHEN forward_keep=1 THEN email||',' ELSE '')||forward_destination ELSE email END) AS destination, email, 0 as wildcard, localpart FROM user)
    WHERE
      (
       wildcard = 0

--- a/postfix/conf/sqlite-virtual_alias_maps.cf
+++ b/postfix/conf/sqlite-virtual_alias_maps.cf
@@ -4,7 +4,7 @@ query =
    FROM
      (SELECT destination, email, wildcard, localpart FROM alias
       UNION
-      SELECT (CASE WHEN forward_enabled=1 THEN (CASE WHEN forward_keep=1 THEN email||',' ELSE '')||forward_destination ELSE email END) AS destination, email, 0 as wildcard, localpart FROM user)
+      SELECT (CASE WHEN forward_enabled=1 THEN (CASE WHEN forward_keep=1 THEN email||',' ELSE '' END)||forward_destination ELSE email END) AS destination, email, 0 as wildcard, localpart FROM user)
    WHERE
      (
       wildcard = 0


### PR DESCRIPTION
Implement the ability to keep or drop forwarded messages (ie. the user can change its email address into a simple alias instead of forward *and* keeping all messages). Related to #243 