### PR TITLE
fix default value for created_at and updated_at

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -101,8 +101,8 @@ class Base(db.Model):
         }
     )
 
-    created_at = db.Column(db.Date, nullable=False, default=datetime.now)
-    updated_at = db.Column(db.Date, nullable=True, onupdate=datetime.now)
+    created_at = db.Column(db.Date, nullable=False, default=date.today)
+    updated_at = db.Column(db.Date, nullable=True, onupdate=date.today)
     comment = db.Column(db.String(255), nullable=True)
 
 


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
When executing the following command (from the docs) to create a new admin:
`docker-compose exec admin flask mailu admin me example.net password`

we're getting the following warning with MySQL as a database backend:

```
/usr/lib/python3.6/site-packages/sqlalchemy/engine/default.py:509: Warning: (1265, "Data truncated for column 'created_at' at row 1") cursor.execute(statement, parameters)
```
That is because we try to store a datetime in a column which support only date.
So this PR is fixing this by using a date instead of datetime for created_at and updated_at.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
