### PR TITLE
support bcrypt and use it as default

### DIFF
--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -57,7 +57,7 @@ default_config = {
     'RECAPTCHA_PUBLIC_KEY': '',
     'RECAPTCHA_PRIVATE_KEY': '',
     # Advanced settings
-    'PASSWORD_SCHEME': 'SHA512-CRYPT',
+    'PASSWORD_SCHEME': 'BLF-CRYPT',
     # Host settings
     'HOST_IMAP': 'imap',
     'HOST_POP3': 'imap',

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -276,7 +276,8 @@ class User(Base, Email):
         else:
             return self.email
 
-    scheme_dict = {'SHA512-CRYPT': "sha512_crypt",
+    scheme_dict = {'BLF-CRYPT': "bcrypt",
+                   'SHA512-CRYPT': "sha512_crypt",
                    'SHA256-CRYPT': "sha256_crypt",
                    'MD5-CRYPT': "md5_crypt",
                    'CRYPT': "des_crypt"}

--- a/core/admin/requirements-prod.txt
+++ b/core/admin/requirements-prod.txt
@@ -1,6 +1,7 @@
 alembic==0.9.9
 asn1crypto==0.24.0
 Babel==2.5.3
+bcrypt==3.1.4
 blinker==1.4
 certifi==2018.4.16
 cffi==1.11.5

--- a/core/admin/requirements.txt
+++ b/core/admin/requirements.txt
@@ -17,3 +17,4 @@ tabulate
 PyYAML
 PyOpenSSL
 dnspython
+bcrypt

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -124,8 +124,8 @@ WEBSITE=https://mailu.io
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=SHA512-CRYPT
+# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
+PASSWORD_SCHEME=BLF-CRYPT
 
 # Header to take the real ip from
 REAL_IP_HEADER=


### PR DESCRIPTION
alternative PR for #635

bcrypt is fast¹ and secure and the hash-formats from passlib and dovecot are the same…

¹ with the C-extension installed; in my local test it was around 1-2x faster than SHA512-CRYPT