### PR TITLE
multiple bugfixes for config_sync and full coverage of user/alias/domain attributes added

### DIFF
--- a/admin/manage.py
+++ b/admin/manage.py
@@ -18,6 +18,7 @@ def admin(localpart, domain_name, password):
     db.session.add(user)
     db.session.commit()
 
+
 @manager.command
 def user(localpart, domain_name, password, hash_scheme=app.config['PASSWORD_SCHEME']):
     """ Create a user
@@ -35,16 +36,18 @@ def user(localpart, domain_name, password, hash_scheme=app.config['PASSWORD_SCHE
     db.session.add(user)
     db.session.commit()
 
-@manager.option('-n','--domain_name',dest='domain_name')
-@manager.option('-u','--max_users',dest='max_users')
-@manager.option('-a','--max_aliases',dest='max_aliases')
-@manager.option('-q','--max_quota_bytes',dest='max_quota_bytes')
+
+@manager.option('-n', '--domain_name', dest='domain_name')
+@manager.option('-u', '--max_users', dest='max_users')
+@manager.option('-a', '--max_aliases', dest='max_aliases')
+@manager.option('-q', '--max_quota_bytes', dest='max_quota_bytes')
 def domain(domain_name, max_users=0, max_aliases=0, max_quota_bytes=0):
     domain = models.Domain.query.get(domain_name)
     if not domain:
         domain = models.Domain(name=domain_name)
         db.session.add(domain)
         db.session.commit()
+
 
 @manager.command
 def user_import(localpart, domain_name, password_hash, hash_scheme=app.config['PASSWORD_SCHEME']):
@@ -67,57 +70,59 @@ def user_import(localpart, domain_name, password_hash, hash_scheme=app.config['P
     db.session.add(user)
     db.session.commit()
 
+
 @manager.command
 def config_update(verbose=False, delete_objects=False):
     """sync configuration with data from YAML-formatted stdin"""
-    import yaml, sys
-    new_config=yaml.load(sys.stdin)
+    import yaml
+    import sys
+    new_config = yaml.load(sys.stdin)
     # print new_config
-    domains=new_config.get('domains',[])
-    tracked_domains=set()
+    domains = new_config.get('domains', [])
+    tracked_domains = set()
     for domain_config in domains:
         if verbose:
             print(str(domain_config))
         domain_name = domain_config['name']
-        max_users=domain_config.get('max_users',0)
-        max_aliases=domain_config.get('max_aliases',0)
-        max_quota_bytes=domain_config.get('max_quota_bytes',0)
+        max_users = domain_config.get('max_users', 0)
+        max_aliases = domain_config.get('max_aliases', 0)
+        max_quota_bytes = domain_config.get('max_quota_bytes', 0)
         tracked_domains.add(domain_name)
         domain = models.Domain.query.get(domain_name)
         if not domain:
             domain = models.Domain(name=domain_name,
-                    max_users=max_users,
-                    max_aliases=max_aliases,
-                    max_quota_bytes=max_quota_bytes)
+                                   max_users=max_users,
+                                   max_aliases=max_aliases,
+                                   max_quota_bytes=max_quota_bytes)
             db.session.add(domain)
-            print("Added "+str(domain_config))
+            print("Added " + str(domain_config))
         else:
             domain.max_users = max_users
             domain.max_aliases = max_aliases
             domain.max_quota_bytes = max_quota_bytes
             db.session.add(domain)
-            print("Updated "+str(domain_config))
+            print("Updated " + str(domain_config))
 
-    users=new_config.get('users',[])
-    tracked_users=set()
-    user_optional_params=('comment','quota_bytes','global_admin',
-            'enable_imap','enable_pop','forward_enabled','forward_destination',
-            'reply_enabled','reply_subject','reply_body','displayed_name','spam_enabled',
-            'email','spam_threshold')
+    users = new_config.get('users', [])
+    tracked_users = set()
+    user_optional_params = ('comment', 'quota_bytes', 'global_admin',
+                            'enable_imap', 'enable_pop', 'forward_enabled', 'forward_destination',
+                            'reply_enabled', 'reply_subject', 'reply_body', 'displayed_name', 'spam_enabled',
+                            'email', 'spam_threshold')
     for user_config in users:
         if verbose:
             print(str(user_config))
-        localpart=user_config['localpart']
-        domain_name=user_config['domain']
-        global_admin=user_config.get('global_admin',False)
-        password_hash=user_config.get('password_hash',None)
-        hash_scheme=user_config.get('hash_scheme',None)
+        localpart = user_config['localpart']
+        domain_name = user_config['domain']
+        global_admin = user_config.get('global_admin', False)
+        password_hash = user_config.get('password_hash', None)
+        hash_scheme = user_config.get('hash_scheme', None)
         domain = models.Domain.query.get(domain_name)
-        email='{0}@{1}'.format(localpart,domain_name)
-        optional_params={}
+        email = '{0}@{1}'.format(localpart, domain_name)
+        optional_params = {}
         for k in user_optional_params:
             if k in user_config:
-                optional_params[k]=user_config[k]
+                optional_params[k] = user_config[k]
         if not domain:
             domain = models.Domain(name=domain_name)
             db.session.add(domain)
@@ -136,20 +141,20 @@ def config_update(verbose=False, delete_objects=False):
         user.set_password(password_hash, hash_scheme=hash_scheme, raw=True)
         db.session.add(user)
 
-    aliases=new_config.get('aliases',[])
-    tracked_aliases=set()
+    aliases = new_config.get('aliases', [])
+    tracked_aliases = set()
     for alias_config in aliases:
         if verbose:
             print(str(alias_config))
-        localpart=alias_config['localpart']
-        domain_name=alias_config['domain']
+        localpart = alias_config['localpart']
+        domain_name = alias_config['domain']
         if type(alias_config['destination']) is str:
             destination = alias_config['destination'].split(',')
         else:
             destination = alias_config['destination']
-        wildcard=alias_config.get('wildcard',False)
+        wildcard = alias_config.get('wildcard', False)
         domain = models.Domain.query.get(domain_name)
-        email='{0}@{1}'.format(localpart,domain_name)
+        email = '{0}@{1}'.format(localpart, domain_name)
         if not domain:
             domain = models.Domain(name=domain_name)
             db.session.add(domain)
@@ -166,12 +171,12 @@ def config_update(verbose=False, delete_objects=False):
             )
         else:
             alias.destination = destination
-            alias.wildcard=wildcard
+            alias.wildcard = wildcard
         db.session.add(alias)
 
     db.session.commit()
 
-    managers=new_config.get('managers',[])
+    managers = new_config.get('managers', [])
     # tracked_managers=set()
     for manager_config in managers:
         if verbose:
@@ -183,26 +188,27 @@ def config_update(verbose=False, delete_objects=False):
         if not manageruser in domain.managers:
             domain.managers.append(manageruser)
         db.session.add(domain)
-    
+
     db.session.commit()
 
     if delete_objects:
         for user in db.session.query(models.User).all():
-            if not ( user.email in tracked_users ):
+            if not (user.email in tracked_users):
                 if verbose:
-                    print("Deleting user: "+str(user.email))
+                    print("Deleting user: " + str(user.email))
                 db.session.delete(user)
         for alias in db.session.query(models.Alias).all():
-            if not ( alias.email in tracked_aliases ):
+            if not (alias.email in tracked_aliases):
                 if verbose:
-                    print("Deleting alias: "+str(alias.email))
+                    print("Deleting alias: " + str(alias.email))
                 db.session.delete(alias)
         for domain in db.session.query(models.Domain).all():
-            if not ( domain.name in tracked_domains ):
+            if not (domain.name in tracked_domains):
                 if verbose:
-                    print("Deleting domain: "+str(domain.name))
+                    print("Deleting domain: " + str(domain.name))
                 db.session.delete(domain)
     db.session.commit()
+
 
 @manager.command
 def user_delete(email):
@@ -212,6 +218,7 @@ def user_delete(email):
         db.session.delete(user)
     db.session.commit()
 
+
 @manager.command
 def alias_delete(email):
     """delete alias"""
@@ -219,6 +226,7 @@ def alias_delete(email):
     if alias:
         db.session.delete(alias)
     db.session.commit()
+
 
 @manager.command
 def alias(localpart, domain_name, destination):
@@ -238,24 +246,28 @@ def alias(localpart, domain_name, destination):
     db.session.commit()
 
 # Set limits to a domain
+
+
 @manager.command
 def setlimits(domain_name, max_users, max_aliases, max_quota_bytes):
-  domain = models.Domain.query.get(domain_name)
-  domain.max_users = max_users
-  domain.max_aliases = max_aliases
-  domain.max_quota_bytes = max_quota_bytes
+    domain = models.Domain.query.get(domain_name)
+    domain.max_users = max_users
+    domain.max_aliases = max_aliases
+    domain.max_quota_bytes = max_quota_bytes
 
-  db.session.add(domain)
-  db.session.commit()
+    db.session.add(domain)
+    db.session.commit()
 
 # Make the user manager of a domain
+
+
 @manager.command
 def setmanager(domain_name, user_name='manager'):
-  domain = models.Domain.query.get(domain_name)
-  manageruser = models.User.query.get(user_name + '@' + domain_name)
-  domain.managers.append(manageruser)
-  db.session.add(domain)
-  db.session.commit()
+    domain = models.Domain.query.get(domain_name)
+    manageruser = models.User.query.get(user_name + '@' + domain_name)
+    domain.managers.append(manageruser)
+    db.session.add(domain)
+    db.session.commit()
 
 
 if __name__ == "__main__":

--- a/admin/manage.py
+++ b/admin/manage.py
@@ -20,7 +20,8 @@ def admin(localpart, domain_name, password):
 
 
 @manager.command
-def user(localpart, domain_name, password, hash_scheme=app.config['PASSWORD_SCHEME']):
+def user(localpart, domain_name, password,
+         hash_scheme=app.config['PASSWORD_SCHEME']):
     """ Create a user
     """
     domain = models.Domain.query.get(domain_name)
@@ -50,7 +51,8 @@ def domain(domain_name, max_users=0, max_aliases=0, max_quota_bytes=0):
 
 
 @manager.command
-def user_import(localpart, domain_name, password_hash, hash_scheme=app.config['PASSWORD_SCHEME']):
+def user_import(localpart, domain_name, password_hash, 
+                hash_scheme=app.config['PASSWORD_SCHEME']):
     """ Import a user along with password hash. Available hashes:
                    'SHA512-CRYPT'
                    'SHA256-CRYPT'
