### PR TITLE
Upgrade PyYAML

### DIFF
--- a/core/admin/requirements-prod.txt
+++ b/core/admin/requirements-prod.txt
@@ -34,7 +34,7 @@ pyOpenSSL==18.0.0
 python-dateutil==2.7.5
 python-editor==1.0.3
 pytz==2018.7
-PyYAML==4.2b1
+PyYAML==4.2b4
 redis==3.0.1
 six==1.11.0
 SQLAlchemy==1.2.13

--- a/core/admin/requirements-prod.txt
+++ b/core/admin/requirements-prod.txt
@@ -34,7 +34,7 @@ pyOpenSSL==18.0.0
 python-dateutil==2.7.5
 python-editor==1.0.3
 pytz==2018.7
-PyYAML==3.13
+PyYAML==4.2b1
 redis==3.0.1
 six==1.11.0
 SQLAlchemy==1.2.13


### PR DESCRIPTION
[CVE-2017-18342](https://nvd.nist.gov/vuln/detail/CVE-2017-18342)
Vulnerable versions: < 4.2b1
Patched version: 4.2b1
In PyYAML before 4.1, the yaml.load() API could execute arbitrary code. In other words, yaml.safe_load is not used.