### PR TITLE
Add various environment variables to allow running outside of docker-compose

### DIFF
--- a/core/dovecot/conf/dovecot-sql.conf.ext
+++ b/core/dovecot/conf/dovecot-sql.conf.ext
@@ -3,7 +3,7 @@ connect = /data/main.db
 
 # Return the user hashed password
 password_query = \
- SELECT NULL as password, 'Y' as nopassword, '{{ FRONT_ADDRESS }}{% if WEBMAIL_ADDRESS %},{{ WEBMAIL_ADDRESS }}{% endif %}' as allow_nets \
+ SELECT NULL as password, 'Y' as nopassword, '{{ FRONT_ADDRESS }}{% if WEBMAIL_ADDRESS %},{{ WEBMAIL_ADDRESS }}{% endif %}{% if MANAGESIEVE_ADDRESS %},{{ MANAGESIEVE_ADDRESS }}{% endif %}' as allow_nets \
    FROM user \
   WHERE user.email = '%u'
 

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -6,7 +6,7 @@ protocols = imap pop3 lmtp sieve
 postmaster_address = {{ POSTMASTER }}@{{ DOMAIN }}
 hostname = {{ HOSTNAMES.split(",")[0] }}
 mail_plugins = $mail_plugins quota
-submission_host = front
+submission_host = {{ FRONT_ADDRESS }}
 
 service dict {
   unix_listener dict {

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -8,9 +8,9 @@ import glob
 convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()).render(**os.environ))
 
 # Actual startup script
-os.environ["FRONT_ADDRESS"] = socket.gethostbyname("front")
+os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
 if os.environ["WEBMAIL"] != "none":
