### PR TITLE
Added extra empty line at the end of file

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -112,3 +112,4 @@ milter_default_action = tempfail
 ###############
 # Extra Settings
 ###############
+


### PR DESCRIPTION
## What type of PR?

Bug-fix

## What does this PR do?

In case if you have postfix.cf in overrides folder then without extra empty line first value from postfix.cf gets added in the comment line.