### PR TITLE
Use alpine:3.7 tag to prevent postix upgrade

### DIFF
--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.7
 
 RUN apk add --no-cache postfix postfix-sqlite postfix-pcre rsyslog python py-jinja2
 


### PR DESCRIPTION
Due to non-versioning, image building pulled in `postfix-3.3.0` from `alpine:3.8`. Appearantly that postfix version in not compatible with the provided config. See issue #548.

In order to keep `mailu:1.5` operational as-was, tagging to `alpine:3.7` is required. I have tested this fix in my own setup.