### PR TITLE
This sets the max attachment size in roundcube

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -21,7 +21,7 @@ RUN rm -rf /var/www/html/ \
  && rm -rf CHANGELOG INSTALL LICENSE README.md UPGRADING composer.json-dist installer \
  && chown -R www-data: logs
 
-COPY php.ini /usr/local/etc/php/conf.d/rainloop.ini
+COPY php.ini /usr/local/etc/php/conf.d/roundcube.ini
 
 COPY config.inc.php /var/www/html/config/
 

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -21,6 +21,8 @@ RUN rm -rf /var/www/html/ \
  && rm -rf CHANGELOG INSTALL LICENSE README.md UPGRADING composer.json-dist installer \
  && chown -R www-data: logs
 
+COPY php.ini /usr/local/etc/php/conf.d/rainloop.ini
+
 COPY config.inc.php /var/www/html/config/
 
 COPY start.sh /start.sh

--- a/webmails/roundcube/php.ini
+++ b/webmails/roundcube/php.ini
@@ -1,0 +1,3 @@
+date.timezone=UTC
+upload_max_filesize = 25M
+post_max_size = 25M


### PR DESCRIPTION
I used the php.ini from the rainloop folder, so they are both set to
25MB.