### PR TITLE
Option to send front logs to journald or syslog

### DIFF
--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -120,6 +120,12 @@ WEBSITE=https://mailu.io
 # Advanced settings
 ###################################
 
+# Log driver for front service. Possible values:
+# json-file (default)
+# journald (On systemd platforms, useful for Fail2Ban integration)
+# syslog (Non systemd platforms, Fail2Ban integration. Disables `docker-compose log` for front!)
+LOG_DRIVER=json-file
+
 # Docker-compose project name, this will prepended to containers names.
 COMPOSE_PROJECT_NAME=mailu
 

--- a/docs/compose/docker-compose.yml
+++ b/docs/compose/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     image: mailu/nginx:$VERSION
     restart: always
     env_file: .env
+    logging:
+      driver: $LOG_DRIVER
     ports:
     - "$BIND_ADDRESS4:80:80"
     - "$BIND_ADDRESS4:443:443"

--- a/tests/compose/core.env
+++ b/tests/compose/core.env
@@ -120,6 +120,12 @@ WEBSITE=https://mailu.io
 # Advanced settings
 ###################################
 
+# Log driver for front service. Possible values:
+# json-file (default)
+# journald (On systemd platforms, useful for Fail2Ban integration)
+# syslog (Non systemd platforms, Fail2Ban integration. Disables `docker-compose log` for front!)
+LOG_DRIVER=json-file
+
 # Docker-compose project name, this will prepended to containers names.
 #COMPOSE_PROJECT_NAME=mailu
 

--- a/tests/compose/run.yml
+++ b/tests/compose/run.yml
@@ -7,7 +7,7 @@ services:
     restart: 'no'
     env_file: $PWD/.env
     logging:
-      driver: journald
+      driver: $LOG_DRIVER
     ports:
     - "$BIND_ADDRESS4:80:80"
     - "$BIND_ADDRESS4:443:443"

--- a/tests/compose/run.yml
+++ b/tests/compose/run.yml
@@ -6,6 +6,8 @@ services:
     image: $DOCKER_ORG/nginx:$VERSION
     restart: 'no'
     env_file: $PWD/.env
+    logging:
+      driver: journald
     ports:
     - "$BIND_ADDRESS4:80:80"
     - "$BIND_ADDRESS4:443:443"


### PR DESCRIPTION
Supersedes PR #654. Implements request from issue #584.

This provides an option to let the Docker deamon send the logs from front to an alternative driver. In principle all [docker log drivers](https://docs.docker.com/config/containers/logging/configure/#supported-logging-drivers) can be set. However, `.env` only mentions the most applicable ones:
1. `json-file`: Docker's default driver, used for `docker-compose logs`
2. `journald`: Send to systemd
3. `syslog`: For non-systemd, breaks `docker-compose logs`.

When setting to `journald` logs can be checked using:
```
journalctl -b CONTAINER_NAME=mailu_front_1
```
On Fedora Fail2Ban is integrated with `journald`. So it would be a matter of finding the right regex to make this work. Make sure not to blacklist any 172.x.x.x addresses or whatever local range you are using.

I have not tested `syslog` myself, as I only use systemd on all my systems.
