### PR TITLE
Adding unbound as dns resolver Pt. 2 [WIP]

### DIFF
--- a/core/unbound/Dockerfile
+++ b/core/unbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.8
 
 RUN apk add --no-cache unbound curl \
 	&& curl -o /etc/unbound/root.hints https://www.internic.net/domain/named.cache \

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -21,9 +21,6 @@ SECRET_KEY=ChangeMeChangeMe
 BIND_ADDRESS4=127.0.0.1
 BIND_ADDRESS6=::1
 
-# Internal Docker network
-IPV4_NETWORK=172.22.1
-
 # Main mail domain
 DOMAIN=mailu.io
 

--- a/docs/compose/docker-compose.yml
+++ b/docs/compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2'
 
 services:
 
@@ -30,20 +30,14 @@ services:
     depends_on:
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - front
+      - 10.177.20.254
 
   unbound:
     image: mailu/unbound:$VERSION
     restart: always
     networks:
-      backend:
-        ipv4_address: ${IPV4_NETWORK:-172.22.1}.254
-        aliases:
-          - unbound
+      default:
+        ipv4_address: 10.177.20.254
 
   redis:
     image: redis:alpine
@@ -51,13 +45,9 @@ services:
     volumes:
       - "$ROOT/redis:/data"
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
+      - 10.177.20.254
     depends_on:
       - unbound
-    networks:
-      backend:
-        aliases:
-          - redis
 
   imap:
     image: mailu/dovecot:$VERSION
@@ -71,11 +61,7 @@ services:
       - front
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - imap
+      - 10.177.20.254
 
   smtp:
     image: mailu/postfix:$VERSION
@@ -88,11 +74,7 @@ services:
       - front
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - smtp
+      - 10.177.20.254
 
   antispam:
     image: mailu/rspamd:$VERSION
@@ -106,11 +88,7 @@ services:
       - front
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - antispam
+      - 10.177.20.254
 
   antivirus:
     image: mailu/$ANTIVIRUS:$VERSION
@@ -121,11 +99,7 @@ services:
     depends_on:
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - antivirus
+      - 10.177.20.254
 
   webdav:
     image: mailu/$WEBDAV:$VERSION
@@ -136,11 +110,7 @@ services:
     depends_on:
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - webdav
+      - 10.177.20.254
 
   admin:
     image: mailu/admin:$VERSION
@@ -154,11 +124,7 @@ services:
       - redis
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - admin
+      - 10.177.20.254
 
   webmail:
     image: "mailu/$WEBMAIL:$VERSION"
@@ -170,11 +136,7 @@ services:
       - imap
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - webmail
+      - 10.177.20.254
 
   fetchmail:
     image: mailu/fetchmail:$VERSION
@@ -185,16 +147,12 @@ services:
     depends_on:
       - unbound
     dns:
-      - ${IPV4_NETWORK:-172.22.1}.254
-    networks:
-      backend:
-        aliases:
-          - fetchmail
+      - 10.177.20.254
 
 networks:
-  backend:
+  default:
     driver: bridge
     ipam:
       driver: default
       config:
-        - subnet: ${IPV4_NETWORK:-172.22.1}.0/24
+        - subnet: 10.177.20.0/24

--- a/tests/build.yml
+++ b/tests/build.yml
@@ -6,6 +6,10 @@ services:
     image: $DOCKER_ORG/nginx:$VERSION
     build: ../core/nginx
 
+  unbound:
+    image: $DOCKER_ORG/unbound:$VERSION
+    build: ../core/unbound
+
   imap:
     image: $DOCKER_ORG/dovecot:$VERSION
     build: ../core/dovecot


### PR DESCRIPTION
This is subsequent work on PR #385, originally submitted by @obi12341. Mainly some cleanup, merge to latest master and DNS testing. This is still a work in progress and this PR should facilitate discussion.

## Docker compose ##
In a regular docker-compose setup, we cannot avoid using static IP. I don't know if this will break anything? Users will not be able to use `docker-compose up -d --scale unbound=x`. (Don't know if other Mailu components are capable of doing that, never tried).

## Docker swarm ##
It is not (yet) possible in Docker swarm to use a static VIP for a service. (moby/moby#24170) Replicated services rely on the service name to be resolved, which will not work as a DNS entry. This means also that `unbound` cannot be replicated, unless multiple serve entries are made.

I've tried exposing the DNS server to the host network and set the DNS entry to the host IP, but docker does not allow this kind of connections between containers, it has to by bridge or overlay network.

## Testing ##
The following things are tested:
1. Resolving of external hostnames
2. Resolving of Docker hostnames.

No mail testing has been conducted as of yet. First I want to discuss this approach.