### PR TITLE
use safer cipher in roundcube

### DIFF
--- a/webmails/roundcube/config.inc.php
+++ b/webmails/roundcube/config.inc.php
@@ -6,6 +6,7 @@ $config = array();
 $config['db_dsnw'] = 'sqlite:////data/roundcube.db';
 $config['temp_dir'] = '/tmp/';
 $config['des_key'] = getenv('SECRET_KEY');
+$config['cipher_method'] = 'AES-256-CBC';
 $config['identities_level'] = 3;
 $config['reply_all_mode'] = 1;
 


### PR DESCRIPTION
"Default is set for backward compatibility to DES-EDE3-CBC,
but you can choose e.g. AES-256-CBC which we consider a better choice."

https://github.com/roundcube/roundcubemail/blob/master/config/defaults.inc.php#L512