### PR TITLE
Option to disable full text search (lucene)

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -7,6 +7,7 @@ postmaster_address = {{ POSTMASTER }}@{{ DOMAIN }}
 hostname = {{ HOSTNAMES.split(",")[0] }}
 submission_host = {{ FRONT_ADDRESS }}
 
+{% if DISABLE_FTS_LUCENE != 'true' %}
 ###############
 # Full-text search
 ###############
@@ -20,6 +21,7 @@ plugin {
 
   fts_lucene = whitespace_chars=@.
 }
+{% endif %}
 
 ###############
 # Mailboxes

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -3,6 +3,10 @@
 # these few settings must however be configured before starting the mail
 # server and require a restart upon change.
 
+# Set this to `true` to disable full text search by lucene (value: true, false)
+# This is a workaround for the bug in issue #751 (indexer-worker crashes)
+DISABLE_FTS_LUCENE=false
+
 ###################################
 # Common configuration variables
 ###################################


### PR DESCRIPTION
This is a workaround for the bug in issue #751.

Flag behavior:

- If flag is not set / missing: `fts_lucene` stays enabled.
- Flag set to `false`: `fts_lucene` stays enabled
- Flag set to `true`: `fts_lucene` will be disabled

With `fts_lucene` disabled it seems that search in webmail (Rainloop) still works, bit probably with limitations.

Before coming to this solution, I've tried to disable only the `fts_autoindex`, that worked for incoming mail. But it still crashed the indexer-worker when doing a search so that wasn't a real option.

Disabling `fts_lucene` has been tested by me on my test server and seems to be stable, even when copying in a big amount of mail into the mailbox.