@@ -106,15 +108,15 @@ def config_update(verbose=False, delete_objects=False):
     users = new_config.get('users', [])
     tracked_users = set()
     user_optional_params = ('comment', 'quota_bytes', 'global_admin',
-                            'enable_imap', 'enable_pop', 'forward_enabled', 'forward_destination',
-                            'reply_enabled', 'reply_subject', 'reply_body', 'displayed_name', 'spam_enabled',
-                            'email', 'spam_threshold')
+                            'enable_imap', 'enable_pop', 'forward_enabled',
+                            'forward_destination', 'reply_enabled',
+                            'reply_subject', 'reply_body', 'displayed_name',
+                            'spam_enabled', 'email', 'spam_threshold')
     for user_config in users:
         if verbose:
             print(str(user_config))
         localpart = user_config['localpart']
         domain_name = user_config['domain']
-        global_admin = user_config.get('global_admin', False)
         password_hash = user_config.get('password_hash', None)
         hash_scheme = user_config.get('hash_scheme', None)
         domain = models.Domain.query.get(domain_name)
@@ -185,7 +187,7 @@ def config_update(verbose=False, delete_objects=False):
         user_name = manager_config['user']
         domain = models.Domain.query.get(domain_name)
         manageruser = models.User.query.get(user_name + '@' + domain_name)
-        if not manageruser in domain.managers:
+        if manageruser not in domain.managers:
             domain.managers.append(manageruser)
         db.session.add(domain)
 


### PR DESCRIPTION
I ended up refactoring quite a few items as I needed quick way of changing global admins etc. managed with external config file. This patch fixes typo from previous PR as well (163/180 ). Hope that logic for manager user maintenance is sound in line 183 - not sure if comparison is done in-depth or just pointer comparison... seems to work though.