### PR TITLE
Fix typo

### DIFF
--- a/docs/compose/setup.rst
+++ b/docs/compose/setup.rst
@@ -92,7 +92,7 @@ setting. The configuration option must be one of the following:
 - ``none`` disables antivirus checks;
 - ``clamav`` is the default values, the popular ClamAV antivirus is enabled.
 
-Make sure that you have at least 1GB or memory for ClamAV to load its signature
+Make sure that you have at least 1GB of memory for ClamAV to load its signature
 database.
 
 If you run Mailu behind a reverse proxy you can use ``REAL_IP_HEADER`` and


### PR DESCRIPTION
Just spotted a typo in the documentation. I don't think there's much to write here, so sorry if I missed something.