### PR TITLE
Added adress verification before accepting mails for delivery

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -91,6 +91,8 @@ smtpd_recipient_restrictions =
   reject_unverified_recipient,
   permit
 
+unverified_recipient_reject_reason = Address lookup failure
+
 ###############
 # Milter
 ###############

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -88,6 +88,7 @@ smtpd_recipient_restrictions =
   reject_non_fqdn_sender,
   reject_unknown_sender_domain,
   reject_unknown_recipient_domain,
+  reject_unverified_recipient,
   permit
 
 ###############


### PR DESCRIPTION
See https://www.endpoint.com/blog/2015/05/28/postfix-address-verification

Block client until address verifiction is completed and mail will not be rejected by relaying MTA or smarthost.
If verification fails, mail is rejected.
If verification takes too long, mail is temporaryly rejected and sending client will retry later.