### PR TITLE
Move the Mailu Docker network to a fixed subnet.

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -50,6 +50,7 @@ DEFAULT_CONFIG = {
     'HOST_WEBMAIL': 'webmail',
     'HOST_FRONT': 'front',
     'HOST_AUTHSMTP': os.environ.get('HOST_SMTP', 'smtp'),
+    'SUBNET': '192.168.203.0/24',
     'POD_ADDRESS_RANGE': None
 }
 

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -10,12 +10,9 @@ import os
 def dovecot_passdb_dict(user_email):
     user = models.User.query.get(user_email) or flask.abort(404)
     allow_nets = []
-    allow_nets.append(
-        app.config.get("POD_ADDRESS_RANGE") or
-        socket.gethostbyname(app.config["HOST_FRONT"])
-    )
-    if os.environ["WEBMAIL"] != "none":
-        allow_nets.append(socket.gethostbyname(app.config["HOST_WEBMAIL"]))
+    allow_nets.append(app.config["SUBNET"])
+    if app.config["POD_ADDRESS_RANGE"]:
+        allow_nets.append(app.config["POD_ADDRESS_RANGE"])
     print(allow_nets)
     return flask.jsonify({
         "password": None,

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -14,7 +14,7 @@ queue_directory = /queue
 message_size_limit = {{ MESSAGE_SIZE_LIMIT }}
 
 # Relayed networks
-mynetworks = 127.0.0.1/32 [::1]/128 {{ RELAYNETS }}
+mynetworks = 127.0.0.1/32 [::1]/128 {{ SUBNET }} {{ RELAYNETS }}
 
 # Empty alias list to override the configuration variable and disable NIS
 alias_maps =
@@ -32,7 +32,8 @@ relayhost = {{ RELAYHOST }}
 recipient_delimiter = {{ RECIPIENT_DELIMITER }}
 
 # Only the front server is allowed to perform xclient
-smtpd_authorized_xclient_hosts={{ FRONT_ADDRESS }} {{ POD_ADDRESS_RANGE }}
+# In kubernetes and Docker swarm, such address cannot be determined using the hostname. Allow for the whole Mailu subnet instead.
+smtpd_authorized_xclient_hosts={{ POD_ADDRESS_RANGE or SUBNET }}
 
 ###############
 # TLS

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -1,6 +1,5 @@
 # Mailu main configuration file
-#
-# Most configuration variables can be modified through the Web interface,
+## Most configuration variables can be modified through the Web interface,
 # these few settings must however be configured before starting the mail
 # server and require a restart upon change.
 
@@ -20,6 +19,9 @@ SECRET_KEY=ChangeMeChangeMe
 # Address where listening ports should bind
 BIND_ADDRESS4=127.0.0.1
 BIND_ADDRESS6=::1
+
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+SUBNET=192.168.203.0/24
 
 # Main mail domain
 DOMAIN=mailu.io
@@ -63,9 +65,9 @@ ANTIVIRUS=none
 # Default: accept messages up to 50MB
 MESSAGE_SIZE_LIMIT=50000000
 
-# Networks granted relay permissions, make sure that you include your Docker
-# internal network (default to 172.17.0.0/16)
-RELAYNETS=172.16.0.0/12
+# Networks granted relay permissions
+# Use this with care, all hosts in this networks will be able to send mail without authentication!
+RELAYNETS=
 
 # Will relay all outgoing mails if configured
 RELAYHOST=

--- a/docs/compose/docker-compose.yml
+++ b/docs/compose/docker-compose.yml
@@ -104,3 +104,11 @@ services:
     image: mailu/fetchmail:$VERSION
     restart: always
     env_file: .env
+
+  networks:
+    default:
+      driver: bridge
+      ipam:
+      driver: default
+      config:
+        - subnet: $SUBNET

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -24,6 +24,11 @@ The ``HOSTNAMES`` are all public hostnames for the mail server. Mailu supports
 a mail server with multiple hostnames. The first declared hostname is the main
 hostname and will be exposed over SMTP, IMAP, etc.
 
+The ``SUBNET`` defines the address range of the docker network used by Mailu.
+This should not conflict with any networks to which your system is connected.
+(Internal and external!). Normally this does not need to be changed,
+unless there is a conflict with existing networks.
+
 The ``POSTMASTER`` is the local part of the postmaster email address. It is
 recommended to setup a generic value and later configure a mail alias for that
 address.
@@ -40,9 +45,9 @@ be too low to avoid dropping legitimate emails and should not be too high to
 avoid filling the disks with large junk emails.
 
 The ``RELAYNETS`` are network addresses for which mail is relayed for free with
-no authentication required. This should be used with great care. It is
-recommended to include your Docker internal network addresses if other Docker
-containers use Mailu as their mail relay.
+no authentication required. This should be used with great care. If you want other
+Docker services' outbound mail to be relayed, you can set this to ``172.16.0.0/12``
+to include **all** Docker networks. The default is to leave this empty.
 
 The ``RELAYHOST`` is an optional address of a mail server relaying all outgoing
 mail.

--- a/services/rspamd/conf/worker-controller.inc
+++ b/services/rspamd/conf/worker-controller.inc
@@ -1,4 +1,4 @@
 type = "controller";
 bind_socket = "*:11334";
 password = "mailu";
-secure_ip = "{% if POD_ADDRESS_RANGE %}{{ POD_ADDRESS_RANGE }}{% else %}{{ FRONT_ADDRESS }}{% endif %}";
+secure_ip = "{{ POD_ADDRESS_RANGE or SUBNET }}";

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -146,8 +146,7 @@ services:
     depends_on:
       - imap
   {% endif %}
-  
-{% if resolver_enabled %}
+
 networks:
   default:
     driver: bridge
@@ -155,4 +154,3 @@ networks:
       driver: default
       config:
         - subnet: {{ subnet }}
-{% endif %}

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -26,7 +26,7 @@ SECRET_KEY={{ secret(16) }}
 # PUBLIC_IPV6= {{ bind6 }} (default: ::1)
 
 # Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
-SUBNET=192.168.203.0/24
+SUBNET={{ subnet }}
 
 # Main mail domain
 DOMAIN={{ domain }}

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -25,8 +25,8 @@ SECRET_KEY={{ secret(16) }}
 # PUBLIC_IPV4= {{ bind4 }} (default: 127.0.0.1)
 # PUBLIC_IPV6= {{ bind6 }} (default: ::1)
 
-# Subnet
-SUBNET={{ subnet }}
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+SUBNET=192.168.203.0/24
 
 # Main mail domain
 DOMAIN={{ domain }}
@@ -75,9 +75,9 @@ ANTISPAM={{ antispam_enabled or 'none'}}
 # Default: accept messages up to 50MB
 MESSAGE_SIZE_LIMIT={{ message_size_limit or '50000000' }}
 
-# Networks granted relay permissions, make sure that you include your Docker
-# internal network (default to 172.17.0.0/16)
-RELAYNETS={{ relaynets or '172.17.0.0/16' }}
+# Networks granted relay permissions
+# Use this with care, all hosts in this networks will be able to send mail without authentication!
+RELAYNETS=
 
 # Will relay all outgoing mails if configured
 RELAYHOST={{ relayhost }}

--- a/setup/flavors/stack/docker-compose.yml
+++ b/setup/flavors/stack/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "{{ root }}/certs:/certs"
     deploy:
       replicas: {{ front_replicas }}
-      
+
   {% if resolver_enabled %}
   resolver:
     image: mailu/unbound:{{ version }}
@@ -56,8 +56,6 @@ services:
     image: ${DOCKER_ORG:-mailu}/dovecot:${MAILU_VERSION:-{{ version }}}
     env_file: {{ env }}
     environment:
-    # Default to 10.0.1.0/24
-      - POD_ADDRESS_RANGE={{ subnet }}
     volumes:
       - "{{ root }}/mail:/mail"
       - "{{ root }}/overrides:/overrides"
@@ -67,8 +65,6 @@ services:
   smtp:
     image: ${DOCKER_ORG:-mailu}/postfix:${MAILU_VERSION:-{{ version }}}
     env_file: {{ env }}
-    environment:
-      - POD_ADDRESS_RANGE={{ subnet }}
     volumes:
       - "{{ root }}/overrides:/overrides"
     deploy:
@@ -81,8 +77,6 @@ services:
   antispam:
     image: ${DOCKER_ORG:-mailu}/rspamd:${MAILU_VERSION:-{{ version }}}
     env_file: {{ env }}
-    environment:
-      - POD_ADDRESS_RANGE={{ subnet }}
     volumes:
       - "{{ root }}/filter:/var/lib/rspamd"
       - "{{ root }}/dkim:/dkim"

--- a/setup/templates/steps/compose/03_expose.html
+++ b/setup/templates/steps/compose/03_expose.html
@@ -34,9 +34,9 @@ avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</co
 </div>
 
 <div class="form-group">
-  <label>Subnet</label>
+  <label>Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)</label>
   <input class="form-control" type="text" name="subnet" required pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$"
-  		value="192.168.0.0/24">
+    value="192.168.203.0/24">
 </div>
 
 <p>You server will be available under a main hostname but may expose multiple public

--- a/setup/templates/steps/stack/03_expose.html
+++ b/setup/templates/steps/stack/03_expose.html
@@ -11,9 +11,9 @@ you expose it to the world.</p>
 </div>
 
 <div class="form-group">
-  <label>Subnet</label>
+  <label>Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)</label>
   <input class="form-control" type="text" name="subnet" required pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$"
