### PR TITLE
Re-enable local dovecot sieve scripts

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -136,7 +136,8 @@ service managesieve {
 }
 
 plugin {
-  sieve = dict:proxy:/tmp/podop.socket:sieve
+  sieve = file:~/sieve;active=~/.dovecot.sieve
+  sieve_before = dict:proxy:/tmp/podop.socket:sieve
   sieve_plugins = sieve_imapsieve sieve_extprograms
   sieve_extensions = +spamtest +spamtestplus +editheader
   sieve_global_extensions = +vnd.dovecot.execute


### PR DESCRIPTION
These were disabled when switching to dynamic generation of scripts by the admin container, but I believe we can re-enable local storage and still have dynamic generation for vacation, antispam, etc.

This should fix #653