### PR TITLE
Add more tests: Auto-Forwarding and Sending to an Alias

### DIFF
--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -1,0 +1,60 @@
+import smtplib
+import imaplib
+import time
+import sys
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+import ntpath
+from email.mime.base import MIMEBase
+from email import encoders
+
+msg = MIMEMultipart()
+msg['From'] = "admin@mailu.io"
+msg['To'] = "forwardinguser@mailu.io"
+msg['Subject'] = "Alias Test"
+msg.attach(MIMEText("Alias Text", 'plain'))
+
+try:
+    smtp_server = smtplib.SMTP('localhost')
+    smtp_server.set_debuglevel(1)
+    smtp_server.connect('localhost', 587)
+    smtp_server.ehlo()
+    smtp_server.starttls()
+    smtp_server.ehlo()
+    smtp_server.login("admin@mailu.io", "password")
+
+    smtp_server.sendmail("admin@mailu.io", "alltheusers@mailu.io", msg.as_string())
+    smtp_server.quit()
+except:
+    sys.exit(25)
+
+time.sleep(30)
+
+for user in ['user@mailu.io', 'admin@mailu.io', 'user/with/slash@mailu.io']:
+    try:
+        imap_server = imaplib.IMAP4_SSL('localhost')
+        imap_server.login(user, 'password')
+    except Exception as exc:
+        print("Failed with:", exc)
+        sys.exit(110)
+
+    stat, count = imap_server.select('inbox')
+    try:
+        stat, data = imap_server.fetch(count[0], '(UID BODY[TEXT])')
+    except :
+        sys.exit(99)
+
+    if "Alias Text" in str(data[0][1]):
+        print("Success: Mail is in aliassed inbox", user)
+    else:
+        print("Failed receiving email in aliassed inbox", user)
+        sys.exit(99)
+
+    typ, data = imap_server.search(None, 'ALL')
+    for num in data[0].split():
+       imap_server.store(num, '+FLAGS', '\\Deleted')
+    imap_server.expunge()
+
+    imap_server.close()
+    imap_server.logout()
+

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -4,9 +4,6 @@ import time
 import sys
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import ntpath
-from email.mime.base import MIMEBase
-from email import encoders
 
 msg = MIMEMultipart()
 msg['From'] = "admin@mailu.io"
@@ -52,7 +49,7 @@ for user in ['user@mailu.io', 'admin@mailu.io', 'user/with/slash@mailu.io']:
 
     typ, data = imap_server.search(None, 'ALL')
     for num in data[0].split():
-       imap_server.store(num, '+FLAGS', '\\Deleted')
+        imap_server.store(num, '+FLAGS', '\\Deleted')
     imap_server.expunge()
 
     imap_server.close()

--- a/tests/compose/core/00_create_users.sh
+++ b/tests/compose/core/00_create_users.sh
@@ -1,4 +1,5 @@
 echo "Creating users ..."
 docker-compose -f tests/compose/core/docker-compose.yml exec admin flask mailu admin admin mailu.io password || exit 1
 docker-compose -f tests/compose/core/docker-compose.yml exec admin flask mailu user user mailu.io 'password' 'SHA512-CRYPT' || exit 1
+docker-compose -f tests/compose/core/docker-compose.yml exec admin flask mailu user 'user/with/slash' mailu.io 'password' 'SHA512-CRYPT' || exit 1
 echo "Admin and user successfully created!"

--- a/tests/compose/core/02_forward_test.sh
+++ b/tests/compose/core/02_forward_test.sh
@@ -1,0 +1,21 @@
+cat << EOF | docker-compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu config-update -v 1
+users:
+  - localpart: forwardinguser
+    password_hash: "\$1\$F2OStvi1\$Q8hBIHkdJpJkJn/TrMIZ9/"
+    hash_scheme: MD5-CRYPT
+    domain: mailu.io
+    forward_enabled: true
+    forward_destination: ["user@mailu.io"]
+EOF
+
+python3 tests/forward_test.py
+
+cat << EOF | docker-compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu config-update -v 1
+users:
+  - localpart: forwardinguser
+    password_hash: "\$1\$F2OStvi1\$Q8hBIHkdJpJkJn/TrMIZ9/"
+    hash_scheme: MD5-CRYPT
+    domain: mailu.io
+    forward_enabled: false
+    forward_destination: []
+EOF

