### PR TITLE
fix broken webmail and logo url in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ v1.6.0 - unreleased
 - Bug: Hostname resolving in start.py should retry on failure [docker swarm]  ([#555](https://github.com/Mailu/Mailu/issues/555))
 - Bug: Error when trying to log in with an account without domain ([#585](https://github.com/Mailu/Mailu/issues/585))
 - Bug: Fix rainloop permissions ([#637](https://github.com/Mailu/Mailu/issues/637))
+- Bug: Fix broken webmail and logo url in admin ([#792](https://github.com/Mailu/Mailu/issues/792))
 
 v1.5.1 - 2017-11-21
 -------------------

--- a/core/admin/mailu/ui/templates/base.html
+++ b/core/admin/mailu/ui/templates/base.html
@@ -28,7 +28,7 @@ class="hold-transition skin-blue sidebar-mini"
   <div class="wrapper">
     {% block navbar %}
     <header class="main-header">
-      <a href="/admin/" class="logo">
+      <a href="{{ config["WEB_ADMIN"] }}" class="logo">
         <span class="logo-lg">{{ config["SITENAME"] }}</span>
       </a>
     </header>

--- a/core/admin/mailu/ui/templates/sidebar.html
+++ b/core/admin/mailu/ui/templates/sidebar.html
@@ -69,7 +69,7 @@
     <li class="header">{% trans %}Go to{% endtrans %}</li>
     {% if config["WEBMAIL"] != "none" %}
     <li>
-      <a href="{{ config["WEB_WEBMAIL"] }}/">
+      <a href="{{ config["WEB_WEBMAIL"] }}">
         <i class="fa fa-envelope-o"></i> <span>{% trans %}Webmail{% endtrans %}</span>
       </a>
     </li>


### PR DESCRIPTION
This fixes two different broken links: 
- If `WEB_WEBMAIL` is set to `'/'`, the url to the webmail in the admin sidebar was broken (double slash) 
- If `WEB_ADMIN` is set to something different then `"/admin"`, the logo still redirects to the default value