### PR TITLE
Fixed libpng12-dev dependency, called libpng-dev now.

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
       libfreetype6-dev \
       libjpeg62-turbo-dev \
       libmcrypt-dev \
-      libpng12-dev \
+      libpng-dev \
  && docker-php-ext-install pdo_mysql mcrypt zip
 
 ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.3.6/roundcubemail-1.3.6-complete.tar.gz


### PR DESCRIPTION
Upstream docker base image probably upgraded distro, libpng12-dev does not exist anymore, lipng-dev does.