### PR TITLE
Add reminder for users not to forget POSTMASTER account or alias

### DIFF
--- a/docs/compose/setup.rst
+++ b/docs/compose/setup.rst
@@ -154,3 +154,5 @@ Finally, you must create the initial admin user account:
   docker-compose exec admin flask mailu admin me example.net password
 
 This will create a user named ``me@example.net`` with password ``password`` and administration privileges. Connect to the Web admin interface and change the password to a strong one.
+
+  .. note:: It is vitally important that either a user with the same email as ``POSTMASTER`` in your ``.env`` exists, or you remember to create an alias with this name after you log in. All kinds of strange errors will occur as a result of not doing so!


### PR DESCRIPTION
## What type of PR?
Documentation

## What does this PR do?
Remind users of POSTMASTER account/alias importance

### Related issue(s)


## Prerequistes
- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
