### PR TITLE
Added config XCLIENT_HOSTS

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -34,7 +34,7 @@ relayhost = {{ RELAYHOST }}
 recipient_delimiter = {{ RECIPIENT_DELIMITER }}
 
 # Only the front server is allowed to perform xclient
-smtpd_authorized_xclient_hosts={{ FRONT_ADDRESS }}
+smtpd_authorized_xclient_hosts={{ FRONT_ADDRESS }} {{XCLIENT_HOSTS}}
 
 ###############
 # TLS

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -135,3 +135,7 @@ REAL_IP_FROM=
 
 # choose wether mailu bounces (no) or rejects (yes) mail when recipient is unknown (value: yes, no)
 REJECT_UNLISTED_RECIPIENT=
+
+# hosts allowed to perform smtp xclient commands.
+# Set this to the docker network if 'front' can run on multiple IP's (like in docker swarm).
+XCLIENT_HOSTS=


### PR DESCRIPTION
With this option, we can run mailu in docker swarm (with the dnsrr workaround) with proper failover. 

When a docker host goes offline in docker swarm, the services get deployed on another server. With this change, the smtp service will still accept xclient commands from the new front host. 

This is a duplicate of https://github.com/Mailu/Mailu/pull/563 which has awaiting fixes. If this is pulled, that one can be closed. 
