### PR TITLE
Fix imap login when no webmail selected

### DIFF
--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -3,7 +3,7 @@ from mailu.internal import internal
 
 import flask
 import socket
-
+import os
 
 @internal.route("/dovecot/passdb/<user_email>")
 def dovecot_passdb_dict(user_email):
@@ -13,7 +13,8 @@ def dovecot_passdb_dict(user_email):
         app.config.get("POD_ADDRESS_RANGE") or
         socket.gethostbyname(app.config["HOST_FRONT"])
     )
-    allow_nets.append(socket.gethostbyname(app.config["HOST_WEBMAIL"]))
+    if os.environ["WEBMAIL"] != "none":
+        allow_nets.append(socket.gethostbyname(app.config["HOST_WEBMAIL"]))
     print(allow_nets)
     return flask.jsonify({
         "password": None,


### PR DESCRIPTION
When there is no webmail selected, imap login was failing with:

```
admin_1      | [2018-10-31 14:36:58,407] ERROR in app: Exception on /internal/dovecot/passdb/admin@mailu.io [GET]
admin_1      | Traceback (most recent call last):
admin_1      |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1982, in wsgi_app
admin_1      |     response = self.full_dispatch_request()
admin_1      |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1614, in full_dispatch_request
admin_1      |     rv = self.handle_user_exception(e)
admin_1      |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1517, in handle_user_exception
admin_1      |     reraise(exc_type, exc_value, tb)
admin_1      |   File "/usr/local/lib/python3.7/site-packages/flask/_compat.py", line 33, in reraise
admin_1      |     raise value
admin_1      |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1612, in full_dispatch_request
admin_1      |     rv = self.dispatch_request()
admin_1      |   File "/usr/local/lib/python3.7/site-packages/flask/app.py", line 1598, in dispatch_request
admin_1      |     return self.view_functions[rule.endpoint](**req.view_args)
admin_1      |   File "/app/mailu/internal/views/dovecot.py", line 16, in dovecot_passdb_dict
admin_1      |     allow_nets.append(socket.gethostbyname(app.config["HOST_WEBMAIL"]))
admin_1      | socket.gaierror: [Errno -2] Name does not resolve
admin_1      | 172.31.0.5 - - [31/Oct/2018:14:36:58 +0000] "GET /internal/dovecot/passdb/admin@mailu.io HTTP/1.1" 500 291 "-" "Python/3.6 aiohttp/3.4.4"
imap_1       | asyncio (ERROR): _GatheringFuture exception was never retrieved
imap_1       | future: <_GatheringFuture finished exception=Exception(500,)>
imap_1       | Traceback (most recent call last):
imap_1       |   File "/usr/lib/python3.6/site-packages/podop/dovecot.py", line 86, in process_lookup
imap_1       |     key, ns=(self.user if key_type == "priv" else None)
imap_1       |   File "/usr/lib/python3.6/site-packages/podop/table.py", line 34, in get
imap_1       |     raise Exception(request.status)
imap_1       | Exception: 500
```

This PR fixes that by checking if there is a webmail selected.
