### PR TITLE
Update fetchmail.py

### DIFF
--- a/services/fetchmail/fetchmail.py
+++ b/services/fetchmail/fetchmail.py
@@ -22,7 +22,7 @@ poll "{host}" proto {protocol}  port {port}
     is "{user_email}"
     smtphost "{smtphost}"
     {options}
-    sslproto 'AUTO'
+    sslproto 'auto'
 """
 
 


### PR DESCRIPTION
## What type of PR?
Typo in fetchmail configuration flag sslproto

## What does this PR do?
Change sslproto=AUTO to sslproto=auto 

### Related issue(s)
#808 

## Prerequistes
None


- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
