### PR TITLE
Update dovecot.conf

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -2,6 +2,8 @@
 # General
 ###############
 log_path = /dev/stderr
+auth_verbose=yes
+login_log_format_elements = "user=<%u> method=%m rip=%r lip=%l mpid=%e %c %k"
 protocols = imap pop3 lmtp sieve
 postmaster_address = {{ POSTMASTER }}@{{ DOMAIN }}
 hostname = {{ HOSTNAMES.split(",")[0] }}


### PR DESCRIPTION
Log all failed authentication attempts, with the "service auth"
ie allows one to view failed login usernames when postfix authorizes against dovecot.

sample output in the log will be like this
````
auth: Info:(test@domain.com,199.99.99.1,<5Ff/7Htd6QCpAM+Y>): invalid credentials
`````

https://wiki2.dovecot.org/Logging
````
auth_verbose=yes enables logging all failed authentication attempts.
````

# login_log_format_elements 
enables the user account and connecting ip to be logged, this  is essential for proper logging of user connections.

https://wiki.dovecot.org/Variables
````
"user=<%u> method=%m rip=%r lip=%l mpid=%e %c %k"
````

sample output
````
Nov 08 15:15:55 imap-login: Info: Login: user=<user@domain.com> method=LOGIN, rip=13.14.15.16, lip=133.144.155.166, mpid=4725, TLS, TLSv1.2 with cipher ECDHE-RSA-AES128-GCM-SHA256 (128/128 bits)
`````