-  		value="192.168.0.0/24">
+    value="192.168.203.0/24">
 </div>
 
 <p>You server will be available under a main hostname but may expose multiple public

--- a/tests/compose/core/docker-compose.yml
+++ b/tests/compose/core/docker-compose.yml
@@ -78,3 +78,12 @@ services:
 
 
   # Webmail
+
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.203.0/24

--- a/tests/compose/core/mailu.env
+++ b/tests/compose/core/mailu.env
@@ -25,6 +25,9 @@ SECRET_KEY=HGZCYGVI6FVG31HS
 # PUBLIC_IPV4= 127.0.0.1 (default: 127.0.0.1)
 # PUBLIC_IPV6=  (default: ::1)
 
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+SUBNET=192.168.203.0/24
+
 # Main mail domain
 DOMAIN=mailu.io
 
@@ -70,9 +73,9 @@ ANTISPAM=none
 # Default: accept messages up to 50MB
 MESSAGE_SIZE_LIMIT=50000000
 
-# Networks granted relay permissions, make sure that you include your Docker
-# internal network (default to 172.17.0.0/16)
-RELAYNETS=172.17.0.0/16
+# Networks granted relay permissions
+# Use this with care, all hosts in this networks will be able to send mail without authentication!
+RELAYNETS=
 
 # Will relay all outgoing mails if configured
 RELAYHOST=

