### PR TITLE
upgrade php for roundcube

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5-apache
+FROM php:7.0-apache
 
 RUN apt-get update && apt-get install -y \
       libfreetype6-dev \

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
       libpng12-dev \
  && docker-php-ext-install pdo_mysql mcrypt
 
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.3.2/roundcubemail-1.3.2-complete.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.3.3/roundcubemail-1.3.3-complete.tar.gz
 
 RUN echo date.timezone=UTC > /usr/local/etc/php/conf.d/timezone.ini
 


### PR DESCRIPTION
RoundCube supports PHP7 officially since 1.2.0