### PR TITLE
Fix start.py for Swarm mode

### DIFF
--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -4,14 +4,26 @@ import jinja2
 import os
 import socket
 import glob
+import time
 
 convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()).render(**os.environ))
 
 # Actual startup script
-os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
-os.environ["REDIS_ADDRESS"] = socket.gethostbyname(os.environ.get("REDIS_ADDRESS", "redis"))
-if os.environ["WEBMAIL"] != "none":
-	os.environ["WEBMAIL_ADDRESS"] = socket.gethostbyname(os.environ.get("WEBMAIL_ADDRESS", "webmail"))
+i = 0
+t = 10
+while True:
+	i += 1
+	try:
+		os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
+		os.environ["REDIS_ADDRESS"] = socket.gethostbyname(os.environ.get("REDIS_ADDRESS", "redis"))
+		if os.environ["WEBMAIL"] != "none":
+			os.environ["WEBMAIL_ADDRESS"] = socket.gethostbyname(os.environ.get("WEBMAIL_ADDRESS", "webmail"))
+	except socket.gaierror as err:
+		if i >= t:
+			raise
+		time.sleep(10)
+		continue
+	break
 
 for dovecot_file in glob.glob("/conf/*"):
     convert(dovecot_file, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.7
 
 RUN apk add --no-cache postfix postfix-sqlite postfix-pcre rsyslog python py-jinja2
 

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -5,11 +5,23 @@ import os
 import socket
 import glob
 import shutil
-	
+import time
+
 convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()).render(**os.environ))
 
 # Actual startup script
-os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
+i = 0
+t = 10
+while True:
+	i += 1
+	try:
+		os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
+	except socket.gaierror as err:
+		if i >= t:
+			raise
+		time.sleep(10)
+		continue
+	break
 os.environ["HOST_ANTISPAM"] = os.environ.get("HOST_ANTISPAM", "antispam:11332")
 os.environ["HOST_LMTP"] = os.environ.get("HOST_LMTP", "imap:2525")
 

--- a/services/rspamd/start.py
+++ b/services/rspamd/start.py
@@ -4,11 +4,23 @@ import jinja2
 import os
 import socket
 import glob
+import time
 
 convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()).render(**os.environ))
 
 # Actual startup script
-os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
+i = 0
+t = 10
+while True:
+	i += 1
+	try:
+		os.environ["FRONT_ADDRESS"] = socket.gethostbyname(os.environ.get("FRONT_ADDRESS", "front"))
+	except socket.gaierror as err:
+		if i >= t:
+			raise
+		time.sleep(10)
+		continue
+	break
 if "HOST_REDIS" not in os.environ: os.environ["HOST_REDIS"] = "redis"
 
 for rspamd_file in glob.glob("/conf/*"):


### PR DESCRIPTION
Images that use early resolving during startup in start.py, now get 10 attempts to resolve. Intervall is 10 seconds between attempts. This is neccesary to have a stable startup cycle in swarm mode. This closes issue #555.

The images have been build and tested in swarm mode and classic docker-compose mode.

Confirmation of a smooth startup:

```
[root@mars mailu2]# docker stack ps mailu2
ID                  NAME                 IMAGE                        NODE                       DESIRED STATE       CURRENT STATE           ERROR               PORTS
czsp3xzhhdl4        mailu2_webdav.1      muhlemmer/none:master        venus.mohlmann.solutions   Running             Running 4 minutes ago                       
7q8x9udc93qj        mailu2_imap.1        muhlemmer/dovecot:master     mars.mohlmann.solutions    Running             Running 4 minutes ago                   
prfzcf3uxwq1        mailu2_admin.1       muhlemmer/admin:master       mars.mohlmann.solutions    Running             Running 4 minutes ago                       
75fu7msc5y57        mailu2_redis.1       redis:alpine                 sun.mohlmann.solutions     Running             Running 4 minutes ago                       
kurhhma895g7        mailu2_fetchmail.1   muhlemmer/fetchmail:master   sun.mohlmann.solutions     Running             Running 4 minutes ago                       
4tmfi37pso3w        mailu2_antispam.1    muhlemmer/rspamd:master      sun.mohlmann.solutions     Running             Running 4 minutes ago                       
lxw9irspeqel        mailu2_antivirus.1   muhlemmer/clamav:master      mars.mohlmann.solutions    Running             Running 4 minutes ago                       
vimgfnxeeqnx        mailu2_smtp.1        muhlemmer/postfix:master     sun.mohlmann.solutions     Running             Running 4 minutes ago                       
uh8n8wve6qdl        mailu2_webmail.1     muhlemmer/roundcube:master   sun.mohlmann.solutions     Running             Running 4 minutes ago                       
75gyd2ltnbpp        mailu2_front.1       muhlemmer/nginx:master       venus.mohlmann.solution
```

Note, this does not yet address the PHP resolver issue #530. I hope to post another PR for that soon.