### PR TITLE
Fix rainloop permissions

### DIFF
--- a/webmails/rainloop/start.py
+++ b/webmails/rainloop/start.py
@@ -18,7 +18,7 @@ os.makedirs(base + "configs", exist_ok=True)
 convert("/default.ini", "/data/_data_/_default_/domains/default.ini")
 convert("/config.ini", "/data/_data_/_default_/configs/config.ini")
 
-os.execv("/usr/local/bin/apache2-foreground", ["apache2-foreground"])
-
 os.system("chown -R www-data:www-data /data")
+
+os.execv("/usr/local/bin/apache2-foreground", ["apache2-foreground"])
 

--- a/webmails/rainloop/start.py
+++ b/webmails/rainloop/start.py
@@ -19,3 +19,6 @@ convert("/default.ini", "/data/_data_/_default_/domains/default.ini")
 convert("/config.ini", "/data/_data_/_default_/configs/config.ini")
 
 os.execv("/usr/local/bin/apache2-foreground", ["apache2-foreground"])
+
+os.system("chown -R www-data:www-data /data")
+


### PR DESCRIPTION
Found out that on latest version of master webmail complaints about permissions on /data folder. 
_[202] Data folder permissions error [is_writable]_

This was not a problem when upgrading from 1.5 because the chmod command was in start.sh
https://github.com/Mailu/Mailu/blob/790e32cfb865f500c8a43a81c9fbd3a355bb48ed/webmails/rainloop/start.sh#L11
