### PR TITLE
Admin: Prevent redirects during health checking

### DIFF
--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -25,4 +25,4 @@ VOLUME ["/data"]
 
 CMD /start.py
 
-HEALTHCHECK CMD curl -f -L http://localhost/ui || exit 1
+HEALTHCHECK CMD curl -f -L http://localhost/ui/login?next=ui.index || exit 1


### PR DESCRIPTION
I saw in the admin logs redirects for every health-check:

```
admin_1      | 127.0.0.1 - - [05/Dec/2018:15:18:58 +0000] "GET /ui HTTP/1.1" 301 247 "-" "curl/7.61.1"
admin_1      | 127.0.0.1 - - [05/Dec/2018:15:18:58 +0000] "GET /ui/ HTTP/1.1" 302 253 "-" "curl/7.61.1"
admin_1      | 127.0.0.1 - - [05/Dec/2018:15:18:58 +0000] "GET /ui/login?next=ui.index HTTP/1.1" 200 4299 "-" "curl/7.61.1"
```
This commit points the health-check to the correct URL directly.

I see a similar thing in `front` but it;s a redirect to the `http/2` protocol and was unable to force cURL to go there directly.