### PR TITLE
remove "ANTISPAM" from "mailu.env"

### DIFF
--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -67,9 +67,6 @@ WEBDAV={{ webdav_enabled or 'none' }}
 # Antivirus solution (value: clamav, none)
 #ANTIVIRUS={{ antivirus_enabled or 'none' }}
 
-#Antispam solution
-ANTISPAM={{ antispam_enabled or 'none'}}
-
 ###################################
 # Mail settings
 ###################################


### PR DESCRIPTION
"ANTISPAM" env variable is not used anymore, and should be removed from "mailu.env" to avoid confusion.
see commit: https://github.com/Mailu/Mailu/commit/1e3392e4175ff41d0dfc61c8fba40914e7d179ea
