### PR TITLE
Parametrize hosts

### DIFF
--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -54,6 +54,11 @@ default_config = {
     'WEB_WEBMAIL': '/webmail',
     # Advanced settings
     'PASSWORD_SCHEME': 'SHA512-CRYPT',
+    # Host settings
+    'HOST_IMAP': 'imap',
+    'HOST_POP3': 'imap',
+    'HOST_SMTP': 'smtp',
+    'HOST_AUTHSMTP': os.environ.get('HOST_SMTP', 'smtp'),
 }
 
 # Load configuration from the environment if available

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -37,10 +37,10 @@ http {
     # Main HTTP server
     server {
       # Variables for proxifying
-      set $admin admin;
-      set $antispam antispam:11334;
-      set $webmail webmail;
-      set $webdav webdav:5232;
+      set $admin {{ HOST_ADMIN }};
+      set $antispam {{ HOST_ANTISPAM }};
+      set $webmail {{ HOST_WEBMAIL }};
+      set $webdav {{ HOST_WEBDAV }};
 
       # Always listen over HTTP
       listen 80;

--- a/core/nginx/config.py
+++ b/core/nginx/config.py
@@ -12,6 +12,14 @@ with open("/etc/resolv.conf") as handle:
     content = handle.read().split()
     args["RESOLVER"] = content[content.index("nameserver") + 1]
 
+if "HOST_WEBMAIL" not in args:
+    args["HOST_WEBMAIL"] = "webmail"
+if "HOST_ADMIN" not in args:
+    args["HOST_ADMIN"] = "admin"
+if "HOST_WEBDAV" not in args:
+    args["HOST_WEBDAV"] = "webdav:5232"
+if "HOST_ANTISPAM" not in args:
+    args["HOST_ANTISPAM"] = "antispam:11334"
 
 # TLS configuration
 args["TLS"] = {

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,3 +69,21 @@ Advanced settings
 The ``PASSWORD_SCHEME`` is the password encryption scheme. You should use the
 default value, unless you are importing password from a separate system and
 want to keep using the old password encryption scheme.
+
+Infrastructure settings
+-----------------------
+
+Various environment variables ``HOST_*`` can be used to run Mailu containers
+separately from a supported orchestrator. It is used by the various components
+to find the location of the other containers it depends on. They can contain an
+optional port number. Those variables are:
+
+- ``HOST_IMAP``: the container that is running the IMAP server (default: ``imap``, port 143)
+- ``HOST_POP3``: the container that is running the POP3 server (default: ``imap``, port 110)
+- ``HOST_SMTP``: the container that is running the SMTP server (default: ``smtp``, port 25)
+- ``HOST_AUTHSMTP``: the container that is running the authenticated SMTP server for the webnmail (default: ``smtp``, port 10025)
+- ``HOST_ADMIN``: the container that is running the admin interface (default: ``admin``)
+- ``HOST_ANTISPAM``: the container that is running the antispam service (default: ``antispam:11334``)
+- ``HOST_WEBMAIL``: the container that is running the webmail (default: ``webmail``)
+- ``HOST_WEBDAV``: the container that is running the webdav server (default: ``webdav:5232``)
+


### PR DESCRIPTION
Allows to use mailu without docker-compose when hostnames are not set up
by docker itself but provided via a separate resolver.

Use case: use mailu using nomad scheduler and consul resolver instead of
docker-compose. Other servers are provided by the DNS resolver that
resolves names like admin.service.consul or webmail.service.consul.
These names needs to be configurable.

This is probaby a duplicate of https://github.com/Mailu/NGINX/pull/2