### PR TITLE
Dynamic attachment size limit

### DIFF
--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -61,6 +61,7 @@ ANTIVIRUS=none
 
 # Message size limit in bytes
 # Default: accept messages up to 50MB
+# Max attachment size will be 33% smaller
 MESSAGE_SIZE_LIMIT=50000000
 
 # Networks granted relay permissions, make sure that you include your Docker

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -73,6 +73,7 @@ ANTISPAM={{ antispam_enabled or 'none'}}
 
 # Message size limit in bytes
 # Default: accept messages up to 50MB
+# Max attachment size will be 33% smaller
 MESSAGE_SIZE_LIMIT={{ message_size_limit or '50000000' }}
 
 # Networks granted relay permissions, make sure that you include your Docker

--- a/webmails/rainloop/Dockerfile
+++ b/webmails/rainloop/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
  && rm -rf /var/lib/apt/lists
 
 COPY include.php /var/www/html/include.php
-COPY php.ini /usr/local/etc/php/conf.d/rainloop.ini
+COPY php.ini /php.ini
 
 COPY config.ini /config.ini
 COPY default.ini /default.ini

--- a/webmails/rainloop/config.ini
+++ b/webmails/rainloop/config.ini
@@ -1,7 +1,7 @@
 ; RainLoop Webmail configuration file
 
 [webmail]
-attachment_size_limit = 25
+attachment_size_limit = {{ MAX_FILESIZE }}
 
 [security]
 allow_admin_panel = Off

--- a/webmails/rainloop/php.ini
+++ b/webmails/rainloop/php.ini
@@ -1,3 +1,4 @@
 date.timezone=UTC
-upload_max_filesize = 25M
-post_max_size = 25M
+upload_max_filesize = {{ MAX_FILESIZE }}M
+post_max_size = {{ MAX_FILESIZE }}M
+

--- a/webmails/rainloop/start.py
+++ b/webmails/rainloop/start.py
@@ -10,6 +10,8 @@ convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()
 os.environ["FRONT_ADDRESS"] = os.environ.get("FRONT_ADDRESS", "front")
 os.environ["IMAP_ADDRESS"] = os.environ.get("IMAP_ADDRESS", "imap")
 
+os.environ["MAX_FILESIZE"] = str(int(int(os.environ.get("MESSAGE_SIZE_LIMIT"))*0.66/1048576))
+
 base = "/data/_data_/_default_/"
 shutil.rmtree(base + "domains/", ignore_errors=True)
 os.makedirs(base + "domains", exist_ok=True)
@@ -17,6 +19,7 @@ os.makedirs(base + "configs", exist_ok=True)
 
 convert("/default.ini", "/data/_data_/_default_/domains/default.ini")
 convert("/config.ini", "/data/_data_/_default_/configs/config.ini")
+convert("/php.ini", "/usr/local/etc/php/conf.d/rainloop.ini")
 
 os.system("chown -R www-data:www-data /data")
 

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
 ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.3.8/roundcubemail-1.3.8-complete.tar.gz
 
 RUN apt-get update && apt-get install -y \
-      zlib1g-dev \
+      zlib1g-dev python3-jinja2 \
  && docker-php-ext-install zip \
  && echo date.timezone=UTC > /usr/local/etc/php/conf.d/timezone.ini \
  && rm -rf /var/www/html/ \
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
  && chown -R www-data: logs temp \
  && rm -rf /var/lib/apt/lists
 
-COPY php.ini /usr/local/etc/php/conf.d/roundcube.ini
+COPY php.ini /php.ini
 COPY config.inc.php /var/www/html/config/
 COPY start.py /start.py
 

--- a/webmails/roundcube/php.ini
+++ b/webmails/roundcube/php.ini
@@ -1,3 +1,4 @@
 date.timezone=UTC
-upload_max_filesize = 25M
-post_max_size = 25M
+upload_max_filesize = {{ MAX_FILESIZE }}M
+post_max_size = {{ MAX_FILESIZE }}M
+

--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -1,6 +1,13 @@
 #!/usr/bin/python3
 
 import os
+import jinja2
+
+convert = lambda src, dst: open(dst, "w").write(jinja2.Template(open(src).read()).render(**os.environ))
+
+os.environ["MAX_FILESIZE"] = str(int(int(os.environ.get("MESSAGE_SIZE_LIMIT"))*0.66/1048576))
+
+convert("/php.ini", "/usr/local/etc/php/conf.d/roundcube.ini")
 
 # Fix some permissions
 os.system("mkdir -p /data/gpg")


### PR DESCRIPTION
Max attachment size will be 33% smaller that MESSAGE_SIZE_LIMIT defined in env file.
This closes #542.