### PR TITLE
Backport of PR #866

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,51 @@
+pull_request_rules:
+
+  - name: Build testing images; trigger bors try
+    conditions:
+      - -title~=(WIP|wip)
+      - -label~=^(status/wip|status/blocked)$
+    actions:
+      comment:
+        message: |
+          Thanks for submitting this pull request.
+          Bors-ng will now build test images. When it succeeds, we will continue to review and test your PR.
+          
+          bors try
+          
+          Note: if this build fails, [read this](http://mailu.io/master/contributors/environment.html#when-bors-try-fails).
+
+  - name: 2 approved reviews; trigger bors r+
+    conditions:
+      - -title~=(WIP|wip)
+      - -label~=^(status/wip|status/blocked)$
+      - "#approved-reviews-by>=2"
+    actions:
+      comment:
+        message: bors r+
+
+  - name: Trusted author and 1 approved review; trigger bors r+
+    conditions:
+      - author~=^(kaiyou|muhlemmer|mildred|HorayNarea|adi90x|hoellen|ofthesun9|Nebukadneza|ionutfilip)$
+      - -title~=(WIP|wip)
+      - -label~=^(status/wip|status/blocked|review/need2)$
+      - "#approved-reviews-by>=1"
+    actions:
+      comment:
+        message: bors r+
+
+  - name: Backport to 1.6 branch
+    conditions:
+      - base=master
+      - label=type/backport
+    actions:
+      backport:
+        branches:
+          - '1.6'
+
+  - name: remove outdated reviews
+    conditions:
+      - base~=^(master|1.6)$
+    actions:
+      dismiss_reviews:
+        approved: True
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+branches:
+  only:
+    - staging
+    - testing
+    - '1.5'
+    - '1.6'
+    - master
+
 sudo: required
 services: docker
 addons:
@@ -6,7 +14,8 @@ addons:
       - docker-ce
 
 env:
-  - MAILU_VERSION=$TRAVIS_BRANCH
+  - MAILU_VERSION=${TRAVIS_BRANCH////-}
+
 language: python
 python:
   - "3.6"
@@ -19,6 +28,7 @@ before_script:
   - docker-compose -v
   - docker-compose -f tests/build.yml build
   - sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
+
 
 script:
 # test.py, test name and timeout between start and tests.

--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,3 @@
+status = [
+  "continuous-integration/travis-ci/push"
+]

--- a/docs/contributors/guide.rst
+++ b/docs/contributors/guide.rst
@@ -52,15 +52,19 @@ master directly if you find this appropriate. Still, keep in mind that:
   that you use branch names prefixed with ``feat-`` or ``fix-`` and followed
   either by the name of the Github issue or a short and meaningful name.
 
-Workflow
-````````
+PR Workflow
+````````````
 
-All commits will be merged to the main ``master`` branch for testing. New
-images are built by Docker Hub with the ``testing`` tag for each new commit on
-the ``master`` branch.
+All pull requests have to be against the main ``master`` branch.
+The PR gets build by Travis and some primitive auto-testing is done.
+Test images get uploaded to a separate section in Docker hub.
+Reviewers will check the PR and test the resulting images.
+See the :ref:`testing` section for more info.
 
-After some brief testing, urgent fixes will be cherry-picked to the current stable
-branch and new stable builds will be released.
+Urgent fixes can be backported to the stable branch.
+For this a member of **Mailu/contributors** has to set the ``type/backport`` label.
+Upon merge of the original PR, a copy of the PR is created against the stable branch.
+After some testing on master, we will approve and merge this new PR as well.
 
 At the end of every milestone, a new stable branch will be created from ``master``
 or any previous commit that matches the completion of the milestone.

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -1,4 +1,16 @@
 #!/bin/bash
 
+# Skip deploy for staging branch
+[ "$TRAVIS_BRANCH" = "staging" ] && exit 0
+
+# Retag in case of `bors try`
+if [ "$TRAVIS_BRANCH" = "testing" ]; then
+    export DOCKER_ORG="mailutest"
+    # Commit message is like "Try #99".
+    # This sets the version tag to "pr-99"
+    export MAILU_VERSION="pr-${TRAVIS_COMMIT_MESSAGE//[!0-9]/}"
+    docker-compose -f tests/build.yml build
+fi
+
 docker login -u $DOCKER_UN -p $DOCKER_PW
 docker-compose -f tests/build.yml push


### PR DESCRIPTION
Automatic creation of review images

- Enable bors-ng for better merging
- Re-enable mergify with a fixed up syntax, it will now only issue bors commands.
- Pull request build images are now pushed to docker hub
- Automatic backport rule
- Fix build tag for branches with slash (/)
- Only push when master and 1.6 target branch

Use bors-ng to create and upload test images

- Reinstate Travis deploy phase
- Better labeling of Mergify rules
- Automatic `bors try` by Mergify
- Explain bors in comment message
- Skip push for staging branch
- Re-update docs to current situation