### PR TITLE
[RFC] Make the handling of IdnaEmails case-sensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ upgrading Freposte.io as some changes will include useful notes.
 v1.6.1 - unreleased
 -------------------
 - Enhancement: Make Unbound drop privileges after binding to port
+- Bug: Can now create aliases with same string, but different case ([#867](https://github.com/Mailu/Mailu/issues/867))
 
 v1.6.0 - 2019-01-18
 -------------------

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -45,7 +45,7 @@ class IdnaEmail(db.TypeDecorator):
             return "{0}@{1}".format(
                 localpart,
                 idna.encode(domain_name).decode('ascii'),
-            ).lower()
+            )
         except ValueError:
             pass
 


### PR DESCRIPTION
While I couldn’t find anything in both code and manual testing, I’m not sure removing that lowercasing in the IdnaEmail class might break something else. Review and Comments warmly welcome!

## What type of PR?
bug-fix

## What does this PR do?
As explained in RFC5321 2.4, domains shall be case insensitive, but local-parts
/ mailbox-names »MUST BE treated as case sensitive«. To achieve this, don’t
force-lowercase mail-addresses in IdnaEmail anymore.

This makes it possible to create mixed-case aliases, which failed with a 500
due to UNIQUE-constraints before. Having such mixed-case aliases is important
to cover the full spectrum of possible localparts as described by the
aforementioned RFC.

closes #867
### Related issue(s)
closes #867

## Prerequistes
- [X] In case of feature or enhancement: documentation updated accordingly
  - Not needed
- [X] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
  - Done
