### PR TITLE
fix some cli commands in the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ v1.6.1 - unreleased
 -------------------
 - Enhancement: Make Unbound drop privileges after binding to port
 - Enhancement: Create an Authentication Token with IPv6 address restriction ([#829](https://github.com/Mailu/Mailu/issues/829))
-- Bug: Fix creating new fetched accounts
 - Enhancement: Missing wildcard option in alias flask command ([#869](https://github.com/Mailu/Mailu/issues/869))
+- Bug: Fix creating new fetched accounts
 - Bug: Fix poor performance if ANTIVIRUS is configured to none.
+- Bug: Rename cli commands and their options (replace "\_" with "-") ([#877](https://github.com/Mailu/Mailu/issues/877))
 
 v1.6.0 - 2019-01-18
 -------------------

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -64,7 +64,7 @@ def admin(localpart, domain_name, password):
 @click.argument('localpart')
 @click.argument('domain_name')
 @click.argument('password')
-@click.argument('hash_scheme')
+@click.argument('hash_scheme', required=False)
 @flask_cli.with_appcontext
 def user(localpart, domain_name, password, hash_scheme=None):
     """ Create a user
@@ -86,12 +86,14 @@ def user(localpart, domain_name, password, hash_scheme=None):
 
 
 @mailu.command()
-@click.option('-n', '--domain-name')
+@click.argument('domain_name')
 @click.option('-u', '--max-users')
 @click.option('-a', '--max-aliases')
 @click.option('-q', '--max-quota-bytes')
 @flask_cli.with_appcontext
 def domain(domain_name, max_users=-1, max_aliases=-1, max_quota_bytes=0):
+    """ Create a domain
+    """
     domain = models.Domain.query.get(domain_name)
     if not domain:
         domain = models.Domain(name=domain_name)

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -86,10 +86,10 @@ def user(localpart, domain_name, password, hash_scheme=None):
 
 
 @mailu.command()
-@click.option('-n', '--domain_name')
-@click.option('-u', '--max_users')
-@click.option('-a', '--max_aliases')
-@click.option('-q', '--max_quota_bytes')
+@click.option('-n', '--domain-name')
+@click.option('-u', '--max-users')
+@click.option('-a', '--max-aliases')
+@click.option('-q', '--max-quota-bytes')
 @flask_cli.with_appcontext
 def domain(domain_name, max_users=-1, max_aliases=-1, max_quota_bytes=0):
     domain = models.Domain.query.get(domain_name)
@@ -126,7 +126,7 @@ def user_import(localpart, domain_name, password_hash, hash_scheme = None):
 
 @mailu.command()
 @click.option('-v', '--verbose')
-@click.option('-d', '--delete_objects')
+@click.option('-d', '--delete-objects')
 @flask_cli.with_appcontext
 def config_update(verbose=False, delete_objects=False):
     """sync configuration with data from YAML-formatted stdin"""

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -4,11 +4,11 @@ Mailu command line
 Managing users and aliases can be done from CLI using commands:
 
 * alias
-* alias_delete
+* alias-delete
 * user
-* user_import
-* user_delete
-* config_update
+* user-import
+* user-delete
+* config-update
 
 alias
 -----
@@ -18,12 +18,12 @@ alias
   docker-compose exec admin flask mailu alias foo example.net "mail1@example.com,mail2@example.com"
 
 
-alias_delete
+alias-delete
 ------------
 
 .. code-block:: bash
 
-  docker-compose exec admin flask mailu alias_delete foo@example.net
+  docker-compose exec admin flask mailu alias-delete foo@example.net
 
 user
 ----
@@ -32,30 +32,30 @@ user
 
   docker-compose exec admin flask mailu user --hash_scheme='SHA512-CRYPT' myuser example.net 'password123'
 
-user_import
+user-import
 -----------
 
 primary difference with simple `user` command is that password is being imported as a hash - very useful when migrating users from other systems where only hash is known.
 
 .. code-block:: bash
 
-  docker-compose run --rm admin python manage.py user --hash_scheme='SHA512-CRYPT' myuser example.net '$6$51ebe0cb9f1dab48effa2a0ad8660cb489b445936b9ffd812a0b8f46bca66dd549fea530ce'
+  docker-compose run --rm admin flask mailu user-import --hash_scheme='SHA512-CRYPT' myuser example.net '$6$51ebe0cb9f1dab48effa2a0ad8660cb489b445936b9ffd812a0b8f46bca66dd549fea530ce'
 
-user_delete
+user-delete
 ------------
 
 .. code-block:: bash
 
-  docker-compose exec admin flask mailu user_delete foo@example.net
+  docker-compose exec admin flask mailu user-delete foo@example.net
 
-config_update
+config-update
 -------------
 
 The sole purpose of this command is for importing users/aliases in bulk and synchronizing DB entries with external YAML template:
 
 .. code-block:: bash
 
-  cat mail-config.yml | docker-compose exec admin flask mailu config_update --delete_objects
+  cat mail-config.yml | docker-compose exec admin flask mailu config-update --delete_objects
 
 where mail-config.yml looks like:
 
@@ -72,7 +72,7 @@ where mail-config.yml looks like:
       domain: example.com
       destination: "user1@example.com,user2@example.com"
 
-without ``--delete_object`` option config_update will only add/update new values but will *not* remove any entries missing in provided YAML input.
+without ``--delete_object`` option config-update will only add/update new values but will *not* remove any entries missing in provided YAML input.
 
 Users
 -----

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -30,7 +30,8 @@ user
 
 .. code-block:: bash
 
-  docker-compose exec admin flask mailu user --hash_scheme='SHA512-CRYPT' myuser example.net 'password123'
+  docker-compose exec admin flask mailu user myuser example.net 'password123'
+
 
 user-import
 -----------
@@ -55,7 +56,7 @@ The sole purpose of this command is for importing users/aliases in bulk and sync
 
 .. code-block:: bash
 
-  cat mail-config.yml | docker-compose exec admin flask mailu config-update --delete_objects
+  cat mail-config.yml | docker-compose exec -T admin flask mailu config-update --delete-objects
 
 where mail-config.yml looks like:
 
@@ -72,7 +73,7 @@ where mail-config.yml looks like:
       domain: example.com
       destination: "user1@example.com,user2@example.com"
 
-without ``--delete_object`` option config-update will only add/update new values but will *not* remove any entries missing in provided YAML input.
+without ``--delete-object`` option config-update will only add/update new values but will *not* remove any entries missing in provided YAML input.
 
 Users
 -----

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -5,6 +5,7 @@ Managing users and aliases can be done from CLI using commands:
 
 * alias
 * alias-delete
+* domain
 * user
 * user-import
 * user-delete
@@ -24,6 +25,15 @@ alias-delete
 .. code-block:: bash
 
   docker-compose exec admin flask mailu alias-delete foo@example.net
+
+
+domain
+----
+
+.. code-block:: bash
+
+  docker-compose exec admin flask mailu domain example.net
+
 
 user
 ----

--- a/docs/kubernetes/mailu/index.rst
+++ b/docs/kubernetes/mailu/index.rst
@@ -128,7 +128,7 @@ And in the pod run the following command. The command uses following entries:
 
 .. code-block:: bash
 
-    python manage.py admin root example.com password
+    flask mailu admin root example.com password
 
 - ``admin`` Make it an admin user
 - ``root`` The first part of the e-mail adres (ROOT@example.com)


### PR DESCRIPTION
## What type of PR?
documentation

## What does this PR do?
Since we updated the python package click to 7.0, commands with underscores in name are replaced by a dash. This PR fixes this in the documentation. 
It also fixes two `python manage.py [...]` leftovers. 

In addition I think we should rename the arguments now as well and replace underscores with dashes, e.g. `--max_users` to `--max-users`. So we keep it consistent. What do you think? I'd update this PR if you agree on this. 


### Related issue(s)
closes #849
closes #925

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.



## Todo
- [x] #911 
- [x] #926 
- [x] rename options (`_` to `-`)
- [x] domain command
