### PR TITLE
unbound: drop privileges after binding to port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Notable changes to this project are documented in the current file. For more
 details about individual changes, see the Git log. You should read this before
 upgrading Freposte.io as some changes will include useful notes.
 
+v1.6.1 - unreleased
+-------------------
+- Enhancement: Make Unbound drop privileges after binding to port
+
 v1.6.0 - 2019-01-18
 -------------------
 

--- a/services/unbound/unbound.conf
+++ b/services/unbound/unbound.conf
@@ -10,7 +10,7 @@ server:
   do-daemonize: no
   access-control: {{ SUBNET }} allow
   directory: "/etc/unbound"
-  username: root
+  username: unbound
   auto-trust-anchor-file: trusted-key.key
   root-hints: "/etc/unbound/root.hints"
   hide-identity: yes


### PR DESCRIPTION
## What type of PR?
enhancement / security-related

## What does this PR do?
make unbound drop privileges, this reduces the attack surface (if an attacker somehow exploits unbound he can no longer gain root access in the container, which is equivalent with root on the host)

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
