### PR TITLE
Fix binding in setup utility's gunicorn

### DIFF
--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.7
 
 RUN apk add --no-cache postfix postfix-sqlite postfix-pcre rsyslog python py-jinja2
 

--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -15,4 +15,4 @@ RUN python setup.py https://github.com/mailu/mailu /data
 
 EXPOSE 80/tcp
 
-CMD gunicorn -w 4 -b 0.0.0.0:80 -b [::]:80 --access-logfile - --error-logfile - --preload main:app
+CMD gunicorn -w 4 -b :80 --access-logfile - --error-logfile - --preload main:app


### PR DESCRIPTION
`gunicorn` invocation explicitly wanted to bind to the global ipv6 address. Start up fails on hosts where Docker is not running with ipv6 support.

The updated command in this PR makes gunicorn to bind on port 80 of any available protocol. Now, it will not fail if ipv6 is not available inside docker.