### PR TITLE
Fix password validator for creating fetched accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ v1.6.1 - unreleased
 -------------------
 - Enhancement: Make Unbound drop privileges after binding to port
 - Enhancement: Create an Authentication Token with IPv6 address restriction ([#829](https://github.com/Mailu/Mailu/issues/829))
-
+- Bug: Fix creating new fetched accounts
+-
 v1.6.0 - 2019-01-18
 -------------------
 

--- a/core/admin/mailu/ui/views/fetches.py
+++ b/core/admin/mailu/ui/views/fetches.py
@@ -22,7 +22,7 @@ def fetch_create(user_email):
     user_email = user_email or flask_login.current_user.email
     user = models.User.query.get(user_email) or flask.abort(404)
     form = forms.FetchForm()
-    form.pw.validators = [wtforms.validators.DataRequired()]
+    form.password.validators = [wtforms.validators.DataRequired()]
     if form.validate_on_submit():
         fetch = models.Fetch(user=user)
         form.populate_obj(fetch)


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Creating fetched accounts was changed in  #817 with a slight typo. I’m an idiot since i approved, but only tested editing, and not creation. But here’s the fix!

### Related issue(s)
Small fix, didn’t feel explanatory issue was necessary

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly
  - Not needed
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
  - Done