-	os.environ["WEBMAIL_ADDRESS"] = socket.gethostbyname("webmail")
+	os.environ["WEBMAIL_ADDRESS"] = socket.gethostbyname(os.environ.get("WEBMAIL_ADDRESS", "webmail"))
 
 for dovecot_file in glob.glob("/conf/*"):
     convert(dovecot_file, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -11,6 +11,8 @@ convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()
 os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
 if os.environ["WEBMAIL"] != "none":
 	os.environ["WEBMAIL_ADDRESS"] = socket.gethostbyname(os.environ.get("WEBMAIL_ADDRESS", "webmail"))
+if os.environ.get("MANAGESIEVE_ADDRESS", "") != "":
+	os.environ["MANAGESIEVE_ADDRESS"] = socket.gethostbyname(os.environ.get("MANAGESIEVE_ADDRESS", "managesieve"))
 
 for dovecot_file in glob.glob("/conf/*"):
     convert(dovecot_file, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -149,7 +149,7 @@ http {
     # Forwarding authentication server
     server {
       # Variables for proxifying
-      set $admin admin;
+      set $admin {{ HOST_ADMIN }};
 
       listen 127.0.0.1:8000;
 

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -63,7 +63,7 @@ virtual_mailbox_maps = $virtual_alias_maps
 # Mails are transported if required, then forwarded to Dovecot for delivery
 relay_domains = ${sql}sqlite-transport.cf
 transport_maps = ${sql}sqlite-transport.cf
-virtual_transport = lmtp:inet:imap:2525
+virtual_transport = lmtp:inet:{{ HOST_LMTP }}
 
 # In order to prevent Postfix from running DNS query, enforce the use of the
 # native DNS stack, that will check /etc/hosts properly.
@@ -97,7 +97,7 @@ unverified_recipient_reject_reason = Address lookup failure
 # Milter
 ###############
 
-smtpd_milters = inet:antispam:11332
+smtpd_milters = inet:{{ HOST_ANTISPAM }}
 milter_protocol = 6
 milter_mail_macros = i {mail_addr} {client_addr} {client_name} {auth_authen}
 milter_default_action = tempfail

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -9,7 +9,9 @@ import shutil
 convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()).render(**os.environ))
 
 # Actual startup script
-os.environ["FRONT_ADDRESS"] = socket.gethostbyname("front")
+os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
+os.environ["HOST_ANTISPAM"] = os.environ.get("HOST_ANTISPAM", "antispam:11332")
+os.environ["HOST_LMTP"] = os.environ.get("HOST_LMTP", "imap:2525")
 
 for postfix_file in glob.glob("/conf/*.cf"):
     convert(postfix_file, os.path.join("/etc/postfix", os.path.basename(postfix_file)))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -79,6 +79,8 @@ to find the location of the other containers it depends on. They can contain an
 optional port number. Those variables are:
 
 - ``HOST_IMAP``: the container that is running the IMAP server (default: ``imap``, port 143)
+- ``HOST_LMTP``: the container that is running the LMTP server (default: ``imap:2525``)
+- ``HOST_HOSTIMAP``: the container that is running the IMAP server for the webmail (default: ``imap``, port 10143)
 - ``HOST_POP3``: the container that is running the POP3 server (default: ``imap``, port 110)
 - ``HOST_SMTP``: the container that is running the SMTP server (default: ``smtp``, port 25)
 - ``HOST_AUTHSMTP``: the container that is running the authenticated SMTP server for the webnmail (default: ``smtp``, port 10025)
@@ -86,4 +88,12 @@ optional port number. Those variables are:
 - ``HOST_ANTISPAM``: the container that is running the antispam service (default: ``antispam:11334``)
 - ``HOST_WEBMAIL``: the container that is running the webmail (default: ``webmail``)
 - ``HOST_WEBDAV``: the container that is running the webdav server (default: ``webdav:5232``)
+- ``HOST_REDIS``: the container that is running the redis daemon (default: ``redis``)
 
+Additional variables are used to locate other containers without dialing a
+specific port number. It is used to either whitelist connection from these
+addresses or connect to containers on the docker network:
+
+- ``FRONT_ADDRESS``: the nginx container address (default: ``front``)
+- ``WEBMAIL_ADDRESS``: the webmail container address (default: ``webmail``)
+- ``IMAP_ADDRESS``: the webmail container address (default: ``webmail``)

--- a/optional/managesieve/Dockerfile
+++ b/optional/managesieve/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:edge
+
+RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
+ && apk add --no-cache \
+     dovecot dovecot-sqlite dovecot-pigeonhole-plugin dovecot-pigeonhole-plugin-extdata \
+     rspamd-client@testing python py-jinja2
+
+COPY conf /conf
+COPY start.py /start.py
+
+CMD /start.py

--- a/optional/managesieve/Dockerfile
+++ b/optional/managesieve/Dockerfile
@@ -5,6 +5,8 @@ RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/re
      dovecot dovecot-sqlite dovecot-pigeonhole-plugin dovecot-pigeonhole-plugin-extdata \
      rspamd-client@testing python py-jinja2
 
+RUN mkdir -p /var/lib/dovecot
+
 COPY conf /conf
 COPY start.py /start.py
 

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -3,6 +3,8 @@
 ###############
 log_path = /dev/stderr
 protocols = sieve
+mail_uid = mail
+mail_gid = mail
 
 ###############
 # Authentication

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -9,8 +9,8 @@ mail_uid = mail
 mail_gid = mail
 
 ssl = yes
-ssl_cert = </certs/cert.pem
-ssl_key = </certs/key.pem
+ssl_cert = </certs/letsencrypt/live/mailu/chain.pem
+ssl_key = </certs/letsencrypt/live/mailu/privkey.pem
 
 ###############
 # Authentication

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -3,6 +3,8 @@
 ###############
 log_path = /dev/stderr
 protocols = sieve
+first_valid_gid = 8
+first_valid_uid = 8
 mail_uid = mail
 mail_gid = mail
 

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -39,4 +39,4 @@ service managesieve {
 # Extensions
 ###############
 
-!include_try /overrides/dovecot.conf
+!include_try /overrides/managesieve.conf

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -18,13 +18,6 @@ disable_plaintext_auth = no
 passdb {
   driver = imap
   args = host={{ FRONT_ADDRESS }} port=10143
-}
-
-# Then add passdb fields to proxy
-passdb {
-  driver = static
-  skip = unauthenticated
-  args = nopassword=y
   default_fields = proxy=y host={{ DOVECOT_ADDRESS }}
 }
 

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -9,7 +9,7 @@ mail_uid = mail
 mail_gid = mail
 
 ssl = yes
-ssl_cert = </certs/letsencrypt/live/mailu/chain.pem
+ssl_cert = </certs/letsencrypt/live/mailu/cert.pem
 ssl_key = </certs/letsencrypt/live/mailu/privkey.pem
 
 ###############

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -9,7 +9,7 @@ mail_uid = mail
 mail_gid = mail
 
 ssl = yes
-ssl_cert = </certs/letsencrypt/live/mailu/cert.pem
+ssl_cert = </certs/letsencrypt/live/mailu/fullchain.pem
 ssl_key = </certs/letsencrypt/live/mailu/privkey.pem
 
 ###############

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -1,0 +1,42 @@
+###############
+# General
+###############
+log_path = /dev/stderr
+protocols = sieve
+
+###############
+# Authentication
+###############
+auth_mechanisms = plain login
+disable_plaintext_auth = no
+
+# Authenticate against IMAP
+passdb {
+  driver = imap
+  args = host={{ FRONT_ADDRESS }}
+}
+
+# Then add passdb fields to proxy
+passdb {
+  driver = static
+  skip = unauthenticated
+  args = nopassword=y
+  default_fields = proxy=y host={{ DOVECOT_ADDRESS }}
+}
+
+###############
+# Filtering
+###############
+
+service managesieve-login {
+  service_count = 0
+}
+
+service managesieve {
+}
+
+###############
+# Extensions
+###############
+
+!include_try /overrides/dovecot.conf

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -13,7 +13,7 @@ disable_plaintext_auth = no
 # Authenticate against IMAP
 passdb {
   driver = imap
-  args = host={{ FRONT_ADDRESS }}
+  args = host={{ FRONT_ADDRESS }} port=10143
 }
 
 # Then add passdb fields to proxy

--- a/optional/managesieve/conf/dovecot.conf
+++ b/optional/managesieve/conf/dovecot.conf
@@ -8,6 +8,10 @@ first_valid_uid = 8
 mail_uid = mail
 mail_gid = mail
 
+ssl = yes
+ssl_cert = </certs/cert.pem
+ssl_key = </certs/key.pem
+
 ###############
 # Authentication
 ###############

--- a/optional/managesieve/start.py
+++ b/optional/managesieve/start.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+import jinja2
+import os
+import socket
+import glob
+
+convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()).render(**os.environ))
+
+# Actual startup script
+os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
+os.environ["DOVECOT_ADDRESS"] = socket.gethostbyname(os.environ.get("DOVECOT_ADDRESS", "imap"))
+
+for dovecot_file in glob.glob("/conf/*"):
+    convert(dovecot_file, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))
+
+# Run postfix
+os.system("chown -R mail:mail /mail /var/lib/dovecot")
+os.execv("/usr/sbin/dovecot", ["dovecot", "-c", "/etc/dovecot/dovecot.conf", "-F"])

