### PR TITLE
Increase dovecot mail_max_userip_connections

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -84,6 +84,7 @@ service auth-worker {
 ###############
 protocol imap {
   mail_plugins = $mail_plugins imap_quota imap_sieve
+  mail_max_userip_connections = 20
 }
 
 protocol pop3 {


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Dovecot default mail_max_userip_connections is set to 10. We manage to exceed the limit being connected simultaneously to different clients eg. Thunderbird, webmail, mobile client etc.

### Related issue(s)

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
