### PR TITLE
Libpng12-dev is now called libpng-dev

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y \
       libfreetype6-dev \
       libjpeg62-turbo-dev \
       libmcrypt-dev \
-      libpng12-dev \
+      libpng-dev \
  && docker-php-ext-install pdo_mysql mcrypt
 
 ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.3.3/roundcubemail-1.3.3-complete.tar.gz


### PR DESCRIPTION
Like PR #514, this prevents re-building the image in the 1.5 branch.