### PR TITLE
Don't generate the clamav configuration if ANTIVIRUS is none.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ v1.6.1 - unreleased
 - Enhancement: Create an Authentication Token with IPv6 address restriction ([#829](https://github.com/Mailu/Mailu/issues/829))
 - Bug: Fix creating new fetched accounts
 - Enhancement: Missing wildcard option in alias flask command ([#869](https://github.com/Mailu/Mailu/issues/869))
+- Bug: Fix poor performance if ANTIVIRUS is configured to none.
 
 v1.6.0 - 2019-01-18
 -------------------

--- a/services/rspamd/conf/antivirus.conf
+++ b/services/rspamd/conf/antivirus.conf
@@ -1,6 +1,8 @@
+{% if ANTIVIRUS == 'clamav' %}
 clamav {
   attachments_only = true;
   symbol = "CLAM_VIRUS";
   type = "clamav";
   servers = "antivirus:3310";
 }
+{% endif %}

--- a/tests/compose/filters/mailu.env
+++ b/tests/compose/filters/mailu.env
@@ -60,7 +60,7 @@ WEBMAIL=none
 WEBDAV=none
 
 # Antivirus solution (value: clamav, none)
-#ANTIVIRUS=clamav
+ANTIVIRUS=clamav
 
 #Antispam solution
 ANTISPAM=none


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Avoid rspamd to try to connect to clamav if you choose ANTIVIRUS="none".  Otherwise the rspamd will try to connect to none, timing out several times and leading to poor performance.

I have a server without CLAMAV; and I'm getting times up to 45s:

```
$ grep 'CLAMAV' ~/downloads/logs-from-antispam-in-mailu-security-5d75fb987-kv958.txt | grep -o 'time: [^m]*'
time: 45011.089
time: 45126.002
time: 45002.024
time: 45037.436
time: 45006.775
...
```

Mails for which clamav is not used range from a tens of miliseconds to a few hundred.


## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