--- a/optional/managesieve/start.py
+++ b/optional/managesieve/start.py
@@ -15,4 +15,5 @@ for dovecot_file in glob.glob("/conf/*"):
     convert(dovecot_file, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))
 
 # Run postfix
+os.system("chown -R mail:mail /var/lib/dovecot")
 os.execv("/usr/sbin/dovecot", ["dovecot", "-c", "/etc/dovecot/dovecot.conf", "-F"])

--- a/optional/managesieve/start.py
+++ b/optional/managesieve/start.py
@@ -15,5 +15,4 @@ for dovecot_file in glob.glob("/conf/*"):
     convert(dovecot_file, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))
 
 # Run postfix
-os.system("chown -R mail:mail /mail /var/lib/dovecot")
 os.execv("/usr/sbin/dovecot", ["dovecot", "-c", "/etc/dovecot/dovecot.conf", "-F"])

--- a/services/fetchmail/fetchmail.py
+++ b/services/fetchmail/fetchmail.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 import shlex
 import subprocess
+import re
 
 
 FETCHMAIL = """
@@ -18,11 +19,14 @@ RC_LINE = """
 poll "{host}" proto {protocol}  port {port}
     user "{username}" password "{password}"
     is "{user_email}"
-    smtphost "smtp"
+    smtphost "{smtphost}"
     {options}
     sslproto 'AUTO'
 """
 
+def extract_host_port(host_and_port, default_port):
+    host, _, port = re.match('^(.*)(:([0-9]*))?$', host_and_port).groups()
+    return host, int(port) if port else default_port
 
 def escape_rc_string(arg):
     return arg.replace("\\", "\\\\").replace('"', '\\"')
@@ -42,6 +46,11 @@ def run(connection, cursor, debug):
         SELECT user_email, protocol, host, port, tls, username, password, keep
         FROM fetch
     """)
