### PR TITLE
Correct hardcoded WEBROOT_REDIRECT

### DIFF
--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -113,7 +113,11 @@ COMPRESSION_LEVEL={{ compression_level }}
 ###################################
 
 # Path to redirect / to
-WEBROOT_REDIRECT=/webmail
+{% if webmail_type != 'none' and webmail_path == '' %}
+WEBROOT_REDIRECT=/
+{% else %}
+WEBROOT_REDIRECT={{ webmail_path }}
+{% endif %}
 
 # Path to the admin interface if enabled
 WEB_ADMIN={{ admin_path }}


### PR DESCRIPTION
We should not assume that the user has chosen the word "webmail" for his webmail path.