### PR TITLE
Query alternative table for domain matches

### DIFF
--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -6,7 +6,9 @@ import flask
 
 @internal.route("/postfix/domain/<domain_name>")
 def postfix_mailbox_domain(domain_name):
-    domain = models.Domain.query.get(domain_name) or flask.abort(404)
+    domain = models.Domain.query.get(domain_name) or \
+             models.Alternative.query.get(domain_name) or \
+             flask.abort(404)
     return flask.jsonify(domain.name)
 
 


### PR DESCRIPTION
At present postfix checks this view for matches in the domain table and is used to accept/deny messages sent into it however it never checks for matches in the alternative table.

Fixes #718