### PR TITLE
Increase health start period for clamav's DB download

### DIFF
--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -15,4 +15,4 @@ VOLUME ["/data"]
 
 CMD /start.py
 
-HEALTHCHECK CMD /health.sh
+HEALTHCHECK --start-period=350s CMD /health.sh


### PR DESCRIPTION
I've seen some health check failures when ClamAV is downloading the virus DB. Like in other services, this causes container re-scheduling in docker stack.