### PR TITLE
Disable ServerSignature of apache2 servers in rainloop and roundcube

### DIFF
--- a/webmails/rainloop/Dockerfile
+++ b/webmails/rainloop/Dockerfile
@@ -2,7 +2,8 @@ FROM php:7.2-apache
 #Shared layer between rainloop and roundcube
 RUN apt-get update && apt-get install -y \
   python3 curl \
-  && rm -rf /var/lib/apt/lists
+  && rm -rf /var/lib/apt/lists \
+  && echo "ServerSignature Off" >> /etc/apache2/apache2.conf
 
 ENV RAINLOOP_URL https://github.com/RainLoop/rainloop-webmail/releases/download/v1.12.1/rainloop-community-1.12.1.zip
 

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -2,7 +2,8 @@ FROM php:7.2-apache
 #Shared layer between rainloop and roundcube
 RUN apt-get update && apt-get install -y \
   python3 curl \
-  && rm -rf /var/lib/apt/lists
+  && rm -rf /var/lib/apt/lists \
+  && echo "ServerSignature Off" >> /etc/apache2/apache2.conf
 
 ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.3.8/roundcubemail-1.3.8-complete.tar.gz
 


### PR DESCRIPTION
Closes #562 
Disables ServerSignature on error pages.
Setting ServerTokens to Prod shouldn't be necessary because the server header is removed by nginx and the ServerSignature is already disabled. 