--- a/tests/compose/fetchmail/docker-compose.yml
+++ b/tests/compose/fetchmail/docker-compose.yml
@@ -82,3 +82,12 @@ services:
     env_file: mailu.env
 
   # Webmail
+
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.203.0/24

--- a/tests/compose/fetchmail/mailu.env
+++ b/tests/compose/fetchmail/mailu.env
@@ -25,6 +25,9 @@ SECRET_KEY=JS48Q9KE3B6T97E6
 # PUBLIC_IPV4= 127.0.0.1 (default: 127.0.0.1)
 # PUBLIC_IPV6=  (default: ::1)
 
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+SUBNET=192.168.203.0/24
+
 # Main mail domain
 DOMAIN=mailu.io
 

--- a/tests/compose/fetchmail/mailu.env
+++ b/tests/compose/fetchmail/mailu.env
@@ -70,9 +70,9 @@ ANTISPAM=none
 # Default: accept messages up to 50MB
 MESSAGE_SIZE_LIMIT=50000000
 
-# Networks granted relay permissions, make sure that you include your Docker
-# internal network (default to 172.17.0.0/16)
-RELAYNETS=172.17.0.0/16
+# Networks granted relay permissions
+# Use this with care, all hosts in this networks will be able to send mail without authentication!
+RELAYNETS=
 
 # Will relay all outgoing mails if configured
 RELAYHOST=

--- a/tests/compose/filters/docker-compose.yml
+++ b/tests/compose/filters/docker-compose.yml
@@ -84,3 +84,12 @@ services:
 
 
   # Webmail
+
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.203.0/24

--- a/tests/compose/filters/mailu.env
+++ b/tests/compose/filters/mailu.env
@@ -25,6 +25,9 @@ SECRET_KEY=11H6XURLGE7GW3U1
 # PUBLIC_IPV4= 127.0.0.1 (default: 127.0.0.1)
 # PUBLIC_IPV6=  (default: ::1)
 
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+SUBNET=192.168.203.0/24
+
 # Main mail domain
 DOMAIN=mailu.io
 

--- a/tests/compose/filters/mailu.env
+++ b/tests/compose/filters/mailu.env
@@ -70,9 +70,9 @@ ANTISPAM=none
 # Default: accept messages up to 50MB
 MESSAGE_SIZE_LIMIT=50000000
 
-# Networks granted relay permissions, make sure that you include your Docker
-# internal network (default to 172.17.0.0/16)
-RELAYNETS=172.17.0.0/16
+# Networks granted relay permissions
+# Use this with care, all hosts in this networks will be able to send mail without authentication!
+RELAYNETS=
 
 # Will relay all outgoing mails if configured
 RELAYHOST=

