### PR TITLE
Fixes the inability to upload attachments from roundcube

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -20,7 +20,7 @@ RUN rm -rf /var/www/html/ \
  && cd html \
  && rm -rf CHANGELOG INSTALL LICENSE README.md UPGRADING composer.json-dist installer \
  && sed -i 's,mod_php5.c,mod_php7.c,g' .htaccess \
- && chown -R www-data: logs
+ && chown -R www-data: logs temp
 
 COPY php.ini /usr/local/etc/php/conf.d/roundcube.ini
 


### PR DESCRIPTION
According to #365 this was already fixed in 1.5, but using the 1.5.1 version of roundcube webmail I could not upload the attachments due to permission error on `/var/www/html/temp` directory.

Please note that I have no idea whether `www-data` is the proper owner of this directory, I do not know if there are any other uses for the `temp` dir and if any other users are accessing the directory. Maybe chmod 777 would be more appropriate.

Nevertheless it fixes the problem for me regarding the attachments