--- a/tests/compose/core/03_alias_test.sh
+++ b/tests/compose/core/03_alias_test.sh
@@ -1,0 +1,12 @@
+cat << EOF | docker-compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu config-update -v 1
+aliases:
+  - localpart: alltheusers
+    domain: mailu.io
+    destination: "admin@mailu.io,user@mailu.io,user/with/slash@mailu.io"
+EOF
+
+python3 tests/alias_test.py
+
+cat << EOF | docker-compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu config-update -v 1
+aliases: []
+EOF

--- a/tests/compose/core/04_reply_test.sh
+++ b/tests/compose/core/04_reply_test.sh
@@ -1,0 +1,21 @@
+cat << EOF | docker-compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu config-update -v 1
+users:
+  - localpart: replyuser
+    password_hash: "\$1\$F2OStvi1\$Q8hBIHkdJpJkJn/TrMIZ9/"
+    hash_scheme: MD5-CRYPT
+    domain: mailu.io
+    reply_enabled: true
+    reply_subject: This will not reach me
+    reply_body: Cause this is just a test
+EOF
+
+python3 tests/reply_test.py
+
+cat << EOF | docker-compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu config-update -v 1
+users:
+  - localpart: replyuser
+    password_hash: "\$1\$F2OStvi1\$Q8hBIHkdJpJkJn/TrMIZ9/"
+    hash_scheme: MD5-CRYPT
+    domain: mailu.io
+    reply_enabled: false
+EOF

--- a/tests/compose/core/mailu.env
+++ b/tests/compose/core/mailu.env
@@ -6,8 +6,6 @@
 # For a detailed list of configuration variables, see the documentation at
 # https://mailu.io
 
-DISABLE_FTS_LUCENE=true
-
 ###################################
 # Common configuration variables
 ###################################

--- a/tests/compose/core/mailu.env
+++ b/tests/compose/core/mailu.env
@@ -6,6 +6,8 @@
 # For a detailed list of configuration variables, see the documentation at
 # https://mailu.io
 
+DISABLE_FTS_LUCENE=true
+
 ###################################
 # Common configuration variables
 ###################################

--- a/tests/email_test.py
+++ b/tests/email_test.py
@@ -29,7 +29,7 @@ try:
     smtp_server.starttls()
     smtp_server.ehlo()
     smtp_server.login("admin@mailu.io", "password")
-    
+
     smtp_server.sendmail("admin@mailu.io", "user@mailu.io", msg.as_string())
     smtp_server.quit()
 except:
@@ -47,13 +47,19 @@ stat, count = imap_server.select('inbox')
 try:
     stat, data = imap_server.fetch(count[0], '(UID BODY[TEXT])')
 except :
+    print("Couldn’t list email in imap inbox")
     sys.exit(99)
-        
+
 if sys.argv[1] in str(data[0][1]):
     print("Success sending and receiving email!")
 else:
-    print("Failed receiving email with message %s" % sys.argv[1])
+    print("Failed receiving email with message %s, message not contained" % sys.argv[1])
     sys.exit(99)
-    
+
+typ, data = imap_server.search(None, 'ALL')
+for num in data[0].split():
+   imap_server.store(num, '+FLAGS', '\\Deleted')
+imap_server.expunge()
+
 imap_server.close()
 imap_server.logout()

--- a/tests/email_test.py
+++ b/tests/email_test.py
@@ -58,7 +58,7 @@ else:
 
 typ, data = imap_server.search(None, 'ALL')
 for num in data[0].split():
-   imap_server.store(num, '+FLAGS', '\\Deleted')
+    imap_server.store(num, '+FLAGS', '\\Deleted')
 imap_server.expunge()
 
 imap_server.close()

