### PR TITLE
Stop building certdumper since it is not supported by traefik anymore

### DIFF
--- a/tests/build.yml
+++ b/tests/build.yml
@@ -30,9 +30,9 @@ services:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}radicale:${MAILU_VERSION:-local}
     build: ../optional/radicale
 
-  traefik-certdumper:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}traefik-certdumper:${MAILU_VERSION:-local}
-    build: ../optional/traefik-certdumper
+#  traefik-certdumper:
+#    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}traefik-certdumper:${MAILU_VERSION:-local}
+#    build: ../optional/traefik-certdumper
 
   admin:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}admin:${MAILU_VERSION:-local}


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix the build by disabling the build of traefik-certdumper, which uses now unsupported certificate dumping script from traefik.

### Related issue(s)
- relates to #1011 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
