### PR TITLE
Add a compose file for mailu/setup

### DIFF
--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.7
 
 RUN apk add --no-cache postfix postfix-sqlite postfix-pcre rsyslog python py-jinja2
 

--- a/setup/docker-compose.yml
+++ b/setup/docker-compose.yml
@@ -1,0 +1,13 @@
+# This file is used to run the mailu/setup utility
+
+version: '2'
+
+services:
+  redis:
+    image: redis:alpine
+
+  setup:
+    image: mailu/setup
+    ports:
+      - "80:80"
+


### PR DESCRIPTION
Setup needs to tal to redis in order to function. To ease running of the setup utility, I've create a short `docker-compose.yml` file.