### PR TITLE
Add extra newline to main.cf

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -112,3 +112,4 @@ milter_default_action = tempfail
 ###############
 # Extra Settings
 ###############
+


### PR DESCRIPTION
This should prevent jinja from stripping the newline, which causes overrides to be appended after the comment section


## What type of PR?

Bugfix

## What does this PR do?

Adds a new empty newline a the end of `conf/main.cf` so prevent jinja from stripping it, by which overrides done with `postconf -e` are not appended correctly.

### Related issue(s)

see #941

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.