### PR TITLE
Check if sender address is not null before trying to check the domain.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ v1.6.0 - unreleased
 - Bug: Fetched accounts: Password field is of type "text" ([#789](https://github.com/Mailu/Mailu/issues/789))
 - Bug: Auto-forward destination not accepting top level domains ([#818](https://github.com/Mailu/Mailu/issues/818))
 - Bug: DOMAIN_REGISTRATION=False in .env was not treated correctly ([#830](https://github.com/Mailu/Mailu/issues/830))
+- Bug: Internal error when checking null sender address ([#846](https://github.com/Mailu/Mailu/issues/846))
 
 v1.5.1 - 2017-11-21
 -------------------

--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -49,5 +49,18 @@ def postfix_sender_login(sender):
 def postfix_sender_access(sender):
     """ Simply reject any sender that pretends to be from a local domain
     """
-    localpart, domain_name = models.Email.resolve_domain(sender)
-    return flask.jsonify("REJECT") if models.Domain.query.get(domain_name) else flask.abort(404)
+    if not is_void_address(sender):
+        localpart, domain_name = models.Email.resolve_domain(sender)
+        return flask.jsonify("REJECT") if models.Domain.query.get(domain_name) else flask.abort(404)
+    else:
+        return flask.abort(404)
+
+
+def is_void_address(email):
+    '''True if the email is void (null) email address.
+    '''
+    if email.startswith('<') and email.endswith('>'):
+        email = email[1:-1]
+    # Some MTAs use things like '<MAILER-DAEMON>' instead of '<>'; so let's
+    # consider void any such thing.
+    return '@' not in email


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Avoid traceback when checking for null sender address (those in the Return-Path for bounces and other notifications).

### Related issue(s)
- Mention an issue like: #846 
- Auto close an issue like: closes #846 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X ] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
