### PR TITLE
implement DNS Blacklists #336

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -87,6 +87,11 @@ smtpd_recipient_restrictions =
   reject_non_fqdn_sender,
   reject_unknown_sender_domain,
   reject_unknown_recipient_domain,
+  {%- if BLACKLISTS -%}
+  {%- for BLACKLIST in BLACKLISTS.split(",") %}
+  reject_rbl_client {{ BLACKLIST|trim }},
+  {%- endfor -%}
+  {% endif %}
   permit
 
 ###############

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -87,6 +87,9 @@ WELCOME=false
 WELCOME_SUBJECT=Welcome to your new email account
 WELCOME_BODY=Welcome to your new email account, if you can read this, then it is configured properly!
 
+# Blacklists to check sender ips against (separated by commas)
+BLACKLISTS=ix.dnsbl.manitu.net
+
 ###################################
 # Web settings
 ###################################


### PR DESCRIPTION
This is a very basic implementation. I tested the template generation but couldn't test it "in the wild" with incoming  mails since i have no public setup yet. I'm not sure if postfix will check against the nginx proxy ip or the real client ip.

If the change itself is good i would add more documentation and will try to find some more public blacklists (most are only for private use).