### PR TITLE
Added webmail-imap dependency in docker-compose.yml.

### DIFF
--- a/docs/compose/docker-compose.yml
+++ b/docs/compose/docker-compose.yml
@@ -97,6 +97,8 @@ services:
     env_file: .env
     volumes:
       - "$ROOT/webmail:/data"
+    depends_on:
+      - imap
 
   fetchmail:
     image: mailu/fetchmail:$VERSION


### PR DESCRIPTION
I noticed that the imap container was restarting on docker-compose up first because a python script depends on the webmail container.