### PR TITLE
Make certdumper output fullchain-pems

### DIFF
--- a/optional/traefik-certdumper/run.sh
+++ b/optional/traefik-certdumper/run.sh
@@ -4,20 +4,16 @@ function dump() {
     echo "$(date) Dumping certificates"
     bash dumpcerts.sh /traefik/acme.json /tmp/work/ || return
 
-    for crt_file in $(ls /tmp/work/certs/*); do
-        pem_file=$(echo $crt_file | sed 's/certs/pem/g' | sed 's/.crt/-public.pem/g')
-        echo "openssl x509 -inform PEM -in $crt_file > $pem_file"
-        openssl x509 -inform PEM -in $crt_file > $pem_file
-    done
+    # private-keys are rsa, we need pem though
     for key_file in $(ls /tmp/work/private/*); do
         pem_file=$(echo $key_file | sed 's/private/pem/g' | sed 's/.key/-private.pem/g')
-        echo "openssl rsa -in $key_file -text > $pem_file"
         openssl rsa -in $key_file -text > $pem_file
     done
 
     echo "$(date) Copying certificates"
     cp -v /tmp/work/pem/${DOMAIN}-private.pem /output/key.pem
-    cp -v /tmp/work/pem/${DOMAIN}-public.pem /output/cert.pem
+    # the .crt is a chained-pem, as common for letsencrypt
+    cp -v /tmp/work/certs/${DOMAIN}.crt /output/cert.pem
 }
 
 mkdir -p /tmp/work/pem /tmp/work/certs


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Before it only outputted a pem-file with the server-certificate —
however, it seems some clients want the fullchain delivered, as it’s
common with letsencrypt.

### Related issue(s)
closes #847 

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
  - minor fix