### PR TITLE
Allow for multiple identities

### DIFF
--- a/webmails/roundcube/config.inc.php
+++ b/webmails/roundcube/config.inc.php
@@ -7,7 +7,7 @@ $config['db_dsnw'] = 'sqlite:////data/roundcube.db';
 $config['temp_dir'] = '/tmp/';
 $config['des_key'] = getenv('SECRET_KEY');
 $config['cipher_method'] = 'AES-256-CBC';
-$config['identities_level'] = 3;
+$config['identities_level'] = 0;
 $config['reply_all_mode'] = 1;
 
 // List of active plugins (in plugins/ directory)


### PR DESCRIPTION
Mailu is already set up to disallow non-existing identities at the SMTP level. People can already set up identities on external email clients. This should allow users to set up multiple identities within Roundcube

## What type of PR?
Enhancement

## What does this PR do?
Makes Roundcube behave like outside email clients

### Related issue(s)
#367  - Still does not synchronize the SQLite database though

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly
No documentation on overriding this feature per-site
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
Minor change