### PR TITLE
Do not remove openssl when purging build deps, fixes #481

### DIFF
--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -4,7 +4,8 @@ RUN mkdir -p /app
 WORKDIR /app
 
 COPY requirements-prod.txt requirements.txt
-RUN apk --update add --virtual build-dep openssl-dev libffi-dev python-dev build-base \
+RUN apk add --no-cache openssl \
+ && apk add --no-cache --virtual build-dep openssl-dev libffi-dev python-dev build-base \
  && pip install -r requirements.txt \
  && apk del build-dep
 


### PR DESCRIPTION
Also needed on 1.5