### PR TITLE
IPv6 stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ v1.6.0 - unreleased
 - Enhancement: Include favicon package ([#801](https://github.com/Mailu/Mailu/issues/801), ([#802](https://github.com/Mailu/Mailu/issues/802))
 - Enhancement: Add logging at critical places in python start.py scripts. Implement LOG_LEVEL to control verbosity ([#588](https://github.com/Mailu/Mailu/issues/588))
 - Enhancement: Mark message as seen when reporting as spam
+- Enhancement: Better support and document IPv6 ([#827](https://github.com/Mailu/Mailu/issues/827))
 - Upstream: Update Roundcube
 - Upstream: Update Rainloop
 - Bug: Rainloop fails with "domain not allowed" ([#93](https://github.com/Mailu/Mailu/issues/93))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,6 @@ v1.6.0 - unreleased
 - Feature: Automated Releases ([#487](https://github.com/Mailu/Mailu/issues/487))
 - Feature: Support for ARC ([#495](https://github.com/Mailu/Mailu/issues/495))
 - Feature: Add posibilty to run webmail on root ([#501](https://github.com/Mailu/Mailu/issues/501))
-- Feature: Upgrade docker-compose.yml to version 3 ([#539](https://github.com/Mailu/Mailu/issues/539))
 - Feature: Documentation to deploy mailu on a docker swarm ([#551](https://github.com/Mailu/Mailu/issues/551))
 - Feature: Add optional Maildir-Compression ([#553](https://github.com/Mailu/Mailu/issues/553))
 - Feature: Preserve rspamd history on container restart ([#561](https://github.com/Mailu/Mailu/issues/561))

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -16,10 +16,11 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
 def start_podop():
     os.setuid(8)
+    url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/dovecot/§"
     run_server(0, "dovecot", "/tmp/podop.socket", [
-		("quota", "url", "http://admin/internal/dovecot/§"),
-		("auth", "url", "http://admin/internal/dovecot/§"),
-		("sieve", "url", "http://admin/internal/dovecot/§"),
+		("quota", "url", url ),
+		("auth", "url", url),
+		("sieve", "url", url),
     ])
 
 def convert(src, dst):
@@ -42,6 +43,7 @@ def resolve(hostname):
 # Actual startup script
 os.environ["FRONT_ADDRESS"] = resolve(os.environ.get("FRONT_ADDRESS", "front"))
 os.environ["REDIS_ADDRESS"] = resolve(os.environ.get("REDIS_ADDRESS", "redis"))
+os.environ["ADMIN_ADDRESS"] = resolve(os.environ.get("ADMIN_ADDRESS", "admin"))
 if os.environ["WEBMAIL"] != "none":
     os.environ["WEBMAIL_ADDRESS"] = resolve(os.environ.get("WEBMAIL_ADDRESS", "webmail"))
 

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -17,14 +17,15 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
 def start_podop():
     os.setuid(100)
+    url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/postfix/"
     # TODO: Remove verbosity setting from Podop?
     run_server(0, "postfix", "/tmp/podop.socket", [
-		("transport", "url", "http://admin/internal/postfix/transport/§"),
-		("alias", "url", "http://admin/internal/postfix/alias/§"),
-		("domain", "url", "http://admin/internal/postfix/domain/§"),
-        ("mailbox", "url", "http://admin/internal/postfix/mailbox/§"),
-        ("senderaccess", "url", "http://admin/internal/postfix/sender/access/§"),
-        ("senderlogin", "url", "http://admin/internal/postfix/sender/login/§")
+		("transport", "url", url + "transport/§"),
+		("alias", "url", url + "alias/§"),
+		("domain", "url", url + "domain/§"),
+        ("mailbox", "url", url + "mailbox/§"),
+        ("senderaccess", "url", url + "sender/access/§"),
+        ("senderlogin", "url", url + "sender/login/§")
     ])
 
 def convert(src, dst):
@@ -46,6 +47,7 @@ def resolve(hostname):
 
 # Actual startup script
 os.environ["FRONT_ADDRESS"] = resolve(os.environ.get("FRONT_ADDRESS", "front"))
+os.environ["ADMIN_ADDRESS"] = resolve(os.environ.get("ADMIN_ADDRESS", "admin"))
 os.environ["HOST_ANTISPAM"] = os.environ.get("HOST_ANTISPAM", "antispam:11332")
 os.environ["HOST_LMTP"] = os.environ.get("HOST_LMTP", "imap:2525")
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -134,6 +134,49 @@ You're mail service will be reachable for IMAP, POP3, SMTP and Webmail at the ad
 
 *Issue reference:* `742`_, `747`_.
 
+How to make IPv6 work?
+``````````````````````
+
+Docker currently does not expose the IPv6 ports properly, as it does not interface with ``ip6tables``.
+Lets start with quoting everything that's wrong:
+
+  Unfortunately, initially Docker was not created with IPv6 in mind.
+  It was added later and, while it has come a long way, is still not as usable as one would want.
+  Much discussion is still going on as to how IPv6 should be used in a containerized world;
+  See the various GitHub issues linked below:
+  
+  - Giving each container a publicly routable address means all ports (even unexposed / unpublished ports) are suddenly
+    reachable by everyone, if no additional filtering is done
+    (`docker/docker#21614 <https://github.com/docker/docker/issues/21614>`_)
+  - By default, each container gets a random IPv6, making it impossible to do properly do DNS;
+    the alternative is to assign a specific IPv6 address to each container,
+    still an administrative hassle (`docker/docker#13481 <https://github.com/docker/docker/issues/13481>`_)
+  - Published ports won't work on IPv6, unless you have the userland proxy enabled
+    (which, for now, is enabled by default in Docker)
+  - The userland proxy, however, seems to be on its way out
+    (`docker/docker#14856 <https://github.com/docker/docker/issues/14856>`_) and has various issues, like:
+  
+    - It can use a lot of RAM (`docker/docker#11185 <https://github.com/docker/docker/issues/11185>`_)
+    - Source IP addresses are rewritten, making it completely unusable for many purposes, e.g. mail servers 
+      (`docker/docker#17666 <https://github.com/docker/docker/issues/17666>`_),
+      (`docker/libnetwork#1099 <https://github.com/docker/libnetwork/issues/1099>`_).
+  
+  -- `Robbert Klarenbeek <https://github.com/robbertkl>`_ (docker-ipv6nat author)
+
+So, how to make it work? Well, by using `docker-ipv6nat`_! This nifty container will set up ``ip6tables``,
+just as Docker would do for IPv4. We know that nat-ing is not advised in IPv6,
+however exposing all containers to public network neither. The choice is ultimately yous.
+
+Mailu `setup utility`_ generates a safe IPv6 ULA subnet by default. So when you run the following command,
+Mailu will start to function on IPv6:
+
+.. code-block:: bash
+
+  docker run -d --restart=always -v /var/run/docker.sock:/var/run/docker.sock:ro --privileged --net=host robbertkl/ipv6nat
+
+.. _`docker-ipv6nat`: https://github.com/robbertkl/docker-ipv6nat
+.. _`setup utility`: https://setup.mailu.io
+
 How does Mailu scale up?
 ````````````````````````
 

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -3,7 +3,7 @@
 # Please read the documentation before attempting any change.
 # Generated for {{ flavor }} flavor
 
-version: '3.6'
+version: '2.2'
 
 services:
 
@@ -160,8 +160,14 @@ services:
 
 networks:
   default:
+    {% if ipv6_enabled %}
+    enable_ipv6: true
+    {% endif %}
     driver: bridge
     ipam:
       driver: default
       config:
         - subnet: {{ subnet }}
+        {% if ipv6_enabled %}
+        - subnet: {{ subnet6 }}
+        {% endif %}

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -27,6 +27,9 @@ SECRET_KEY={{ secret(16) }}
 
 # Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
 SUBNET={{ subnet }}
+{% if ipv6_enabled %}
+SUBNET6={{ subnet6 }}
+{% endif %}
 
 # Main mail domain
 DOMAIN={{ domain }}

--- a/setup/static/render.js
+++ b/setup/static/render.js
@@ -86,3 +86,16 @@ $(document).ready(function() {
 		}
 	});
 });
+
+$(document).ready(function() {
+	if ($('#enable_ipv6').prop('checked')) {
+		$("#ipv6").show();
+	}
+	$("#enable_ipv6").change(function() {
+		if ($(this).is(":checked")) {
+			$("#ipv6").show();
+		} else {
+			$("#ipv6").hide();
+		}
+	});
+});

--- a/setup/templates/steps/compose/03_expose.html
+++ b/setup/templates/steps/compose/03_expose.html
@@ -31,8 +31,7 @@ avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</co
 </div>
 
 <div class="form-group" id="ipv6" style="display: none">
-  <p><span class="label label-warning">Warning</span> You must use specific addresses, please
-	avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</code>.</p>
+  <p><span class="label label-danger">Read this:</span> Docker currently does not expose the IPv6 ports properly, as it does not interface with <code>ip6tables</code>. Be sure to read our <a href="https://mailu.io/{{ version }}/faq.html#how-to-make-ipv6-work">FAQ section</a>!</p>
   <label>IPv6 listen address</label>
 <!--   Validates IPv6 address -->
   <input class="form-control" type="text" name="bind6" value="::1"

--- a/setup/templates/steps/compose/03_expose.html
+++ b/setup/templates/steps/compose/03_expose.html
@@ -18,13 +18,27 @@ avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</co
 <!--   Validates IPv4 address -->
   <input class="form-control" type="text" name="bind4" value="127.0.0.1" 
   		pattern="^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$">
+  <label>Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)</label>
+  <input class="form-control" type="text" name="subnet" required pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$"
+    value="192.168.203.0/24">
 </div>
 
-<div class="form-group">
+<div class="form-check form-check-inline">
+  <label class="form-check-label">
+    <input class="form-check-input" type="checkbox" name="ipv6_enabled" value="true" id="enable_ipv6">
+    Enable IPv6
+  </label>
+</div>
+
+<div class="form-group" id="ipv6" style="display: none">
+  <p><span class="label label-warning">Warning</span> You must use specific addresses, please
+	avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</code>.</p>
   <label>IPv6 listen address</label>
 <!--   Validates IPv6 address -->
   <input class="form-control" type="text" name="bind6" value="::1"
   		pattern="^s*((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]d|1dd|[1-9]?d)(.(25[0-5]|2[0-4]d|1dd|[1-9]?d)){3}))|:)))(%.+)?s*(\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?$">
+  <label>Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)</label>
+  <input class="form-control" type="text" name="subnet6" required value="{{ subnet6 }}:beef::/64">
 </div>
 
 <p>The unbound resolver enables Mailu to do DNSsec verification, DNS root lookups and caching. This also helps the antispam service not to get blocked by the public or ISP DNS servers.</p>
@@ -33,12 +47,6 @@ avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</co
     <input class="form-check-input" type="checkbox" name="resolver_enabled" value="true">
     Enable unbound resolver
   </label>
-</div>
-<br><br>
-<div class="form-group">
-  <label>Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)</label>
-  <input class="form-control" type="text" name="subnet" required pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$"
-    value="192.168.203.0/24">
 </div>
 
 <p>You server will be available under a main hostname but may expose multiple public


### PR DESCRIPTION
## What type of PR?

(Feature, enhancement, bug-fix, documentation) -> A bit of everything

## What does this PR do?

Document how to use ipv6nat. This, however triggers some kind of flaky behavior with the Docker DNS resolver, resulting in lookup failures inside Podop. So this is fixed in theis PR as well... We now do `admin` resolving once, during startup. (As we did with other services).

Note: `docker-compose.yml` downgrade is necessary, as IPv6 settings are not supported by the Docker Compose file format 3 :disappointed:  

Credit to @cooperaj for finding this ipv6nat tool. And @robbertkl for writing it in the first place!

### Related issue(s)
- Fixes #827 
- Hopefully helps with #829 and #834

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
