### PR TITLE
RainLoop: Allow two factor auth

### DIFF
--- a/rainloop/config.ini
+++ b/rainloop/config.ini
@@ -5,6 +5,7 @@ attachment_size_limit = 25
 
 [security]
 allow_admin_panel = Off
+allow_two_factor_auth = On
 
 [labs]
 allow_gravatar = Off


### PR DESCRIPTION
This settings enables users to configure two-factor authentication for their account. As force_two_factor_auth is still off, users are not forced to use two-factor.