### PR TITLE
Change quota columns type to BigInteger 

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -131,7 +131,7 @@ class Domain(Base):
         backref=db.backref('manager_of'), lazy='dynamic')
     max_users = db.Column(db.Integer, nullable=False, default=-1)
     max_aliases = db.Column(db.Integer, nullable=False, default=-1)
-    max_quota_bytes = db.Column(db.Integer(), nullable=False, default=0)
+    max_quota_bytes = db.Column(db.BigInteger(), nullable=False, default=0)
     signup_enabled = db.Column(db.Boolean(), nullable=False, default=False)
 
     @property
@@ -307,8 +307,8 @@ class User(Base, Email):
     domain = db.relationship(Domain,
         backref=db.backref('users', cascade='all, delete-orphan'))
     password = db.Column(db.String(255), nullable=False)
-    quota_bytes = db.Column(db.Integer(), nullable=False, default=10**9)
-    quota_bytes_used = db.Column(db.Integer(), nullable=False, default=0)
+    quota_bytes = db.Column(db.BigInteger(), nullable=False, default=10**9)
+    quota_bytes_used = db.Column(db.BigInteger(), nullable=False, default=0)
     global_admin = db.Column(db.Boolean(), nullable=False, default=False)
     enabled = db.Column(db.Boolean(), nullable=False, default=True)
 

--- a/core/admin/migrations/versions/2335c80a6bc3_.py
+++ b/core/admin/migrations/versions/2335c80a6bc3_.py
@@ -15,7 +15,7 @@ import sqlalchemy as sa
 
 
 def upgrade():
-    op.add_column('domain', sa.Column('max_quota_bytes', sa.Integer(), nullable=False, server_default='0'))
+    op.add_column('domain', sa.Column('max_quota_bytes', sa.BigInteger(), nullable=False, server_default='0'))
 
 
 def downgrade():

--- a/core/admin/migrations/versions/25fd6c7bcb4a_.py
+++ b/core/admin/migrations/versions/25fd6c7bcb4a_.py
@@ -20,7 +20,7 @@ import sqlalchemy as sa
 
 def upgrade():
     with op.batch_alter_table('user') as batch:
-        batch.add_column(sa.Column('quota_bytes_used', sa.Integer(), nullable=False, server_default='0'))
+        batch.add_column(sa.Column('quota_bytes_used', sa.BigInteger(), nullable=False, server_default='0'))
 
 
 def downgrade():

--- a/core/admin/migrations/versions/ff0417f4318f_.py
+++ b/core/admin/migrations/versions/ff0417f4318f_.py
@@ -41,7 +41,7 @@ def upgrade():
         sa.Column('comment', sa.String(length=255), nullable=True),
         sa.Column('localpart', sa.String(length=80), nullable=False),
         sa.Column('password', sa.String(length=255), nullable=False),
-        sa.Column('quota_bytes', sa.Integer(), nullable=False),
+        sa.Column('quota_bytes', sa.BigInteger(), nullable=False),
         sa.Column('global_admin', sa.Boolean(), nullable=False),
         sa.Column('enable_imap', sa.Boolean(), nullable=False),
         sa.Column('enable_pop', sa.Boolean(), nullable=False),


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
As described in this [comment](https://github.com/Mailu/Mailu/pull/788#issuecomment-453690849) we need a bigger type for columns which store the size of quota. 
With this PR I can successfully migrate an existing sqlite3 installation to MySQL/MariaDB. :tada: 

@muhlemmer  #788 is accidentally merged already and this PR does not do a migration. But since external databases are considered as experimental and it is only merged a few days it is OK for me. So we don't have to mess up the migration. 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
