### PR TITLE
support PBKDF2 and use it as default

### DIFF
--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -58,7 +58,7 @@ default_config = {
     'RECAPTCHA_PUBLIC_KEY': '',
     'RECAPTCHA_PRIVATE_KEY': '',
     # Advanced settings
-    'PASSWORD_SCHEME': 'SHA512-CRYPT',
+    'PASSWORD_SCHEME': 'PBKDF2',
     # Host settings
     'HOST_IMAP': 'imap',
     'HOST_POP3': 'imap',

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -269,7 +269,8 @@ class User(Base, Email):
     def quota_bytes_used(self):
         return quota.get(self.email + "/quota/storage") or 0
 
-    scheme_dict = {'SHA512-CRYPT': "sha512_crypt",
+    scheme_dict = {'PBKDF2': "pbkdf2_sha512",
+                   'SHA512-CRYPT': "sha512_crypt",
                    'SHA256-CRYPT': "sha256_crypt",
                    'MD5-CRYPT': "md5_crypt",
                    'CRYPT': "des_crypt"}

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -124,8 +124,8 @@ WEBSITE=https://mailu.io
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=SHA512-CRYPT
+# (value: PBKDF2, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
+PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from
 REAL_IP_HEADER=


### PR DESCRIPTION
PBKDF2-SHA512 is as secure as SHA512-CRYPT but works in constant-time based on the rounds, not the length of the password - eliminating the leakage of password-length based on timing

this should also reduce the performance impact as reported by #546
(in my local tests with the script by @t-t-yano PBKDF2-SHA512 is 2-3x faster than SHA512-CRYPT)