### PR TITLE
Unify and coerce booleans from env used in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ v1.6.0 - unreleased
 - Bug: Don't recursivly chown on mailboxes ([#776](https://github.com/Mailu/Mailu/issues/776))
 - Bug: Fix forced password input for user edit ([#745](https://github.com/Mailu/Mailu/issues/745))
 - Bug: Fetched accounts: Password field is of type "text" ([#789](https://github.com/Mailu/Mailu/issues/789))
+- Bug: DOMAIN_REGISTRATION=False in .env was not treated correctly ([#830](https://github.com/Mailu/Mailu/issues/830))
 
 v1.5.1 - 2017-11-21
 -------------------

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -30,11 +30,11 @@ DEFAULT_CONFIG = {
     'POSTMASTER': 'postmaster',
     'TLS_FLAVOR': 'cert',
     'AUTH_RATELIMIT': '10/minute;1000/hour',
-    'DISABLE_STATISTICS': 'False',
+    'DISABLE_STATISTICS': False,
     # Mail settings
     'DMARC_RUA': None,
     'DMARC_RUF': None,
-    'WELCOME': 'False',
+    'WELCOME': False,
     'WELCOME_SUBJECT': 'Dummy welcome topic',
     'WELCOME_BODY': 'Dummy welcome body',
     'DKIM_SELECTOR': 'dkim',
@@ -74,13 +74,21 @@ class ConfigManager(dict):
     def __init__(self):
         self.config = dict()
 
+    def __coerce_value(self, value):
+        if isinstance(value, str) and value.lower() in ('true','yes'):
+            return True
+        elif isinstance(value, str) and value.lower() in ('false', 'no'):
+            return False
+        return value
+
     def init_app(self, app):
         self.config.update(app.config)
         # get environment variables
         self.config.update({
-            key: os.environ.get(key, value)
+            key: self.__coerce_value(os.environ.get(key, value))
             for key, value in DEFAULT_CONFIG.items()
         })
+
         # automatically set the sqlalchemy string
         if self.config['DB_FLAVOR']:
             template = self.DB_TEMPLATES[self.config['DB_FLAVOR']]

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -31,7 +31,7 @@ def advertise():
         instance_id = str(uuid.uuid4())
         with open(app.config["INSTANCE_ID_PATH"], "w") as handle:
             handle.write(instance_id)
-    if app.config["DISABLE_STATISTICS"].lower() != "true":
+    if not app.config["DISABLE_STATISTICS"]:
         try:
             socket.gethostbyname(app.config["STATS_ENDPOINT"].format(instance_id))
         except:

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -410,7 +410,7 @@ class User(Base, Email):
         return emails
 
     def send_welcome(self):
-        if app.config["WELCOME"].lower() == "true":
+        if app.config["WELCOME"]:
             self.sendmail(app.config["WELCOME_SUBJECT"],
                 app.config["WELCOME_BODY"])
 


### PR DESCRIPTION
At some places, the string that DOMAIN_REGISTRATION is got used like a boolean
(an easy misassumption to make while in python and dealing with the config
dict), making `DOMAIN_REGISTRATION=False` act as a truthy value. To stop such
future problems from happening, coerce environment config strings to real
bools.

closes #830

## What type of PR?
Bug-fix
## What does this PR do?

### Related issue(s)
closes #830

## Prerequistes
- [X] In case of feature or enhancement: documentation updated accordingly
  - not needed
- [X] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
