### PR TITLE
Attempt to fix the docs build context

### DIFF
--- a/tests/build.yml
+++ b/tests/build.yml
@@ -50,4 +50,4 @@ services:
     image: mailu/docs:$VERSION
     build:
       context: ../
-      dockerfile: ../docs/Dockerfile
+      dockerfile: docs/Dockerfile


### PR DESCRIPTION
The build context is solved by not referring twice to the parent directory.

However, sphinx is not able to find it's docs and the build still fails. I've tried a thing or two, but I don't have enough understanding on how sphinx is working with git. Maybe you have a suggestion, @kaiyou?
