### PR TITLE
disable ssl_session_tickets

### DIFF
--- a/core/nginx/conf/tls.conf
+++ b/core/nginx/conf/tls.conf
@@ -2,6 +2,7 @@ ssl_protocols TLSv1.1 TLSv1.2;
 ssl_ciphers 'ECDHE-RSA-AES256-GCM-SHA512:DHE-RSA-AES256-GCM-SHA512:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-SHA384';
 ssl_prefer_server_ciphers on;
 ssl_session_timeout 10m;
+ssl_session_tickets off;
 ssl_certificate {{ TLS[0] }};
 ssl_certificate_key {{ TLS[1] }};
 ssl_dhparam /certs/dhparam.pem;


### PR DESCRIPTION
see https://github.com/mozilla/server-side-tls/issues/135 and [RFC 5077](https://tools.ietf.org/html/rfc5077)

TL;DR: Mozilla/IETF suggest disabling session-tickets¹ because the key to sign them is only changed when the webserver is restarted and that could lead to effectivly no perfect forward secrecy

¹ currently [Mozilla's recommendation](https://wiki.mozilla.org/Security/Server_Side_TLS#TLS_tickets_.28RFC_5077.29) is: schedule frequent restarts… not sure about that.


(Disclaimer: I'm no crypto-wizzard, my TL;DR might be not very accurate :D)