### PR TITLE
Return correct status codes from auth rate limiter failure.

### DIFF
--- a/core/admin/mailu/internal/__init__.py
+++ b/core/admin/mailu/internal/__init__.py
@@ -1,3 +1,5 @@
+from flask_limiter import RateLimitExceeded
+
 from mailu import limiter
 
 import socket
@@ -6,6 +8,14 @@ import flask
 
 internal = flask.Blueprint('internal', __name__)
 
+@internal.app_errorhandler(RateLimitExceeded)
+def rate_limit_handler(e):
+    response = flask.Response()
+    response.headers['Auth-Status'] = 'Authentication rate limit from one source exceeded'
+    response.headers['Auth-Error-Code'] = '451 4.3.2'
+    if int(flask.request.headers['Auth-Login-Attempt']) < 10:
+        response.headers['Auth-Wait'] = '3'
+    return response
 
 @limiter.request_filter
 def whitelist_webmail():


### PR DESCRIPTION
When failing on rate limiter, the nginx reports on SMTP port unhelpful "Internal server error". This patch returns error response that nginx will present to the SMTP client.