### PR TITLE
Fix nginx conf if webmail is on root path

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -91,8 +91,10 @@ http {
       {% endif %}
 
       location {{ WEB_WEBMAIL }} {
+        {% if WEB_WEBMAIL != '/' %}
         rewrite ^({{ WEB_WEBMAIL }})$ $1/ permanent;
         rewrite ^{{ WEB_WEBMAIL }}/(.*) /$1 break;
+        {% endif %}
         include /etc/nginx/proxy.conf;
         client_max_body_size {{ MESSAGE_SIZE_LIMIT|int + 8388608 }};
         proxy_pass http://$webmail;


### PR DESCRIPTION
This removes the rewrites in the nginx config, if the webmail is running on root path (e.g. mail.example.com) because it breaks the request.