### PR TITLE
Set HTTP_CLIENT_IP header for admin container

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -111,6 +111,7 @@ http {
       location /internal {
         internal;
 
+        proxy_set_header Client-IP $remote_addr;
         proxy_set_header Authorization $http_authorization;
         proxy_pass_header Authorization;
         proxy_pass http://$admin;


### PR DESCRIPTION
The admin container needs the `HTTP_CLIENT_IP` header setting or it will error in the following function in `/app/mailu/internal/views.py`

```
@limiter.limit(
    app.config["AUTH_RATELIMIT"],
    lambda: flask.request.headers["Client-Ip"]
)
```
Without it I see the following errors

```[2017-11-20 23:03:11,349] ERROR in app: Exception on /internal/auth/email [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1982, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1614, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1517, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python3.6/site-packages/flask/_compat.py", line 33, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1610, in full_dispatch_request
    rv = self.preprocess_request()
  File "/usr/local/lib/python3.6/site-packages/flask/app.py", line 1831, in preprocess_request
    rv = func()
  File "/usr/local/lib/python3.6/site-packages/flask_limiter/extension.py", line 434, in __check_request_limit
    six.reraise(*sys.exc_info())
  File "/usr/local/lib/python3.6/site-packages/six.py", line 693, in reraise
    raise value
  File "/usr/local/lib/python3.6/site-packages/flask_limiter/extension.py", line 395, in __check_request_limit
    limit_key = lim.key_func()
  File "/app/mailu/internal/views.py", line 13, in <lambda>
    lambda: flask.request.headers["Client-Ip"]
  File "/usr/local/lib/python3.6/site-packages/werkzeug/datastructures.py", line 1349, in __getitem__
    return _unicodify_header_value(self.environ['HTTP_' + key])
KeyError: 'HTTP_CLIENT_IP'
```

and

```front_1      | 127.0.0.1 - - [20/Nov/2017:22:45:25 +0000] "GET /auth/email HTTP/1.0" 502 166 "-" "-"
front_1      | 2017/11/20 22:45:25 [error] 10#10: *44 connect() failed (111: Connection refused) while connecting to upstream, client: 127.0.0.1, server: , request: "GET /auth/email HTTP/1.0", upstream: "http://172.18.0.6:80/internal/auth/email", host: "127.0.0.1"
```