### PR TITLE
fix edit of fetched acc without changing password

### DIFF
--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -169,7 +169,7 @@ class FetchForm(flask_wtf.FlaskForm):
     port = fields.IntegerField(_('TCP port'), [validators.DataRequired(), validators.NumberRange(min=0, max=65535)])
     tls = fields.BooleanField(_('Enable TLS'))
     username = fields.StringField(_('Username'), [validators.DataRequired()])
-    password = fields.PasswordField(_('Password'), [validators.DataRequired()])
+    password = fields.PasswordField(_('Password'))
     keep = fields.BooleanField(_('Keep emails on the server'))
     submit = fields.SubmitField(_('Submit'))
 

--- a/core/admin/mailu/ui/views/fetches.py
+++ b/core/admin/mailu/ui/views/fetches.py
@@ -3,6 +3,7 @@ from mailu.ui import ui, forms, access
 
 import flask
 import flask_login
+import wtforms
 
 
 @ui.route('/fetch/list', methods=['GET', 'POST'], defaults={'user_email': None})
@@ -21,6 +22,7 @@ def fetch_create(user_email):
     user_email = user_email or flask_login.current_user.email
     user = models.User.query.get(user_email) or flask.abort(404)
     form = forms.FetchForm()
+    form.pw.validators = [wtforms.validators.DataRequired()]
     if form.validate_on_submit():
         fetch = models.Fetch(user=user)
         form.populate_obj(fetch)
@@ -38,6 +40,8 @@ def fetch_edit(fetch_id):
     fetch = models.Fetch.query.get(fetch_id) or flask.abort(404)
     form = forms.FetchForm(obj=fetch)
     if form.validate_on_submit():
+        if not form.password.data:
+            form.password.data = fetch.password
         form.populate_obj(fetch)
         models.db.session.commit()
         flask.flash('Fetch configuration updated')


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Fix a bug which was introduced by #812:
>  If you want to edit a fetch account, you have to type in the password again.


## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
