### PR TITLE
Use POD_ADDRESS_RANGE for Dovecot if it exists

### DIFF
--- a/core/dovecot/conf/dovecot-sql.conf.ext
+++ b/core/dovecot/conf/dovecot-sql.conf.ext
@@ -3,7 +3,7 @@ connect = /data/main.db
 
 # Return the user hashed password
 password_query = \
- SELECT NULL as password, 'Y' as nopassword, '{{ FRONT_ADDRESS }}{% if WEBMAIL_ADDRESS %},{{ WEBMAIL_ADDRESS }}{% endif %}' as allow_nets \
+ SELECT NULL as password, 'Y' as nopassword, '{% if POD_ADDRESS_RANGE %}{{ POD_ADDRESS_RANGE }}{% else %}{{ FRONT_ADDRESS }}{% if WEBMAIL_ADDRESS %},{{ WEBMAIL_ADDRESS }}{% endif %}{% endif %}' as allow_nets \
    FROM user \
   WHERE user.email = '%u'
 


### PR DESCRIPTION
This is required to override allow_nets in the Dovecot passdb query.  In a Kubernetes environment where pods are not recreated with the same IP address, restricting to FRONT_ADDRESS and WEBMAIL_ADDRESS only works as long as the front and webmail pod don't die.   Once they die, the query no longer is valid as their IP addresses have changed.

This solves the problem by allowing a POD_ADDRESS_RANGE environment variable in Dovecot which can be defined as a subnet (10.0.0.0/12 for example) that encompasses any possible IP address a pod may receive.  If POD_ADDRESS_RANGE is not defined, previous behavior to use FRONT_ADDRESS and WEBMAIL_ADDRESS continues.

If its helpful for testing, an image is pushed to Docker hub romracer/mailu-dovecot:master with this change.  I am currently using that version of this container in a Kubernetes setup.