### PR TITLE
Adding options for when using reverse proxy (real ip header / from and mail-letsencrypt)

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -20,6 +20,14 @@ http {
     absolute_redirect off;
     resolver {{ RESOLVER }} valid=30s;
 
+    {% if REAL_IP_HEADER %}
+    real_ip_header {{ REAL_IP_HEADER }};
+    {% endif %}
+
+    {% if REAL_IP_FROM %}{% for from_ip in REAL_IP_FROM.split(',') %}
+    set_real_ip_from {{ from_ip }};
+    {% endfor %}{% endif %}
+
     # Header maps
     map $http_x_forwarded_proto $proxy_x_forwarded_proto {
       default $http_x_forwarded_proto;
@@ -45,17 +53,23 @@ http {
 
       include /etc/nginx/tls.conf;
       ssl_session_cache shared:SSLHTTP:50m;
-      add_header Strict-Transport-Security max-age=15768000;
+      add_header Strict-Transport-Security 'max-age=31536000';
 
-      {% if not TLS_FLAVOR == "mail" %}
-      if ($scheme = http) {
+      {% if not TLS_FLAVOR in [ 'mail', 'mail-letsencrypt' ] %}
+      if ($proxy_x_forwarded_proto = http) {
         return 301 https://$host$request_uri;
       }
       {% endif %}
       {% endif %}
 
+      add_header X-Frame-Options 'DENY';
+      add_header X-Content-Type-Options 'nosniff';
+      add_header X-Permitted-Cross-Domain-Policies 'none';
+      add_header X-XSS-Protection '1; mode=block';
+      add_header Referrer-Policy 'same-origin';
+
       # In any case, enable the proxy for certbot if the flavor is letsencrypt
-      {% if TLS_FLAVOR == 'letsencrypt' %}
+      {% if TLS_FLAVOR in [ 'letsencrypt', 'mail-letsencrypt' ] %}
       location ^~ /.well-known/acme-challenge/ {
           proxy_pass http://127.0.0.1:8008;
       }

--- a/core/nginx/config.py
+++ b/core/nginx/config.py
@@ -16,8 +16,10 @@ with open("/etc/resolv.conf") as handle:
 # TLS configuration
 args["TLS"] = {
     "cert": ("/certs/cert.pem", "/certs/key.pem"),
-    "mail": ("/certs/cert.pem", "/certs/key.pem"),
     "letsencrypt": ("/certs/letsencrypt/live/mailu/fullchain.pem",
+        "/certs/letsencrypt/live/mailu/privkey.pem"),
+    "mail": ("/certs/cert.pem", "/certs/key.pem"),
+    "mail-letsencrypt": ("/certs/letsencrypt/live/mailu/fullchain.pem",
         "/certs/letsencrypt/live/mailu/privkey.pem"),
     "notls": None
 }[args["TLS_FLAVOR"]]
@@ -25,7 +27,6 @@ args["TLS"] = {
 if args["TLS"] and not all(os.path.exists(file_path) for file_path in args["TLS"]):
     print("Missing cert or key file, disabling TLS")
     args["TLS_ERROR"] = "yes"
-
 
 # Build final configuration paths
 convert("/conf/tls.conf", "/etc/nginx/tls.conf", args)

--- a/core/nginx/start.py
+++ b/core/nginx/start.py
@@ -7,7 +7,7 @@ import subprocess
 if os.path.exists("/var/log/nginx.pid"):
     os.remove("/var/log/nginx.pid")
 
-if os.environ["TLS_FLAVOR"] == "letsencrypt":
+if os.environ["TLS_FLAVOR"] in [ "letsencrypt","mail-letsencrypt" ]:
     subprocess.Popen(["/letsencrypt.py"])
 
 subprocess.call(["/config.py"])

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -30,7 +30,7 @@ HOSTNAMES=mail.mailu.io,alternative.mailu.io,yetanother.mailu.io
 # Postmaster local part (will append the main mail domain)
 POSTMASTER=admin
 
-# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail)
+# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
 TLS_FLAVOR=cert
 
 # Authentication rate limit (per source IP address)
@@ -113,3 +113,9 @@ COMPOSE_PROJECT_NAME=mailu
 # Default password scheme used for newly created accounts and changed passwords
 # (value: SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
 PASSWORD_SCHEME=SHA512-CRYPT
+
+# Header to take the real ip from
+REAL_IP_HEADER=
+
+# IPs for nginx set_real_ip_from (CIDR list separated by commas)
+REAL_IP_FROM=

--- a/docs/compose/setup.rst
+++ b/docs/compose/setup.rst
@@ -52,6 +52,8 @@ values:
 - ``letsencrypt`` will use the Letsencrypt! CA to generate automatic ceriticates;
 - ``mail`` is similar to ``cert`` except that TLS will only be served for
   emails (IMAP and SMTP), not HTTP (use it behind reverse proxies);
+- ``mail-letsencrypt`` is similar to ``letsencrypt`` except that TLS will only be served for
+  emails (IMAP and SMTP), not HTTP (use it behind reverse proxies);
 - ``notls`` will disable TLS, this is not recommended except for testing.
 
 Enable optional features
@@ -92,6 +94,12 @@ setting. The configuration option must be one of the following:
 
 Make sure that you have at least 1GB or memory for ClamAV to load its signature
 database.
+
+If you run Mailu behind a reverse proxy you can use ``REAL_IP_HEADER`` and
+``REAL_IP_FROM`` to set the values of respective the Nginx directives
+``real_ip_header`` and ``set_real_ip_from``. The ``REAL_IP_FROM`` configuration
+option is a comma-separated list of IPs (or CIDRs) of which for each a
+``set_real_ip_from`` directive is added in the Nginx configuration file.
 
 Finish setting up TLS
 ---------------------


### PR DESCRIPTION
Added some options to allow for using LetsEncrypt for mail (IMAP/POP3/SMTP), but keep HTTP(S) behind a reverse proxy.

- TLS_FLAVOR: added `mail-letsencrypt` (uses LetsEncrypt, but still allows reverse proxy for HTTPS)
- REAL_IP_HEADER: env to set the `real_ip_header` in nginx when behind a reverse proxy
- REAL_IP_FROM: env to set the `set_real_ip_from` in nginx when behind reverse proxy
- HTTPS_REDIRECT: redirect traffic to HTTPS also for `mail` and `mail-letsencrypt`