### PR TITLE
Added the option to choose your own RSPAMD password

### DIFF
--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -126,6 +126,9 @@ WEBSITE=https://mailu.io
 # syslog (Non systemd platforms, Fail2Ban integration. Disables `docker-compose log` for front!)
 LOG_DRIVER=json-file
 
+# Add your specific password to rspamd
+ RSPAMD_PASSWORD: "Your_secret_password_here"
+
 # Docker-compose project name, this will prepended to containers names.
 COMPOSE_PROJECT_NAME=mailu
 

--- a/docs/kubernetes/mailu/configmap.yaml
+++ b/docs/kubernetes/mailu/configmap.yaml
@@ -148,6 +148,9 @@
     # Header to take the real ip from
     #REAL_IP_HEADER:
 
+    # Add your specific password to rspamd
+    RSPAMD_PASSWORD: "Your_secret_password_here"
+
     # IPs for nginx set_real_ip_from (CIDR list separated by commas)
     #REAL_IP_FROM:
 

--- a/services/rspamd/conf/worker-controller.inc
+++ b/services/rspamd/conf/worker-controller.inc
@@ -1,4 +1,8 @@
 type = "controller";
 bind_socket = "*:11334";
+{% if RSPAMD_PASSWORD %}
+password = "{{ RSPAMD_PASSWORD }}";
+{% else %}
 password = "mailu";
+{% endif %}
 secure_ip = "{% if POD_ADDRESS_RANGE %}{{ POD_ADDRESS_RANGE }}{% else %}{{ FRONT_ADDRESS }}{% endif %}";


### PR DESCRIPTION
As promised to @muhlemmer I made a separate PR to add the option to choose your custom rspamd password. Although it was not really clear if this was done using the admin interface or not.

Signed-off-by: Hans Cornelis <hacornelis@gmail.com>