### PR TITLE
Consistency for nginx.pid path

### DIFF
--- a/core/nginx/config.py
+++ b/core/nginx/config.py
@@ -42,5 +42,5 @@ if args["TLS"] and not all(os.path.exists(file_path) for file_path in args["TLS"
 convert("/conf/tls.conf", "/etc/nginx/tls.conf", args)
 convert("/conf/proxy.conf", "/etc/nginx/proxy.conf", args)
 convert("/conf/nginx.conf", "/etc/nginx/nginx.conf", args)
-if os.path.exists("/var/log/nginx.pid"):
+if os.path.exists("/var/run/nginx.pid"):
     os.system("nginx -s reload")

--- a/core/nginx/start.py
+++ b/core/nginx/start.py
@@ -4,8 +4,8 @@ import os
 import subprocess
 
 # Check if a stale pid file exists
-if os.path.exists("/var/log/nginx.pid"):
-    os.remove("/var/log/nginx.pid")
+if os.path.exists("/var/run/nginx.pid"):
+    os.remove("/var/run/nginx.pid")
 
 if os.environ["TLS_FLAVOR"] in [ "letsencrypt","mail-letsencrypt" ]:
     subprocess.Popen(["/letsencrypt.py"])


### PR DESCRIPTION
I noticed a discrepancy (typo) for the location of nginx.pid betweend:
-core/nginx/start.py
-core/nginx/config.py
-core/nginx/conf/nginx.conf

As nginx.pid cannot be found in /var/log/ngninx.pid, config.py is never reloading nginx, hence not propagating certificates changes made with Let's encrypt