### PR TITLE
Deliver mails to alias-stripped-of-delimeter, even if catchall exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ v1.6.0 - unreleased
 - Bug: Fix rainloop permissions ([#637](https://github.com/Mailu/Mailu/issues/637))
 - Bug: Fix broken webmail and logo url in admin ([#792](https://github.com/Mailu/Mailu/issues/792))
 - Bug: Don't recursivly chown on mailboxes ([#776](https://github.com/Mailu/Mailu/issues/776))
+- Bug: Don't deliver alias and recipient-delimiter to overwhelming wildcard-alias ([#813](https://github.com/Mailu/Mailu/issues/813))
 
 v1.5.1 - 2017-11-21
 -------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,7 +111,6 @@ v1.6.0 - unreleased
 - Bug: Fix rainloop permissions ([#637](https://github.com/Mailu/Mailu/issues/637))
 - Bug: Fix broken webmail and logo url in admin ([#792](https://github.com/Mailu/Mailu/issues/792))
 - Bug: Don't recursivly chown on mailboxes ([#776](https://github.com/Mailu/Mailu/issues/776))
-- Bug: Don't deliver alias and recipient-delimiter to overwhelming wildcard-alias ([#813](https://github.com/Mailu/Mailu/issues/813))
 
 v1.5.1 - 2017-11-21
 -------------------

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -260,24 +260,14 @@ class Email(object):
 
     @classmethod
     def resolve_destination(cls, localpart, domain_name, ignore_forward_keep=False):
-        localpart_stripped = None
-        stripped_alias = None
-
+        localpart_maybe_split = localpart
         if os.environ.get('RECIPIENT_DELIMITER') in localpart:
-            localpart_stripped = localpart.rsplit(os.environ.get('RECIPIENT_DELIMITER'), 1)[0]
+            localpart_maybe_split = localpart.rsplit(os.environ.get('RECIPIENT_DELIMITER'), 1)[0]
 
-        pure_alias = Alias.resolve(localpart, domain_name)
-        has_wildcard = pure_alias and '%' in pure_alias.email and pure_alias.wildcard
-        stripped_alias = Alias.resolve(localpart_stripped, domain_name)
+        alias = Alias.resolve(localpart_maybe_split, domain_name)
 
-        if pure_alias and not has_wildcard:
-            return pure_alias.destination
-        elif not pure_alias and stripped_alias:
-            return stripped_alias.destination
-        elif has_wildcard and localpart_stripped and stripped_alias:
-            return stripped_alias.destination
-        elif pure_alias:
-            return pure_alias.destination
+        if alias:
+            return alias.destination
 
         user = User.query.get('{}@{}'.format(localpart, domain_name))
         if not user and localpart_stripped:

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -267,10 +267,9 @@ class Email(object):
             localpart_stripped = localpart.rsplit(os.environ.get('RECIPIENT_DELIMITER'), 1)[0]
 
         pure_alias = Alias.resolve(localpart, domain_name)
-        pure_alias_has_wildcard = pure_alias and '%' in pure_alias.email and pure_alias.wildcard
         stripped_alias = Alias.resolve(localpart_stripped, domain_name)
 
-        if pure_alias and not pure_alias_has_wildcard:
+        if pure_alias and not pure_alias.wildcard:
             return pure_alias.destination
         elif stripped_alias:
             return stripped_alias.destination

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -260,14 +260,22 @@ class Email(object):
 
     @classmethod
     def resolve_destination(cls, localpart, domain_name, ignore_forward_keep=False):
-        localpart_maybe_split = localpart
+        localpart_stripped = None
+        stripped_alias = None
+
         if os.environ.get('RECIPIENT_DELIMITER') in localpart:
-            localpart_maybe_split = localpart.rsplit(os.environ.get('RECIPIENT_DELIMITER'), 1)[0]
+            localpart_stripped = localpart.rsplit(os.environ.get('RECIPIENT_DELIMITER'), 1)[0]
 
-        alias = Alias.resolve(localpart_maybe_split, domain_name)
+        pure_alias = Alias.resolve(localpart, domain_name)
+        pure_alias_has_wildcard = pure_alias and '%' in pure_alias.email and pure_alias.wildcard
+        stripped_alias = Alias.resolve(localpart_stripped, domain_name)
 
-        if alias:
-            return alias.destination
+        if pure_alias and not pure_alias_has_wildcard:
+            return pure_alias.destination
+        elif stripped_alias:
+            return stripped_alias.destination
+        elif pure_alias:
+            return pure_alias.destination
 
         user = User.query.get('{}@{}'.format(localpart, domain_name))
         if not user and localpart_stripped:

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -261,14 +261,23 @@ class Email(object):
     @classmethod
     def resolve_destination(cls, localpart, domain_name, ignore_forward_keep=False):
         localpart_stripped = None
+        stripped_alias = None
+
         if os.environ.get('RECIPIENT_DELIMITER') in localpart:
             localpart_stripped = localpart.rsplit(os.environ.get('RECIPIENT_DELIMITER'), 1)[0]
 
-        alias = Alias.resolve(localpart, domain_name)
-        if not alias and localpart_stripped:
-            alias = Alias.resolve(localpart_stripped, domain_name)
-        if alias:
-            return alias.destination
+        pure_alias = Alias.resolve(localpart, domain_name)
+        has_wildcard = pure_alias and '%' in pure_alias.email and pure_alias.wildcard
+        stripped_alias = Alias.resolve(localpart_stripped, domain_name)
+
+        if pure_alias and not has_wildcard:
+            return pure_alias.destination
+        elif not pure_alias and stripped_alias:
+            return stripped_alias.destination
+        elif has_wildcard and localpart_stripped and stripped_alias:
+            return stripped_alias.destination
+        elif pure_alias:
+            return pure_alias.destination
 
         user = User.query.get('{}@{}'.format(localpart, domain_name))
         if not user and localpart_stripped:


### PR DESCRIPTION
This fixes delivery to an alias minus recipient delimiter in cases where a
wildcard alias would also match. For example,
* foo@xxx.tld
* %@xxx.tld
Sending to foo+spam@xxx.tld would get eaten by the catchall before this fix.
Now, the order of alias resolution is made clearer.

closes #813

## What type of PR?
bug-fix

## What does this PR do?
This re-orders the resolution of aliases, such that more specific aliases are preferred over wildcards — even if it means stripping the recipient-delimited part.

### Related issue(s)
closes #813

## Prerequistes
- [X] In case of feature or enhancement: documentation updated accordingly
  - Not required: Bugfix restores intuitive behavior
- [X] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
