### PR TITLE
Update fetchmail to selfbuilt 7.0.0-alpha

### DIFF
--- a/services/fetchmail/Dockerfile
+++ b/services/fetchmail/Dockerfile
@@ -1,13 +1,30 @@
+# First stage: Build
+FROM alpine:3.8 as builder
+
+# build dependencies
+RUN apk add --no-cache curl tar xz autoconf git gettext build-base openssl openssl-dev
+
+RUN curl 'https://netcologne.dl.sourceforge.net/project/fetchmail/branch_6.3/fetchmail-7.0.0-alpha6.tar.xz' | tar xJ
+RUN cd fetchmail-7.0.0-alpha6 && \
+    ./configure --with-ssl --prefix /usr/local --disable-nls && \
+    make
+
 FROM alpine:3.8
+
+
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip bash \
   && pip3 install --upgrade pip
+
 # Image specific layers under this line
-RUN apk add --no-cache fetchmail ca-certificates \
+RUN apk add --no-cache ca-certificates openssl \
  && pip3 install requests
 
+COPY --from=builder /fetchmail-7.0.0-alpha6/fetchmail /usr/local/bin
 COPY fetchmail.py /fetchmail.py
+
+RUN adduser -D fetchmail
 USER fetchmail
 
 CMD ["/fetchmail.py"]

--- a/services/fetchmail/Dockerfile
+++ b/services/fetchmail/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as builder
 # build dependencies
 RUN apk add --no-cache curl tar xz autoconf git gettext build-base openssl openssl-dev
 
-RUN curl -L 'https://netcologne.dl.sourceforge.net/project/fetchmail/branch_6.3/fetchmail-7.0.0-alpha6.tar.xz' | tar xJ
+RUN curl -L 'https://sourceforge.net/projects/fetchmail/files/branch_7-alpha/fetchmail-7.0.0-alpha6.tar.xz/download' | tar xJ
 RUN cd fetchmail-7.0.0-alpha6 && \
     ./configure --with-ssl --prefix /usr/local --disable-nls && \
     make

--- a/services/fetchmail/Dockerfile
+++ b/services/fetchmail/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.8 as builder
 # build dependencies
 RUN apk add --no-cache curl tar xz autoconf git gettext build-base openssl openssl-dev
 
-RUN curl 'https://netcologne.dl.sourceforge.net/project/fetchmail/branch_6.3/fetchmail-7.0.0-alpha6.tar.xz' | tar xJ
+RUN curl -L 'https://netcologne.dl.sourceforge.net/project/fetchmail/branch_6.3/fetchmail-7.0.0-alpha6.tar.xz' | tar xJ
 RUN cd fetchmail-7.0.0-alpha6 && \
     ./configure --with-ssl --prefix /usr/local --disable-nls && \
     make

--- a/services/fetchmail/fetchmail.py
+++ b/services/fetchmail/fetchmail.py
@@ -22,7 +22,6 @@ poll "{host}" proto {protocol}  port {port}
     is "{user_email}"
     smtphost "{smtphost}"
     {options}
-    sslproto 'AUTO'
 """
 
 
@@ -54,7 +53,7 @@ def run(debug):
     for fetch in fetches:
         fetchmailrc = ""
         options = "options antispam 501, 504, 550, 553, 554"
-        options += " ssl" if fetch["tls"] else ""
+        options += " sslmode wrapped" if fetch["tls"] else ""
         options += " keep" if fetch["keep"] else " fetchall"
         fetchmailrc += RC_LINE.format(
             user_email=escape_rc_string(fetch["user_email"]),

--- a/towncrier/newsfragments/891.feature
+++ b/towncrier/newsfragments/891.feature
@@ -1,0 +1,1 @@
+Update Fetchmail to 7.0.0, which features more current SSL support


### PR DESCRIPTION
## What type of PR?
enhancement

## What does this PR do?
Fetchmail in alpine is ~5 years old — and doesn’t support current SSL/TLS
variants anymore. This especially leads to our own fetchmail not being able to
pull mail from mailu itself. Since no new fetchmail release is on the horizon,
let’s build the lastest distribution artifact — which strangely is not
6.4.0-snapshot, but 7.0.0-alpha — ourselves.

### Related issue(s)
closes #808 

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
