### PR TITLE
Kubernetes manifests finetuning

### DIFF
--- a/docs/kubernetes/mailu/admin.yaml
+++ b/docs/kubernetes/mailu/admin.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: admin
-        image: mailu/admin:master
+        image: mailu/admin:1.6
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/docs/kubernetes/mailu/fetchmail.yaml
+++ b/docs/kubernetes/mailu/fetchmail.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: fetchmail
-        image: mailu/fetchmail:master
+        image: mailu/fetchmail:1.6
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/docs/kubernetes/mailu/front.yaml
+++ b/docs/kubernetes/mailu/front.yaml
@@ -35,7 +35,7 @@ spec:
       terminationGracePeriodSeconds: 60
       containers:
       - name: front
-        image: mailu/nginx:master
+        image: mailu/nginx:1.6
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/docs/kubernetes/mailu/imap.yaml
+++ b/docs/kubernetes/mailu/imap.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: imap
-        image: mailu/dovecot:master
+        image: mailu/dovecot:1.6
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/docs/kubernetes/mailu/security-ingress.yaml
+++ b/docs/kubernetes/mailu/security-ingress.yaml
@@ -6,11 +6,11 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: letsencrypt-stage
+    ingress.kubernetes.io/rewrite-target: "/"
+    ingress.kubernetes.io/auth-url: http://admin.mailu-mailserver.svc.cluster.local/internal/auth/admin
+    # Following snippet sets the password automatically because you're approved by the auth-url
     ingress.kubernetes.io/configuration-snippet: |
-      rewrite ^/admin/antispam/(.*) /$1 break;
-      auth_request /internal/auth/admin;
-      proxy_set_header X-Real-IP "";
-      proxy_set_header X-Forwarded-For "";
+      proxy_set_header Password "mailu";
   labels:
     app: mailu
     role: mail

--- a/docs/kubernetes/mailu/security.yaml
+++ b/docs/kubernetes/mailu/security.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: antispam
-        image: mailu/rspamd:master
+        image: mailu/rspamd:1.6
         imagePullPolicy: Always
         envFrom:
           - configMapRef:
@@ -45,7 +45,7 @@ spec:
             mountPath: /etc/rspamd/override.d
             subPath: rspamd-overrides
       - name: antivirus
-        image: mailu/clamav:master
+        image: mailu/clamav:1.6
         imagePullPolicy: Always
         resources:
           requests:

--- a/docs/kubernetes/mailu/smtp.yaml
+++ b/docs/kubernetes/mailu/smtp.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: smtp
-        image: mailu/postfix:master
+        image: mailu/postfix:1.6
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/docs/kubernetes/mailu/webdav.yaml
+++ b/docs/kubernetes/mailu/webdav.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: radicale
-        image: mailu/radicale:master
+        image: mailu/radicale:1.6
         imagePullPolicy: Always
         envFrom:
           - configMapRef:

--- a/docs/kubernetes/mailu/webmail.yaml
+++ b/docs/kubernetes/mailu/webmail.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: roundcube
-        image: mailu/roundcube:master
+        image: mailu/roundcube:1.6
         imagePullPolicy: Always
         envFrom:
           - configMapRef:


### PR DESCRIPTION
## What type of PR?
enhancement

## What does this PR do?
- Added better implementation of Rspamd ingress for kubernetes
- Updated container versions to `1.6` instead of `master` for kubernetes manifests (this makes branch 1.6 a stable one, also for kubernetes)

### Related issue(s)
- Mention an issue like: #893 
