### PR TITLE
roundcube: fix host parametrization

### DIFF
--- a/webmails/roundcube/config.inc.php
+++ b/webmails/roundcube/config.inc.php
@@ -18,16 +18,19 @@ $config['plugins'] = array(
     'enigma'
 );
 
+$front = getenv('FRONT_ADDRESS') ? getenv('FRONT_ADDRESS') : 'front';
+$imap  = getenv('IMAP_ADDRESS')  ? getenv('IMAP_ADDRESS')  : 'imap';
+
 // Mail servers
-$config['default_host'] = getenv('FRONT_ADDRESS') || 'front';
+$config['default_host'] = $front;
 $config['default_port'] = 10143;
-$config['smtp_server'] = getenv('FRONT_ADDRESS') || 'front';
+$config['smtp_server'] = $front;
 $config['smtp_port'] = 10025;
 $config['smtp_user'] = '%u';
 $config['smtp_pass'] = '%p';
 
 // Sieve script management
-$config['managesieve_host'] = getenv('IMAP_ADDRESS') || 'imap';
+$config['managesieve_host'] = $imap;
 $config['managesieve_usetls'] = false;
 
 // We access the IMAP and SMTP servers locally with internal names, SSL


### PR DESCRIPTION
Roundcube can be parametrized so it can take a different hostname than
'front' or 'imap' to connect to the mail servers through environment
variables. Unfortunately, this was not correct and in PHP a `||`
operator always returns a boolean. It did not work as expected.

Instead use the ternary operator `:?` that works in all cases.