### PR TITLE
Use HOST_ADMIN in "Forwarding authentication server".  Fixes #436.

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -149,7 +149,7 @@ http {
     # Forwarding authentication server
     server {
       # Variables for proxifying
-      set $admin admin;
+      set $admin {{ HOST_ADMIN }};
 
       listen 127.0.0.1:8000;
 


### PR DESCRIPTION
This change is required to run under Kubernetes which requires using HOST_ variables to specify the FQDNs for services.