### PR TITLE
upgrade to PHP 7.2 and remove unused dependencies

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -1,11 +1,10 @@
-FROM php:7.0-apache
+FROM php:7.2-apache
 
 RUN apt-get update && apt-get install -y \
       libfreetype6-dev \
       libjpeg62-turbo-dev \
-      libmcrypt-dev \
       libpng-dev \
- && docker-php-ext-install pdo_mysql mcrypt zip
+ && docker-php-ext-install pdo_mysql zip
 
 ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.3.7/roundcubemail-1.3.7-complete.tar.gz
 

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -1,10 +1,8 @@
 FROM php:7.2-apache
 
 RUN apt-get update && apt-get install -y \
-      libfreetype6-dev \
-      libjpeg62-turbo-dev \
-      libpng-dev \
- && docker-php-ext-install pdo_mysql zip
+      zlib1g-dev \
+ && docker-php-ext-install zip
 
 ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.3.7/roundcubemail-1.3.7-complete.tar.gz
 


### PR DESCRIPTION
removed mcrypt because Rouncube uses openssl exclusively since version 1.2 and mcrypt was removed from PHP 7.2