### PR TITLE
1.5 autobuild

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,29 @@
+sudo: required
+services: docker
+addons:
+  apt:
+    packages:
+      - docker-ce
+
+env:
+  - MAILU_VERSION=$TRAVIS_BRANCH
+language: python
+python:
+  - "3.6"
+install:
+  - sudo curl -L https://github.com/docker/compose/releases/download/1.23.0-rc3/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+  - sudo chmod +x /usr/local/bin/docker-compose
+
+before_script:
+  - docker-compose -v
+  - docker-compose -f tests/build.yml build
+
 script:
   - /bin/true
+
+deploy:
+  provider: script
+  script: bash tests/deploy.sh
+  on:
+    all_branches: true
+    condition: -n $DOCKER_UN

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:edge
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
  && apk add --no-cache radicale@testing py-dulwich@testing

--- a/tests/build.yml
+++ b/tests/build.yml
@@ -1,0 +1,52 @@
+version: '3'
+
+services:
+
+  front:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}nginx:${MAILU_VERSION:-local}
+    build: ../core/nginx
+
+  imap:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}dovecot:${MAILU_VERSION:-local}
+    build: ../core/dovecot
+
+  smtp:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}postfix:${MAILU_VERSION:-local}
+    build: ../core/postfix
+
+  antispam:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}rspamd:${MAILU_VERSION:-local}
+    build: ../services/rspamd
+
+  antivirus:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}clamav:${MAILU_VERSION:-local}
+    build: ../optional/clamav
+
+  webdav:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}radicale:${MAILU_VERSION:-local}
+    build: ../optional/radicale
+
+  admin:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}admin:${MAILU_VERSION:-local}
+    build: ../core/admin
+
+  roundcube:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}roundcube:${MAILU_VERSION:-local}
+    build: ../webmails/roundcube
+
+  rainloop:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}rainloop:${MAILU_VERSION:-local}
+    build: ../webmails/rainloop
+
+  fetchmail:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}fetchmail:${MAILU_VERSION:-local}
+    build: ../services/fetchmail
+
+  none:
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}none:${MAILU_VERSION:-local}
+    build: ../core/none
+
+# Uncomment next section after docs Dockerfile creation.
+#  docs:
+#    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}docs:${MAILU_VERSION:-local}
+#    build: ../docs

--- a/tests/build.yml
+++ b/tests/build.yml
@@ -49,4 +49,7 @@ services:
 # Uncomment next section after docs Dockerfile creation.
 #  docs:
 #    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX}docs:${MAILU_VERSION:-local}
-#    build: ../docs
+#    build:
+#      context: ../docs
+#      args:
+#        version: ${MAILU_VERSION:-local}

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker login -u $DOCKER_UN -p $DOCKER_PW
+docker-compose -f tests/build.yml push


### PR DESCRIPTION
In preparation of a multi-version documentation setup, I considered it would be helpful to move 1.5 to travis building also. This is a simplified back port, without any testing.

@kaiyou, If you agree with this, I'll disable the autobuild on Docker hub, before merging this PR. This is to prevent collisions.