### PR TITLE
Hide administration header in sidebar for normal users.

### DIFF
--- a/core/admin/mailu/ui/templates/sidebar.html
+++ b/core/admin/mailu/ui/templates/sidebar.html
@@ -32,7 +32,9 @@
       </a>
     </li>
 
+    {% if current_user.manager_of or current_user.global_admin %}
     <li class="header">{% trans %}Administration{% endtrans %}</li>
+    {% endif %}
     {% if current_user.global_admin %}
     <li>
       <a href="{{ url_for('.announcement') }}">


### PR DESCRIPTION
Hide empty menu point as described in title.