### PR TITLE
Feature recipient delimiter

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -73,6 +73,10 @@ RELAYHOST=
 # Fetchmail delay
 FETCHMAIL_DELAY=600
 
+# Recipient delimiter, character used to delimiter localpart from custom address part
+# e.g. localpart+custom@domain;tld
+RECIPIENT_DELIMITER=+
+
 ###################################
 # Nginx settings
 ###################################

--- a/dovecot/conf/dovecot.conf
+++ b/dovecot/conf/dovecot.conf
@@ -127,7 +127,7 @@ service imap-login {
 
 protocol lmtp {
   mail_plugins = $mail_plugins sieve
-  recipient_delimiter = +
+  recipient_delimiter = {{ RECIPIENT_DELIMITER }}
 }
 
 service lmtp {

--- a/postfix/conf/main.cf
+++ b/postfix/conf/main.cf
@@ -28,6 +28,9 @@ mydestination =
 # Relayhost if any is configured
 relayhost = {{ RELAYHOST }}
 
+# Recipient delimiter for extended addresses
+recipient_delimiter = +
+
 ###############
 # TLS
 ###############

--- a/postfix/conf/main.cf
+++ b/postfix/conf/main.cf
@@ -29,7 +29,7 @@ mydestination =
 relayhost = {{ RELAYHOST }}
 
 # Recipient delimiter for extended addresses
-recipient_delimiter = +
+recipient_delimiter = {{ RECIPIENT_DELIMITER }}
 
 ###############
 # TLS


### PR DESCRIPTION
Add the ability to specify a recipient delimiter to separate the localpart from a customizable and optional part, e.g. use addresses like localpart+spam@domain.tld