### PR TITLE
Don't recursivly chown on mailboxes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ v1.6.0 - unreleased
 - Bug: Error when trying to log in with an account without domain ([#585](https://github.com/Mailu/Mailu/issues/585))
 - Bug: Fix rainloop permissions ([#637](https://github.com/Mailu/Mailu/issues/637))
 - Bug: Fix broken webmail and logo url in admin ([#792](https://github.com/Mailu/Mailu/issues/792))
+- Bug: Don't recursivly chown on mailboxes ([#776](https://github.com/Mailu/Mailu/issues/776))
 
 v1.5.1 - 2017-11-21
 -------------------

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -10,7 +10,8 @@ RUN pip3 install tenacity
 # Image specific layers under this line
 RUN apk add --no-cache \
   dovecot dovecot-pigeonhole-plugin dovecot-fts-lucene rspamd-client bash \
-  && pip3 install podop
+  && pip3 install podop \
+  && mkdir /var/lib/dovecot
 
 COPY conf /conf
 COPY start.py /start.py

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -33,5 +33,6 @@ for dovecot_file in glob.glob("/conf/*.conf"):
 
 # Run Podop, then postfix
 multiprocessing.Process(target=start_podop).start()
-os.system("chown -R mail:mail /mail /var/lib/dovecot /conf")
+os.system("chown mail:mail /mail")
+os.system("chown -R mail:mail /var/lib/dovecot /conf")
 os.execv("/usr/sbin/dovecot", ["dovecot", "-c", "/etc/dovecot/dovecot.conf", "-F"])


### PR DESCRIPTION
## What type of PR?

Bug-fix

## What does this PR do?
Don't recursivly chown on mailboxes. Recursion is not needed, as the permissions will only need to be set on the first invocation.

### Related issue(s)
-  This fixes #776.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.