### PR TITLE
Adding unbound as dns resolver

### DIFF
--- a/core/unbound/Dockerfile
+++ b/core/unbound/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:edge
+
+RUN apk add --no-cache unbound curl \
+	&& curl -o /etc/unbound/root.hints https://www.internic.net/domain/named.cache \
+	&& chown root:unbound /etc/unbound \
+	&& chmod 775 /etc/unbound \
+	&& apk del --no-cache curl \
+	&& /usr/sbin/unbound-anchor -a /etc/unbound/trusted-key.key | true
+
+COPY unbound.conf /etc/unbound/unbound.conf
+
+EXPOSE 53/udp 53/tcp
+
+CMD /usr/sbin/unbound

--- a/core/unbound/unbound.conf
+++ b/core/unbound/unbound.conf
@@ -1,0 +1,19 @@
+server:
+  verbosity: 1
+  interface: 0.0.0.0
+  interface: ::0
+  logfile: /dev/stdout
+  do-ip4: yes
+  do-ip6: yes
+  do-udp: yes
+  do-tcp: yes
+  do-daemonize: no
+  access-control: 0.0.0.0/0 allow
+  directory: "/etc/unbound"
+  username: unbound
+  auto-trust-anchor-file: trusted-key.key
+  root-hints: "/etc/unbound/root.hints"
+  hide-identity: yes
+  hide-version: yes
+  max-udp-size: 4096
+  msg-buffer-size: 65552

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -21,6 +21,9 @@ SECRET_KEY=ChangeMeChangeMe
 BIND_ADDRESS4=127.0.0.1
 BIND_ADDRESS6=::1
 
+# Internal Docker network
+IPV4_NETWORK=172.22.1
+
 # Main mail domain
 DOMAIN=mailu.io
 

--- a/docs/compose/docker-compose.yml
+++ b/docs/compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
 
@@ -27,12 +27,37 @@ services:
     - "$BIND_ADDRESS6:587:587"
     volumes:
       - "$ROOT/certs:/certs"
+    depends_on:
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - front
+
+  unbound:
+    image: mailu/unbound:$VERSION
+    restart: always
+    networks:
+      backend:
+        ipv4_address: ${IPV4_NETWORK:-172.22.1}.254
+        aliases:
+          - unbound
 
   redis:
     image: redis:alpine
     restart: always
     volumes:
       - "$ROOT/redis:/data"
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    depends_on:
+      - unbound
+    networks:
+      backend:
+        aliases:
+          - redis
 
   imap:
     image: mailu/dovecot:$VERSION
@@ -44,6 +69,13 @@ services:
       - "$ROOT/overrides:/overrides"
     depends_on:
       - front
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - imap
 
   smtp:
     image: mailu/postfix:$VERSION
@@ -54,6 +86,13 @@ services:
       - "$ROOT/overrides:/overrides"
     depends_on:
       - front
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - smtp
 
   antispam:
     image: mailu/rspamd:$VERSION
@@ -65,6 +104,13 @@ services:
       - "$ROOT/overrides/rspamd:/etc/rspamd/override.d"
     depends_on:
       - front
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - antispam
 
   antivirus:
     image: mailu/$ANTIVIRUS:$VERSION
@@ -72,6 +118,14 @@ services:
     env_file: .env
     volumes:
       - "$ROOT/filter:/data"
+    depends_on:
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - antivirus
 
   webdav:
     image: mailu/$WEBDAV:$VERSION
@@ -79,6 +133,14 @@ services:
     env_file: .env
     volumes:
       - "$ROOT/dav:/data"
+    depends_on:
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - webdav
 
   admin:
     image: mailu/admin:$VERSION
@@ -90,6 +152,13 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
       - redis
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - admin
 
   webmail:
     image: "mailu/$WEBMAIL:$VERSION"
@@ -99,6 +168,13 @@ services:
       - "$ROOT/webmail:/data"
     depends_on:
       - imap
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - webmail
 
   fetchmail:
     image: mailu/fetchmail:$VERSION
@@ -106,3 +182,19 @@ services:
     env_file: .env
     volumes:
       - "$ROOT/data:/data"
+    depends_on:
+      - unbound
+    dns:
+      - ${IPV4_NETWORK:-172.22.1}.254
+    networks:
+      backend:
+        aliases:
+          - fetchmail
+
+networks:
+  backend:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: ${IPV4_NETWORK:-172.22.1}.0/24


### PR DESCRIPTION
Hello,

this should be discussed.
This allows to use unbound as dns-resolver, this is especially useful for blacklist checking, because some are blocking public DNS like 8.8.8.8 etc.
This helped me to increase spam blocking from 30% to 60% because rspamd was complaining about not able to resolve uribl.com checks.