### PR TITLE
Improve password checking performance

### DIFF
--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -12,7 +12,7 @@ import docker
 import socket
 import uuid
 
-from werkzeug.contrib import fixers
+from werkzeug.contrib import fixers, profiler
 
 # Create application
 app = flask.Flask(__name__)
@@ -62,7 +62,10 @@ default_config = {
     'HOST_IMAP': 'imap',
     'HOST_POP3': 'imap',
     'HOST_SMTP': 'smtp',
+    'HOST_WEBMAIL': 'webmail',
+    'HOST_FRONT': 'front',
     'HOST_AUTHSMTP': os.environ.get('HOST_SMTP', 'smtp'),
+    'POD_ADDRESS_RANGE': None
 }
 
 # Load configuration from the environment if available
@@ -79,6 +82,10 @@ limiter = flask_limiter.Limiter(app, key_func=lambda: current_user.username)
 if app.config.get("DEBUG"):
     import flask_debugtoolbar
     toolbar = flask_debugtoolbar.DebugToolbarExtension(app)
+
+# Profiler
+if app.config.get("DEBUG"):
+    app.wsgi_app = profiler.ProfilerMiddleware(app.wsgi_app, restrictions=[30])
 
 # Manager commnad
 manager = flask_script.Manager(app)
@@ -128,5 +135,6 @@ class PrefixMiddleware(object):
         if prefix:
             environ['SCRIPT_NAME'] = prefix
         return self.app(environ, start_response)
+
 
 app.wsgi_app = PrefixMiddleware(fixers.ProxyFix(app.wsgi_app))

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -1,14 +1,24 @@
-from mailu import db, models
+from mailu import db, models, app
 from mailu.internal import internal
 
 import flask
+import socket
 
 
 @internal.route("/dovecot/passdb/<user_email>")
 def dovecot_passdb_dict(user_email):
     user = models.User.query.get(user_email) or flask.abort(404)
+    allow_nets = []
+    allow_nets.append(
+        app.config.get("POD_ADDRESS_RANGE") or
+        socket.gethostbyname(app.config["HOST_FRONT"])
+    )
+    allow_nets.append(socket.gethostbyname(app.config["HOST_WEBMAIL"]))
+    print(allow_nets)
     return flask.jsonify({
-        "password": user.password,
+        "password": None,
+        "nopassword": "Y",
+        "allow_nets": ",".join(allow_nets)
     })
 
 

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -276,7 +276,8 @@ class User(Base, Email):
         else:
             return self.email
 
-    scheme_dict = {'BLF-CRYPT': "bcrypt",
+    scheme_dict = {'PBKDF2': "pbkdf2_sha512",
+                   'BLF-CRYPT': "bcrypt",
                    'SHA512-CRYPT': "sha512_crypt",
                    'SHA256-CRYPT': "sha256_crypt",
                    'MD5-CRYPT': "md5_crypt",
@@ -287,8 +288,14 @@ class User(Base, Email):
     )
 
     def check_password(self, password):
+        context = User.pw_context
         reference = re.match('({[^}]+})?(.*)', self.password).group(2)
-        return User.pw_context.verify(password, reference)
+        result = context.verify(password, reference)
+        if result and context.identify(reference) != context.default_scheme():
+            self.set_password(password)
+            db.session.add(self)
+            db.session.commit()
+        return result
 
     def set_password(self, password, hash_scheme=app.config['PASSWORD_SCHEME'], raw=False):
         """Set password for user with specified encryption scheme

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -130,8 +130,8 @@ LOG_DRIVER=json-file
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=BLF-CRYPT
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
+PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from
 REAL_IP_HEADER=

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -130,7 +130,7 @@ LOG_DRIVER=json-file
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
 PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from


### PR DESCRIPTION
After @HorayNarea closed #635 because Dovecot was using the password for a second-time check, I re-implemented the IP check that removes the need for double password checking.

Now, at the cost of a couple dns queries, Dovecot does not check the password anymore, which helps in two ways:
- it divides the checking time by a factor of 2
- it allows PBKDF2, which is significantly faster (factor of 10 at least).

Finally, I added the ability for the user password to be dynamically updated upon login if the database version is in an older format. This way, people can now switch to PBKDF2 and quickly see a decent performance improvement.