### PR TITLE
1.5 htaccess php7

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -19,7 +19,8 @@ RUN rm -rf /var/www/html/ \
  && mv roundcubemail-* html \
  && cd html \
  && rm -rf CHANGELOG INSTALL LICENSE README.md UPGRADING composer.json-dist installer \
- && chown -R www-data: logs
+ && chown -R www-data: logs \
+ && sed -i 's/mod_php5.c/mod_php7.c/g' /var/www/html/.htaccess 
 
 COPY config.inc.php /var/www/html/config/
 


### PR DESCRIPTION
The `.htaccess` file needs to be modified when php7 is being used (as stated in the .htaccess file comment).

Otherwise, we don't benefit from the Roundcube provided config and thus changing `upload_max_filesize` or `post_max_size` in `.htaccess` won't have any effect since this block is being ignored.