### PR TITLE
Fixes #738 regarding application context

### DIFF
--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -8,7 +8,6 @@ def create_app_from_config(config):
     """ Create a new application based on the given configuration
     """
     app = flask.Flask(__name__)
-    app.app_context().push()
     app.cli.add_command(manage.mailu)
 
     # Bootstrap is used for basic JS and CSS loading

--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -9,7 +9,7 @@ import base64
 
 @internal.route("/auth/email")
 @utils.limiter.limit(
-    app.config["AUTH_RATELIMIT"],
+    lambda: app.config["AUTH_RATELIMIT"],
     lambda: flask.request.headers["Client-Ip"]
 )
 def nginx_authentication():

--- a/core/admin/requirements-prod.txt
+++ b/core/admin/requirements-prod.txt
@@ -1,13 +1,13 @@
 alembic==1.0.2
 asn1crypto==0.24.0
 Babel==2.6.0
-bcrypt==3.1.4
+bcrypt==3.1.5
 blinker==1.4
 cffi==1.11.5
 Click==7.0
 cryptography==2.3.1
 decorator==4.3.0
-dnspython==1.15.0
+dnspython==1.16.0
 dominate==2.3.4
 Flask==1.0.2
 Flask-Babel==0.12.2
@@ -15,7 +15,7 @@ Flask-Bootstrap==3.3.7.1
 Flask-DebugToolbar==0.10.1
 Flask-Limiter==1.0.1
 Flask-Login==0.4.1
-Flask-Migrate==2.3.0
+Flask-Migrate==2.3.1
 Flask-Script==2.0.6
 Flask-SQLAlchemy==2.3.2
 Flask-WTF==0.14.2
@@ -35,10 +35,11 @@ python-dateutil==2.7.5
 python-editor==1.0.3
 pytz==2018.7
 PyYAML==3.13
-redis==2.10.6
+redis==3.0.1
 six==1.11.0
 SQLAlchemy==1.2.13
 tabulate==0.8.2
+tenacity==5.0.2
 validators==0.12.2
 visitor==0.1.3
 Werkzeug==0.14.1


### PR DESCRIPTION
Fix the way we handle the application context
    
The init script was pushing an application context, which maked
flask.g global and persisted across requests. This was evaluated
to have a minimal security impact.
    
This explains/fixes #738: flask_wtf caches the csrf token in the
application context to have a single token per request, and only
sets the session attribute after the first generation.
