### PR TITLE
Fixed hardcoded antispam and antivirus host addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ v1.6.1 - unreleased
 - Enhancement: Create an Authentication Token with IPv6 address restriction ([#829](https://github.com/Mailu/Mailu/issues/829))
 - Enhancement: Automatically create admin user on container startup if given appropriate environment variables
 - Enhancement: Missing wildcard option in alias flask command ([#869](https://github.com/Mailu/Mailu/issues/869))
-- Enhancement: Fixed hardcoded antispam and antivirus host addresses ([#978](https://github.com/Mailu/Mailu/issues/978))
 - Bug: Fix creating new fetched accounts
 - Bug: Fix poor performance if ANTIVIRUS is configured to none.
 - Bug: Implement mailustart to resolve webmail in admin ([#716](https://github.com/Mailu/Mailu/issues/716))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ v1.6.1 - unreleased
 - Enhancement: Create an Authentication Token with IPv6 address restriction ([#829](https://github.com/Mailu/Mailu/issues/829))
 - Enhancement: Automatically create admin user on container startup if given appropriate environment variables
 - Enhancement: Missing wildcard option in alias flask command ([#869](https://github.com/Mailu/Mailu/issues/869))
+- Enhancement: Fixed hardcoded antispam and antivirus host addresses ([#978](https://github.com/Mailu/Mailu/issues/978))
 - Bug: Fix creating new fetched accounts
 - Bug: Fix poor performance if ANTIVIRUS is configured to none.
 - Bug: Implement mailustart to resolve webmail in admin ([#716](https://github.com/Mailu/Mailu/issues/716))

--- a/core/dovecot/conf/bin/ham
+++ b/core/dovecot/conf/bin/ham
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-tee >(rspamc -h antispam:11334 -P mailu learn_ham /dev/stdin) \
-    | rspamc -h antispam:11334 -P mailu -f 13 fuzzy_add /dev/stdin
+tee >(rspamc -h ${HOST_ANTISPAM:-antispam:11334} -P mailu learn_ham /dev/stdin) \
+    | rspamc -h ${HOST_ANTISPAM:-antispam:11334} -P mailu -f 13 fuzzy_add /dev/stdin

--- a/core/dovecot/conf/bin/ham
+++ b/core/dovecot/conf/bin/ham
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-tee >(rspamc -h ${HOST_ANTISPAM:-antispam:11334} -P mailu learn_ham /dev/stdin) \
-    | rspamc -h ${HOST_ANTISPAM:-antispam:11334} -P mailu -f 13 fuzzy_add /dev/stdin
+tee >(rspamc -h ${ANTISPAM_ADDRESS} -P mailu learn_ham /dev/stdin) \
+    | rspamc -h ${ANTISPAM_ADDRESS} -P mailu -f 13 fuzzy_add /dev/stdin

--- a/core/dovecot/conf/bin/spam
+++ b/core/dovecot/conf/bin/spam
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-tee >(rspamc -h antispam:11334 -P mailu learn_spam /dev/stdin) \
-    >(rspamc -h antispam:11334 -P mailu -f 11 fuzzy_add /dev/stdin)
+tee >(rspamc -h ${HOST_ANTISPAM:-antispam:11334} -P mailu learn_spam /dev/stdin) \
+    >(rspamc -h ${HOST_ANTISPAM:-antispam:11334} -P mailu -f 11 fuzzy_add /dev/stdin)

--- a/core/dovecot/conf/bin/spam
+++ b/core/dovecot/conf/bin/spam
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-tee >(rspamc -h ${HOST_ANTISPAM:-antispam:11334} -P mailu learn_spam /dev/stdin) \
-    >(rspamc -h ${HOST_ANTISPAM:-antispam:11334} -P mailu -f 11 fuzzy_add /dev/stdin)
+tee >(rspamc -h ${ANTISPAM_ADDRESS} -P mailu learn_spam /dev/stdin) \
+    >(rspamc -h ${ANTISPAM_ADDRESS} -P mailu -f 11 fuzzy_add /dev/stdin)

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -24,6 +24,7 @@ def start_podop():
 os.environ["FRONT_ADDRESS"] = system.resolve_address(os.environ.get("HOST_FRONT", "front"))
 os.environ["REDIS_ADDRESS"] = system.resolve_address(os.environ.get("HOST_REDIS", "redis"))
 os.environ["ADMIN_ADDRESS"] = system.resolve_address(os.environ.get("HOST_ADMIN", "admin"))
+os.environ["ANTISPAM_ADDRESS"] = system.resolve_address(os.environ.get("HOST_ANTISPAM", "antispam:11334"))
 if os.environ["WEBMAIL"] != "none":
     os.environ["WEBMAIL_ADDRESS"] = system.resolve_address(os.environ.get("HOST_WEBMAIL", "webmail"))
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -147,6 +147,7 @@ optional port number. Those variables are:
 - ``HOST_AUTHSMTP``: the container that is running the authenticated SMTP server for the webnmail (default: ``smtp``, port 10025)
 - ``HOST_ADMIN``: the container that is running the admin interface (default: ``admin``)
 - ``HOST_ANTISPAM``: the container that is running the antispam service (default: ``antispam:11334``)
+- ``HOST_ANTIVIRUS``: the container that is running the antivirus service (default: ``antivirus:3310``)
 - ``HOST_WEBMAIL``: the container that is running the webmail (default: ``webmail``)
 - ``HOST_WEBDAV``: the container that is running the webdav server (default: ``webdav:5232``)
 - ``HOST_REDIS``: the container that is running the redis daemon (default: ``redis``)

--- a/docs/kubernetes/mailu/configmap.yaml
+++ b/docs/kubernetes/mailu/configmap.yaml
@@ -165,4 +165,5 @@
     HOST_ADMIN: "admin.mailu-mailserver.svc.cluster.local"
     HOST_WEBDAV: "webdav.mailu-mailserver.svc.cluster.local:5232"
     HOST_ANTISPAM: "antispam.mailu-mailserver.svc.cluster.local:11332"
+    HOST_ANTIVIRUS: "antivirus.mailu-mailserver.svc.cluster.local:3310"
     HOST_REDIS: "redis.mailu-mailserver.svc.cluster.local"

--- a/services/rspamd/conf/antivirus.conf
+++ b/services/rspamd/conf/antivirus.conf
@@ -3,6 +3,6 @@ clamav {
   attachments_only = true;
   symbol = "CLAM_VIRUS";
   type = "clamav";
-  servers = "{{ HOST_ANTIVIRUS }}";
+  servers = "{{ ANTIVIRUS_ADDRESS }}";
 }
 {% endif %}

--- a/services/rspamd/conf/antivirus.conf
+++ b/services/rspamd/conf/antivirus.conf
@@ -3,6 +3,6 @@ clamav {
   attachments_only = true;
   symbol = "CLAM_VIRUS";
   type = "clamav";
-  servers = "antivirus:3310";
+  servers = "{{ HOST_ANTIVIRUS }}";
 }
 {% endif %}

--- a/services/rspamd/start.py
+++ b/services/rspamd/start.py
@@ -9,11 +9,12 @@ from socrate import system, conf
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
 # Actual startup script
+
 os.environ["FRONT_ADDRESS"] = system.resolve_address(os.environ.get("HOST_FRONT", "front"))
 
 if "HOST_REDIS" not in os.environ:
     os.environ["REDIS_ADDRESS"] = system.resolve_address(os.environ.get("HOST_REDIS", "redis"))
-
+os.environ["HOST_ANTIVIRUS"] = system.resolve_address(os.environ.get("HOST_ANTIVIRUS", "antivirus:3310"))
 
 for rspamd_file in glob.glob("/conf/*"):
     conf.jinja(rspamd_file, os.environ, os.path.join("/etc/rspamd/local.d", os.path.basename(rspamd_file)))

--- a/services/rspamd/start.py
+++ b/services/rspamd/start.py
@@ -14,7 +14,9 @@ os.environ["FRONT_ADDRESS"] = system.resolve_address(os.environ.get("HOST_FRONT"
 
 if "HOST_REDIS" not in os.environ:
     os.environ["REDIS_ADDRESS"] = system.resolve_address(os.environ.get("HOST_REDIS", "redis"))
-os.environ["HOST_ANTIVIRUS"] = system.resolve_address(os.environ.get("HOST_ANTIVIRUS", "antivirus:3310"))
+
+if os.environ.get("ANTIVIRUS") == 'clamav':
+    os.environ["ANTIVIRUS_ADDRESS"] = system.resolve_address(os.environ.get("HOST_ANTIVIRUS", "antivirus:3310"))
 
 for rspamd_file in glob.glob("/conf/*"):
     conf.jinja(rspamd_file, os.environ, os.path.join("/etc/rspamd/local.d", os.path.basename(rspamd_file)))

--- a/towncrier/newsfragments/979.feature
+++ b/towncrier/newsfragments/979.feature
@@ -1,0 +1,1 @@
+Fixed hardcoded antispam and antivirus host addresses


### PR DESCRIPTION
## What type of PR?

enchancement

## What does this PR do?

Adds configurable parameters `HOST_ANTISPAM` and `HOST_ANTIVIRUS` for `core/dovecot` and `services/rspamd`, instead of using hardcoded container names.

### Related issue(s)
- closes #978 