--- a/tests/forward_test.py
+++ b/tests/forward_test.py
@@ -4,9 +4,6 @@ import time
 import sys
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import ntpath
-from email.mime.base import MIMEBase
-from email import encoders
 
 msg = MIMEMultipart()
 msg['From'] = "admin@mailu.io"
@@ -52,7 +49,7 @@ else:
 
 typ, data = imap_server.search(None, 'ALL')
 for num in data[0].split():
-   imap_server.store(num, '+FLAGS', '\\Deleted')
+    imap_server.store(num, '+FLAGS', '\\Deleted')
 imap_server.expunge()
 
 imap_server.close()
@@ -80,7 +77,7 @@ else:
 
 typ, data = imap_server.search(None, 'ALL')
 for num in data[0].split():
-   imap_server.store(num, '+FLAGS', '\\Deleted')
+    imap_server.store(num, '+FLAGS', '\\Deleted')
 imap_server.expunge()
 
 imap_server.close()

--- a/tests/forward_test.py
+++ b/tests/forward_test.py
@@ -1,0 +1,87 @@
+import smtplib
+import imaplib
+import time
+import sys
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+import ntpath
+from email.mime.base import MIMEBase
+from email import encoders
+
+msg = MIMEMultipart()
+msg['From'] = "admin@mailu.io"
+msg['To'] = "forwardinguser@mailu.io"
+msg['Subject'] = "Forward Test"
+msg.attach(MIMEText("Forward Text", 'plain'))
+
+try:
+    smtp_server = smtplib.SMTP('localhost')
+    smtp_server.set_debuglevel(1)
+    smtp_server.connect('localhost', 587)
+    smtp_server.ehlo()
+    smtp_server.starttls()
+    smtp_server.ehlo()
+    smtp_server.login("admin@mailu.io", "password")
+
+    smtp_server.sendmail("admin@mailu.io", "forwardinguser@mailu.io", msg.as_string())
+    smtp_server.quit()
+except:
+    sys.exit(25)
+
+time.sleep(30)
+
+# check forward target
+try:
+    imap_server = imaplib.IMAP4_SSL('localhost')
+    imap_server.login('user@mailu.io', 'password')
+except Exception as exc:
+    print("Failed with:", exc)
+    sys.exit(110)
+
+stat, count = imap_server.select('inbox')
+try:
+    stat, data = imap_server.fetch(count[0], '(UID BODY[TEXT])')
+except :
+    sys.exit(99)
+
+if "Forward Text" in str(data[0][1]):
+    print("Success: Mail is in forwarded inbox")
+else:
+    print("Failed receiving email in forwarded inbox")
+    sys.exit(99)
+
+typ, data = imap_server.search(None, 'ALL')
+for num in data[0].split():
+   imap_server.store(num, '+FLAGS', '\\Deleted')
+imap_server.expunge()
+
+imap_server.close()
+imap_server.logout()
+
+# check original user
+try:
+    imap_server = imaplib.IMAP4_SSL('localhost')
+    imap_server.login('forwardinguser@mailu.io', 'password')
+except Exception as exc:
+    print("Failed with:", exc)
+    sys.exit(110)
+
+stat, count = imap_server.select('inbox')
+try:
+    stat, data = imap_server.fetch(count[0], '(UID BODY[TEXT])')
+except :
+    sys.exit(99)
+
+if "Forward Text" in str(data[0][1]):
+    print("Success: Mail is in forwarding inbox")
+else:
+    print("Failed receiving email in forwarding inbox")
+    sys.exit(99)
+
+typ, data = imap_server.search(None, 'ALL')
+for num in data[0].split():
+   imap_server.store(num, '+FLAGS', '\\Deleted')
+imap_server.expunge()
+
+imap_server.close()
+imap_server.logout()

--- a/tests/reply_test.py
+++ b/tests/reply_test.py
@@ -4,9 +4,6 @@ import time
 import sys
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-import ntpath
-from email.mime.base import MIMEBase
-from email import encoders
 
 msg = MIMEMultipart()
 msg['From'] = "admin@mailu.io"