--- a/tests/compose/rainloop/docker-compose.yml
+++ b/tests/compose/rainloop/docker-compose.yml
@@ -86,3 +86,12 @@ services:
       - "/mailu/webmail:/data"
     depends_on:
       - imap
+
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.203.0/24

--- a/tests/compose/rainloop/mailu.env
+++ b/tests/compose/rainloop/mailu.env
@@ -25,6 +25,9 @@ SECRET_KEY=V5J4SHRYVW9PZIQU
 # PUBLIC_IPV4= 127.0.0.1 (default: 127.0.0.1)
 # PUBLIC_IPV6=  (default: ::1)
 
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+SUBNET=192.168.203.0/24
+
 # Main mail domain
 DOMAIN=mailu.io
 

--- a/tests/compose/rainloop/mailu.env
+++ b/tests/compose/rainloop/mailu.env
@@ -70,9 +70,9 @@ ANTISPAM=none
 # Default: accept messages up to 50MB
 MESSAGE_SIZE_LIMIT=50000000
 
-# Networks granted relay permissions, make sure that you include your Docker
-# internal network (default to 172.17.0.0/16)
-RELAYNETS=172.17.0.0/16
+# Networks granted relay permissions
+# Use this with care, all hosts in this networks will be able to send mail without authentication!
+RELAYNETS=
 
 # Will relay all outgoing mails if configured
 RELAYHOST=

--- a/tests/compose/roundcube/docker-compose.yml
+++ b/tests/compose/roundcube/docker-compose.yml
@@ -86,3 +86,12 @@ services:
       - "/mailu/webmail:/data"
     depends_on:
       - imap
+
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.203.0/24

--- a/tests/compose/roundcube/mailu.env
+++ b/tests/compose/roundcube/mailu.env
@@ -25,6 +25,9 @@ SECRET_KEY=PGGO2JRQ59QV3DW7
 # PUBLIC_IPV4= 127.0.0.1 (default: 127.0.0.1)
 # PUBLIC_IPV6=  (default: ::1)
 
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+SUBNET=192.168.203.0/24
+
 # Main mail domain
 DOMAIN=mailu.io
 

--- a/tests/compose/roundcube/mailu.env
+++ b/tests/compose/roundcube/mailu.env
@@ -70,9 +70,9 @@ ANTISPAM=none
 # Default: accept messages up to 50MB
 MESSAGE_SIZE_LIMIT=50000000
 
-# Networks granted relay permissions, make sure that you include your Docker
-# internal network (default to 172.17.0.0/16)
-RELAYNETS=172.17.0.0/16
+# Networks granted relay permissions
+# Use this with care, all hosts in this networks will be able to send mail without authentication!
+RELAYNETS=
 
 # Will relay all outgoing mails if configured
 RELAYHOST=

--- a/tests/compose/webdav/docker-compose.yml
+++ b/tests/compose/webdav/docker-compose.yml
@@ -84,3 +84,12 @@ services:
 
 
   # Webmail
+
+
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 192.168.203.0/24

--- a/tests/compose/webdav/mailu.env
+++ b/tests/compose/webdav/mailu.env
@@ -25,6 +25,9 @@ SECRET_KEY=XVDDSWOAGVF5J9QJ
 # PUBLIC_IPV4= 127.0.0.1 (default: 127.0.0.1)
 # PUBLIC_IPV6=  (default: ::1)
 
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
+SUBNET=192.168.203.0/24
+
 # Main mail domain
 DOMAIN=mailu.io
 

--- a/tests/compose/webdav/mailu.env
+++ b/tests/compose/webdav/mailu.env
@@ -70,9 +70,9 @@ ANTISPAM=none
 # Default: accept messages up to 50MB
 MESSAGE_SIZE_LIMIT=50000000
 
-# Networks granted relay permissions, make sure that you include your Docker
-# internal network (default to 172.17.0.0/16)
-RELAYNETS=172.17.0.0/16
+# Networks granted relay permissions
+# Use this with care, all hosts in this networks will be able to send mail without authentication!
+RELAYNETS=
 
 # Will relay all outgoing mails if configured
 RELAYHOST=


### PR DESCRIPTION
This will make network configuration and host based authentication
more robust, across different deployment platforms.
The options `RELAYNETS` and`POD_ADDRESS_RANGE` are kept for compatibility.
However, their usage have become optional.

This is a re-submission of PR #721