### PR TITLE
Install bash in alpine based images.

### DIFF
--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git \
+    python3 py3-pip git bash \
   && pip3 install --upgrade pip
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart
 # Image specific layers under this line

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git \
+    python3 py3-pip git bash \
   && pip3 install --upgrade pip
 # Shared layer between rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart

--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git \
+    python3 py3-pip git bash \
   && pip3 install --upgrade pip
 # Shared layer between rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git \
+    python3 py3-pip git bash \
   && pip3 install --upgrade pip
 # Shared layer between rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart

--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip \
+    python3 py3-pip bash \
   && pip3 install --upgrade pip
 # Image specific layers under this line
 RUN apk add --no-cache clamav rsyslog wget clamav-libunrar

--- a/optional/postgresql/Dockerfile
+++ b/optional/postgresql/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip \
+    python3 py3-pip bash \
   && pip3 install --upgrade pip
 # Shared layer between rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install jinja2

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
 
 RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
- && apk add --no-cache radicale@testing py-dulwich@testing curl
+ && apk add --no-cache radicale@testing py-dulwich@testing curl bash
 
 COPY radicale.conf /radicale.conf
 

--- a/services/fetchmail/Dockerfile
+++ b/services/fetchmail/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip \
+    python3 py3-pip bash \
   && pip3 install --upgrade pip
 # Image specific layers under this line
 RUN apk add --no-cache fetchmail ca-certificates \

--- a/services/rspamd/Dockerfile
+++ b/services/rspamd/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git \
+    python3 py3-pip git bash \
   && pip3 install --upgrade pip
 # Shared layer between rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart

--- a/services/unbound/Dockerfile
+++ b/services/unbound/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.8
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git \
+    python3 py3-pip git bash \
   && pip3 install --upgrade pip
 # Shared layer between rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart


### PR DESCRIPTION
This fixes #918

Bash shell is used by default in Kubernetes' dashboard console, which is very
useful for admins.

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
- closes #918 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: place entry in the [changelog](CHANGELOG.md), under the latest un-released version.
