### PR TITLE
Travis-CI automated test build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-language: python
-python:
-  - "3.6"
-install:
-  - pip install -r docs/requirements.txt
+sudo: required
+services: docker
+addons:
+  apt:
+    packages:
+      - docker-ce
+env:
+  - VERSION=$TRAVIS_BRANCH
+
 script:
-  - sphinx-versioning build -b -B 1.5 -r 1.5 -w '^[0-9.]*$' -w master -W '^$' docs/ build/
-  - python "docs/conf.py" "build" "$DEPLOY_HOST" "$DEPLOY_USERNAME" "$DEPLOY_PASSWORD" "$DEPLOY_REMOTEDIR"
+- docker-compose -f tests/build.yml -p Mailu build

--- a/tests/build.yml
+++ b/tests/build.yml
@@ -1,0 +1,47 @@
+version: '3'
+
+services:
+
+  front:
+    image: mailu/nginx:$VERSION
+    build: ../core/nginx
+
+  imap:
+    image: mailu/dovecot:$VERSION
+    build: ../core/dovecot
+
+  smtp:
+    image: mailu/postfix:$VERSION
+    build: ../core/postfix
+
+  antispam:
+    image: mailu/rspamd:$VERSION
+    build: ../services/rspamd
+
+  antivirus:
+    image: mailu/clamav:$VERSION
+    build: ../optional/clamav
+
+  webdav:
+    image: mailu/radicale:$VERSION
+    build: ../optional/radicale
+
+  admin:
+    image: mailu/admin:$VERSION
+    build: ../core/admin
+
+  roundcube:
+    image: mailu/roundcube:$VERSION
+    build: ../webmails/roundcube
+
+  rainloop:
+    image: mailu/rainloop:$VERSION
+    build: ../webmails/rainloop
+
+  fetchmail:
+    image: mailu/fetchmail:$VERSION
+    build: ../services/fetchmail
+
+  none:
+    image: mailu/none:$VERSION
+    build: ../core/none


### PR DESCRIPTION
This PR is the first step into creating testing suite. At this stage, it instructs travis-ci to build all the Mailu images and the success of the test is only evaluated on this.

Note that the documentation deploy system has already been removed from `.travis.yml` , as it was giving complications. This functionality should be replaced as per #601.