### PR TITLE
Added kubernetes CNI support for Mailu

### DIFF
--- a/docs/kubernetes/mailu/configmap.yaml
+++ b/docs/kubernetes/mailu/configmap.yaml
@@ -53,6 +53,11 @@
     # This way we can make use of the advantages of the cert-manager deployment
     KUBERNETES_INGRESS: "true"
 
+    # POD_ADDRESS_RANGE is normally provided by default with Kubernetes
+    # Only use this value when you are using Flannel, Calico or a special kind of CNI
+    # Provide the IPs of your network interface or bridge which is used for VXLAN network traffic
+    # POD_ADDRESS_RANGE: 10.2.0.0/16,10.1.6.0/24
+
     ###################################
     # Optional features
     ###################################

--- a/docs/kubernetes/mailu/index.rst
+++ b/docs/kubernetes/mailu/index.rst
@@ -191,3 +191,18 @@ This problem can be easily fixed by running following commands:
 
     kubectl -n mailu-mailserver exec -it maolu-imap-... /bin/sh
     chmod 777 /data/main.db
+
+If the login problem still persists, or more specific, happens now and then and you see some Auth problems on your webmail or mail client, try following steps:
+
+- Add ``auth_debug=yes`` to the ``/overrides/dovecot.conf`` file and delete the pod in order to start a new one, which loads the configuration
+- Depending on your network configuration you could still see some ``allow_nets check failed`` results in the logs. This means that the IP is not allowed a login
+- If this is happening your network plugin has troubles with the Nginx Ingress Controller using the ``hostNetwork: true`` option. Known cases: Flannel and Calico.
+- You should uncomment ``POD_ADDRESS_RANGE`` in the ``configmap.yaml`` file and add the IP range of your pod network bridge (the range that sadly has failed the ``allowed_nets`` test)
+- Delete the IMAP pod and wait for it to restart
+
+.. code:: bash
+
+    kubectl -n mailu-mailserver get po
+    kubectl -n mailu-mailserver delete po/mailu-imap...
+
+Happy mailing!


### PR DESCRIPTION
This adaptations make it possible to use Mailu stable on Kubernetes using a special CNI (network plugin). 
Sometimes problems occurred when logging in to IMAP, the reasons for this were the following:

- The Nginx Ingress Controller uses `hostNetwork: true` to be able to open up the mail ports on your nodes
- This way the NGinx pods don't receive an IP in the `POD_ADDRESS_RANGE`
- They try to login to the IMAP container using the network bridge (eg: `10.2.0.0` address)
- This is OK, but in one specific situation, when the user accesses the NGinx Container on the same node that is running the IMAP container, it uses it's own address of the network bridge, which is on a different subnet as the `POD_ADDRESS_RANGE` to access the imap pod (in my case it was `10.1.6.0/24). 
- By providing a specific `POD_ADDRESS_RANGE` in the configmap, using commas it gets added in the IMAP pod and the connections are accepted!

Docs are updated
 
Signed-off-by: Hans Cornelis <hacornelis@gmail.com>