### PR TITLE
TLS using configurable filenames

### DIFF
--- a/core/nginx/config.py
+++ b/core/nginx/config.py
@@ -22,11 +22,13 @@ if "HOST_ANTISPAM" not in args:
     args["HOST_ANTISPAM"] = "antispam:11334"
 
 # TLS configuration
+cert_name = os.getenv("TLS_CERT_FILENAME", default="cert.pem")
+keypair_name = os.getenv("TLS_KEYPAIR_FILENAME", default="key.pem")
 args["TLS"] = {
-    "cert": ("/certs/cert.pem", "/certs/key.pem"),
+    "cert": ("/certs/%s" % cert_name, "/certs/%s" % keypair_name),
     "letsencrypt": ("/certs/letsencrypt/live/mailu/fullchain.pem",
         "/certs/letsencrypt/live/mailu/privkey.pem"),
-    "mail": ("/certs/cert.pem", "/certs/key.pem"),
+    "mail": ("/certs/%s" % cert_name, "/certs/%s" % keypair_name),
     "mail-letsencrypt": ("/certs/letsencrypt/live/mailu/fullchain.pem",
         "/certs/letsencrypt/live/mailu/privkey.pem"),
     "notls": None

--- a/docs/compose/setup.rst
+++ b/docs/compose/setup.rst
@@ -107,10 +107,11 @@ Finish setting up TLS
 Mailu relies heavily on TLS and must have a key pair and a certificate
 available, at least for the hostname configured in the ``.env`` file.
 
-If you set ``TLS_FLAVOR`` to ``cert`` or if then you must create a ``certs`` directory
+If you set ``TLS_FLAVOR`` to ``cert`` or ``mail`` then you must create a ``certs`` directory
 in your root path and setup a key-certificate pair there:
-- ``cert.pem`` contains the certificate,
-- ``key.pem`` contains the key pair.
+
+- ``cert.pem`` contains the certificate (override with ``TLS_CERT_FILENAME``),
+- ``key.pem`` contains the key pair (override with ``TLS_KEYPAIR_FILENAME``).
 
 Start Mailu
 -----------


### PR DESCRIPTION
The current implementation uses fixed filenames for certificates and key pairs for TLS flavors `mail` and `cert`.

My currently used Docker environment provides multiple services on different sub-domains. Therefore, a certificate bot (based on Let's Encrypt) provides different certificates and keys for each service (as required) in **different filenames**. Those certificates are also **updated periodically** in the background prior to their expiration date.

I think most users can work with the default implementation, because I didn't find any information in the repo prior to my request.
Therefore, I keep the default filenames, if the user's configuration doesn't override them explicitly.