### PR TITLE
Catch webmail-url empty but webmail configured and force to default

### DIFF
--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -116,7 +116,11 @@ WEBROOT_REDIRECT=/webmail
 WEB_ADMIN={{ admin_path }}
 
 # Path to the webmail if enabled
+{% if webmail_type != 'none' and webmail_path == '' %}
+WEB_WEBMAIL=/webmail
+{% else %}
 WEB_WEBMAIL={{ webmail_path }}
+{% endif %}
 
 # Website name
 SITENAME={{ site_name }}

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -117,7 +117,7 @@ WEB_ADMIN={{ admin_path }}
 
 # Path to the webmail if enabled
 {% if webmail_type != 'none' and webmail_path == '' %}
-WEB_WEBMAIL=/webmail
+WEB_WEBMAIL=/
 {% else %}
 WEB_WEBMAIL={{ webmail_path }}
 {% endif %}


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Quite some users managed to delete the contents of the webmail-url field in
setup, which forces front into a restart loop. Catch the case where a webmail
service is configured, but url is empty — and force to default /webmail.

### Related issue(s)
closes #856

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
