### PR TITLE
Update .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,10 +1,16 @@
-rules:
-  default: null
-  branches:
-    master:
-      protection:
-        required_status_checks:
-          contexts:
-            - continuous-integration/travis-ci 
-        required_pull_request_reviews:
-          required_approving_review_count: 2
+pull_request_rules:
+  - name: Successful travis and 2 approved reviews
+    conditions:
+      - status-success=continuous-integration/travis-ci/pr
+      - "#approved-reviews-by>=2"
+    actions:
+      merge:
+        method: merge
+  - name: Trusted author, successful travis and 1 approved review
+    conditions:
+      - author~=(kaiyou|muhlemmer|mildred|HorayNarea|adi90x|hoellen|ofthesun9)
+      - status-success=continuous-integration/travis-ci/pr
+      - "#approved-reviews-by>=1"
+    actions:
+      merge:
+        method: merge


### PR DESCRIPTION
Update to new syntax for mergify engine v. 2

Relax review rules for trusted users. The users currently in @Mailu/contributors are listed in a regex. Any pull requests from those users will only need 1 review. My motivation is that trusted users should already make sure their change is tested. So now a submission is always handled by exactly 2 trusted users:
- PR from outside contributor gets reviewed by 2 trusted users
- PR from trusted user gets reviewed by second trusted user.