### PR TITLE
Add original Delivered-To header to received messages

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -138,7 +138,7 @@ service managesieve {
 plugin {
   sieve = file:~/sieve;active=~/.dovecot.sieve
   sieve_plugins = sieve_extdata sieve_imapsieve sieve_extprograms
-  sieve_global_extensions = +vnd.dovecot.extdata +spamtest +spamtestplus +vnd.dovecot.execute
+  sieve_global_extensions = +vnd.dovecot.extdata +spamtest +spamtestplus +vnd.dovecot.execute +editheader
   sieve_before = /var/lib/dovecot/before.sieve
   sieve_default = /var/lib/dovecot/default.sieve
   sieve_after = /var/lib/dovecot/after.sieve

--- a/core/dovecot/sieve/before.sieve
+++ b/core/dovecot/sieve/before.sieve
@@ -11,6 +11,14 @@ require "comparator-i;ascii-numeric";
 require "vnd.dovecot.extdata";
 require "vnd.dovecot.execute";
 require "spamtestplus";
+require "editheader";
+require "index";
+
+if header :index 2 :matches "Received" "from * by * for <*>; *"
+{
+  deleteheader "Delivered-To";
+  addheader "Delivered-To" "<${3}>";
+}
 
 if allof (string :is "${extdata.spam_enabled}" "1",
           spamtest :percent :value "gt" :comparator "i;ascii-numeric"  "${extdata.spam_threshold}")


### PR DESCRIPTION
Postfix, after expanding the alias, is not transmitting the original
envelope recipient email address to dovecot and cannot record it in a
Received: header.

The LMTP DSN extension allows postfix to specify an ORCPT= parameter to
the "RCPT TO:" line (in postfix src/smtp/smtp_proto.c). However, dovecot
does not support the DNS extension on the LMTP endpoint. It has
preliminary support of the ORCPT parameter in latest versions but is is
disabled and not working.

The solution taken was to add a sieve script to parse the Received:
header written by postfix and parse the original RCPT TO address from
it. Then add the header through the "editheader" sieve extension. Later
sieve scripts can take this header to perform further filtering.