### PR TITLE
 Mark messages as seen when reporting them as spam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@ v1.6.0 - unreleased
 - Enhancement: Update documentation
 - Enhancement: Include favicon package ([#801](https://github.com/Mailu/Mailu/issues/801), ([#802](https://github.com/Mailu/Mailu/issues/802))
 - Enhancement: Add logging at critical places in python start.py scripts. Implement LOG_LEVEL to control verbosity ([#588](https://github.com/Mailu/Mailu/issues/588))
+- Enhancement: Mark message as seen when reporting as spam
 - Upstream: Update Roundcube
 - Upstream: Update Rainloop
 - Bug: Rainloop fails with "domain not allowed" ([#93](https://github.com/Mailu/Mailu/issues/93))

--- a/core/dovecot/conf/report-spam.sieve
+++ b/core/dovecot/conf/report-spam.sieve
@@ -1,3 +1,5 @@
+require "imap4flags";
 require "vnd.dovecot.execute";
 
+setflag "\\seen";
 execute :pipe "spam";


### PR DESCRIPTION
## What type of PR?
enhancement

## What does this PR do?
Some email clients (e.g. K-9) don't mark messages as seen, when reporting them as spam. This PR fixes it.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
