### PR TITLE
Add variable to choose whether to bounce or reject email when recipient is unknown. Fixes #583

### DIFF
--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -8,6 +8,7 @@ smtp      inet  n       -       n       -       -       smtpd
 10025     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_recipient_restrictions=reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit
+  -o smtpd_reject_unlisted_recipient={{ REJECT_UNLISTED_RECIPIENT }}
   -o cleanup_service_name=outclean
 outclean  unix n       -       n       -       0       cleanup
   -o header_checks=pcre:/etc/postfix/outclean_header_filter.cf

--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -8,7 +8,7 @@ smtp      inet  n       -       n       -       -       smtpd
 10025     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_recipient_restrictions=reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit
-  -o smtpd_reject_unlisted_recipient={{ REJECT_UNLISTED_RECIPIENT }}
+  -o smtpd_reject_unlisted_recipient={% if REJECT_UNLISTED_RECIPIENT %}{{ REJECT_UNLISTED_RECIPIENT }}{% else %}no{% endif %}
   -o cleanup_service_name=outclean
 outclean  unix n       -       n       -       0       cleanup
   -o header_checks=pcre:/etc/postfix/outclean_header_filter.cf

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -132,3 +132,6 @@ REAL_IP_HEADER=
 
 # IPs for nginx set_real_ip_from (CIDR list separated by commas)
 REAL_IP_FROM=
+
+# choose wether mailu bounces (no) or rejects (yes) mail when recipient is unknown (value: yes, no)
+REJECT_UNLISTED_RECIPIENT=


### PR DESCRIPTION
As described in #583, Mailu bounces email when recipient is unknown.
This PR add a variable (in .env) to choose whether to reject or to bounce.

If the variable is not set, the current Mailu behaviour is kept (equivalent to set it to "no")
To REJECT mail, the .env file has to set the variable to yes