+    smtphost, smtpport = extract_host_port(os.environ.get("HOST_SMTP", "smtp"), None)
+    if smtpport is None:
+        smtphostport = smtphost
+    else:
+        smtphostport = "%s/%d" % (smtphost, smtpport)
     for line in cursor.fetchall():
         fetchmailrc = ""
         user_email, protocol, host, port, tls, username, password, keep = line
@@ -53,6 +62,7 @@ def run(connection, cursor, debug):
             protocol=protocol,
             host=escape_rc_string(host),
             port=port,
+            smtphost=smtphostport,
             username=escape_rc_string(username),
             password=escape_rc_string(password),
             options=options

--- a/services/rspamd/conf/redis.conf
+++ b/services/rspamd/conf/redis.conf
@@ -1,1 +1,1 @@
-servers = "redis";
+servers = "{{ HOST_REDIS }}";

--- a/services/rspamd/start.py
+++ b/services/rspamd/start.py
@@ -8,7 +8,8 @@ import glob
 convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()).render(**os.environ))
 
 # Actual startup script
-os.environ["FRONT_ADDRESS"] = socket.gethostbyname("front")
+os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
+if "HOST_REDIS" not in os.environ: os.environ["HOST_REDIS"] = "redis"
 
 for rspamd_file in glob.glob("/conf/*"):
     convert(rspamd_file, os.path.join("/etc/rspamd/local.d", os.path.basename(rspamd_file)))

--- a/webmails/rainloop/default.ini
+++ b/webmails/rainloop/default.ini
@@ -1,13 +1,13 @@
-imap_host = "front"
+imap_host = "%FRONT_ADDRESS%"
 imap_port = 10143
 imap_secure = "None"
 imap_short_login = Off
 sieve_use = On
 sieve_allow_raw = Off
-sieve_host = "imap"
+sieve_host = "%IMAP_ADDRESS%"
 sieve_port = 4190
 sieve_secure = "None"
-smtp_host = "front"
+smtp_host = "%FRONT_ADDRESS%"
 smtp_port = 10025
 smtp_secure = "None"
 smtp_short_login = Off

--- a/webmails/rainloop/start.sh
+++ b/webmails/rainloop/start.sh
@@ -1,11 +1,17 @@
 #!/bin/sh
 
+template(){
+  sed \
+    -e "s/%FRONT_ADDRESS%/$FRONT_ADDRESS/g" \
+    -e "s/%IMAP_ADDRESS%/$IMAP_ADDRESS/g"
+}
+
 # There is no cleaner way to setup the default SMTP/IMAP server or to
 # override the configuration
 rm -f /data/_data_/_default_/domains/*
 mkdir -p /data/_data_/_default_/domains/ /data/_data_/_default_/configs/
-cp /default.ini /data/_data_/_default_/domains/
-cp /config.ini /data/_data_/_default_/configs/
+template </default.ini >/data/_data_/_default_/domains/default.ini
+template </config.ini  >/data/_data_/_default_/configs/config.ini
 
 # Fix some permissions
 chown -R www-data:www-data /data

--- a/webmails/roundcube/config.inc.php
+++ b/webmails/roundcube/config.inc.php
@@ -18,15 +18,15 @@ $config['plugins'] = array(
 );
 
 // Mail servers
-$config['default_host'] = 'front';
+$config['default_host'] = getenv('FRONT_ADDRESS') || 'front';
 $config['default_port'] = 10143;
-$config['smtp_server'] = 'front';
+$config['smtp_server'] = getenv('FRONT_ADDRESS') || 'front';
 $config['smtp_port'] = 10025;
 $config['smtp_user'] = '%u';
 $config['smtp_pass'] = '%p';
 
 // Sieve script management
-$config['managesieve_host'] = 'imap';
+$config['managesieve_host'] = getenv('IMAP_ADDRESS') || 'imap';
 $config['managesieve_usetls'] = false;
 
 // We access the IMAP and SMTP servers locally with internal names, SSL


### PR DESCRIPTION
This pull request follows https://github.com/Mailu/Mailu/pull/373

These changes allow to run the containers and parametrize the hostnames and IP addresses of the other containers. This is used in the end to run mailu using the nomad scheduler and consul delivery service.

With this, I could run most of the services without much problems. I could receive and send e-mails. I can follow up this pull request by providing the nomad configuration files too.