### PR TITLE
Restore VERSION_TAG template

### DIFF
--- a/docs/_templates/page.html
+++ b/docs/_templates/page.html
@@ -1,0 +1,4 @@
+{%- extends "layout.html" %}
+{% block body %}
+  {{ body|replace("VERSION_TAG", version) }}
+{% endblock %}


### PR DESCRIPTION
` docs/_templates/page.html` was deleted in commit https://github.com/Mailu/Mailu/commit/8fa80c15894da57131cea00f8274737d37d8054f, breaking the `wget` download example in `master/compose/setup.html`.

Related to issue #777.