### PR TITLE
Reverse the resolution order of user and alias

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -266,16 +266,6 @@ class Email(object):
         if os.environ.get('RECIPIENT_DELIMITER') in localpart:
             localpart_stripped = localpart.rsplit(os.environ.get('RECIPIENT_DELIMITER'), 1)[0]
 
-        pure_alias = Alias.resolve(localpart, domain_name)
-        stripped_alias = Alias.resolve(localpart_stripped, domain_name)
-
-        if pure_alias and not pure_alias.wildcard:
-            return pure_alias.destination
-        elif stripped_alias:
-            return stripped_alias.destination
-        elif pure_alias:
-            return pure_alias.destination
-
         user = User.query.get('{}@{}'.format(localpart, domain_name))
         if not user and localpart_stripped:
             user = User.query.get('{}@{}'.format(localpart_stripped, domain_name))
@@ -287,6 +277,16 @@ class Email(object):
             else:
                 destination = [user.email]
             return destination
+
+        pure_alias = Alias.resolve(localpart, domain_name)
+        stripped_alias = Alias.resolve(localpart_stripped, domain_name)
+
+        if pure_alias and not pure_alias.wildcard:
+            return pure_alias.destination
+        elif stripped_alias:
+            return stripped_alias.destination
+        elif pure_alias:
+            return pure_alias.destination
 
     def __str__(self):
         return self.email


### PR DESCRIPTION
Since it’s common for wildcard~ish systems to prefer concrete objects over
wildcards, and aliases can be broad-wildcards (think catchall, %@xxx.tld), it
may be more intuitive for users that user-names rank higher than aliases. This
makes it impossible for user-names to be unreachable, since they can be
completely overridden by a catchall otherwise.

This changes default behavior, and is not configurable.

closes #815

## What type of PR?

(Feature, enhancement, bug-fix, documentation)

## What does this PR do?

### Related issue(s)
- Mention an issue like: #001
- Auto close an issue like: closes #001

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