@@ -52,7 +49,7 @@ else:
 
 typ, data = imap_server.search(None, 'ALL')
 for num in data[0].split():
-   imap_server.store(num, '+FLAGS', '\\Deleted')
+    imap_server.store(num, '+FLAGS', '\\Deleted')
 imap_server.expunge()
 
 imap_server.close()
@@ -80,7 +77,7 @@ else:
 
 typ, data = imap_server.search(None, 'ALL')
 for num in data[0].split():
-   imap_server.store(num, '+FLAGS', '\\Deleted')
+    imap_server.store(num, '+FLAGS', '\\Deleted')
 imap_server.expunge()
 
 imap_server.close()

--- a/tests/reply_test.py
+++ b/tests/reply_test.py
@@ -1,0 +1,87 @@
+import smtplib
+import imaplib
+import time
+import sys
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+import ntpath
+from email.mime.base import MIMEBase
+from email import encoders
+
+msg = MIMEMultipart()
+msg['From'] = "admin@mailu.io"
+msg['To'] = "replyusea@mailu.io"
+msg['Subject'] = "Reply Test"
+msg.attach(MIMEText("Reply Text", 'plain'))
+
+try:
+    smtp_server = smtplib.SMTP('localhost')
+    smtp_server.set_debuglevel(1)
+    smtp_server.connect('localhost', 587)
+    smtp_server.ehlo()
+    smtp_server.starttls()
+    smtp_server.ehlo()
+    smtp_server.login("admin@mailu.io", "password")
+
+    smtp_server.sendmail("admin@mailu.io", "replyuser@mailu.io", msg.as_string())
+    smtp_server.quit()
+except:
+    sys.exit(25)
+
+time.sleep(30)
+
+# check original target
+try:
+    imap_server = imaplib.IMAP4_SSL('localhost')
+    imap_server.login('replyuser@mailu.io', 'password')
+except Exception as exc:
+    print("Failed with:", exc)
+    sys.exit(110)
+
+stat, count = imap_server.select('inbox')
+try:
+    stat, data = imap_server.fetch(count[0], '(UID BODY[TEXT])')
+except :
+    sys.exit(99)
+
+if "Reply Text" in str(data[0][1]):
+    print("Success: Mail is in target inbox")
+else:
+    print("Failed receiving email in target inbox")
+    sys.exit(99)
+
+typ, data = imap_server.search(None, 'ALL')
+for num in data[0].split():
+   imap_server.store(num, '+FLAGS', '\\Deleted')
+imap_server.expunge()
+
+imap_server.close()
+imap_server.logout()
+
+# check original/replied user
+try:
+    imap_server = imaplib.IMAP4_SSL('localhost')
+    imap_server.login('admin@mailu.io', 'password')
+except Exception as exc:
+    print("Failed with:", exc)
+    sys.exit(110)
+
+stat, count = imap_server.select('inbox')
+try:
+    stat, data = imap_server.fetch(count[0], '(UID BODY[TEXT])')
+except :
+    sys.exit(99)
+
+if "Cause this is just a test" in str(data[0][1]):
+    print("Success: Reply is in original inbox")
+else:
+    print("Failed receiving reply in original inbox")
+    sys.exit(99)
+
+typ, data = imap_server.search(None, 'ALL')
+for num in data[0].split():
+   imap_server.store(num, '+FLAGS', '\\Deleted')
+imap_server.expunge()
+
+imap_server.close()
+imap_server.logout()


### PR DESCRIPTION
While looking at the todo/checklist of the multiple-SQL-databases PR, it occurred to me that this is something which should be easily testable automatically. Adding more auto-tests also guards from other regressions, and should thus be considered a good thing.

One note: This is horrible duplication! I’d like to pull it apart, but as part of that, I’d like to switch from `imaplib` which is very low-level to `imapclient`, however, even with SSL-checks disable i couldn’t get a login against dovecot with it. I guess I’ll push that later, however: When it comes to tests, let’s better have dup’ed ones than none ^_^.