### PR TITLE
Merge DNS hints, and hostname/domain ordering hints.

### DIFF
--- a/docs/dns.rst
+++ b/docs/dns.rst
@@ -48,3 +48,13 @@ And for another domain, ``myotherdomain.com`` for example:
   myotherdomain.com.  IN  MX  10 mail.mydomain.com.
 
 Note that both point to the same mail server hostname, which is unique to your server.
+
+DKIM/SPF & DMARC Entries
+------------------------
+
+Finally, you'll need to visit the admin dashboard (or use the cli) to regenerate your DMARC, SPF, and DKIM records.
+
+Once the DNS changes to your host have propogated (and if SSL / domain rules were setup correctly, visit your admin
+dashboard at https://example.com/admin/ui/domain/details/example.com. Click on `regenerate keys` and add the required
+records to your DNS provider. If you've enabled DKIM/SPF / DMARC and haven't added these entries, your mail might
+not get delivered.

--- a/docs/dns.rst
+++ b/docs/dns.rst
@@ -54,7 +54,7 @@ DKIM/SPF & DMARC Entries
 
 Finally, you'll need to visit the admin dashboard (or use the cli) to regenerate your DMARC, SPF, and DKIM records.
 
-Once the DNS changes to your host have propogated (and if SSL / domain rules were setup correctly, visit your admin
+Once the DNS changes to your host have propogated (and if SSL / domain rules were setup correctly), visit your admin
 dashboard at https://example.com/admin/ui/domain/details/example.com. Click on `regenerate keys` and add the required
 records to your DNS provider. If you've enabled DKIM/SPF / DMARC and haven't added these entries, your mail might
 not get delivered.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -319,6 +319,11 @@ down and up again. A container restart is not sufficient.
 
 *Issue reference:* `615`_.
 
+Access Denied Errors
+--------------------
+
+While this may be due to several issues, check to make sure your ``DOMAIN=`` entry is the **first** entry in your ``HOSTNAMES=``.
+
 TLS certificate issues
 ``````````````````````
 

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -61,6 +61,10 @@ Perform the specific setup steps
 Specific setup steps are described per flavor (Compose, Kubernetes, etc.)
 and you should follow the steps after completing the requirements.
 
+After setting up your flavor, continue to the DNS setup instructions,
+additional steps in the admin dashboard will be needed to generate your
+DMARC and SPF/DKIM keys.
+
 Make sure that you test properly before going live!
 
 - Try to send an email to an external service

--- a/setup/templates/steps/compose/03_expose.html
+++ b/setup/templates/steps/compose/03_expose.html
@@ -50,7 +50,9 @@ avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</co
 
 <p>You server will be available under a main hostname but may expose multiple public
 hostnames. Every e-mail domain that points to this server must have one of the
-hostnames in its <code>MX</code> record. Hostnames must be coma-separated.</p>
+hostnames in its <code>MX</code> record. Hostnames must be coma-separated. If you're having
+trouble accessing your admin interface, make sure it is the first entry here (and possibly the
+same as your <code>DOMAIN</code> entry from earlier.</p>
 
 <div class="form-group">
   <label>Public hostnames</label>

--- a/setup/templates/steps/stack/03_expose.html
+++ b/setup/templates/steps/stack/03_expose.html
@@ -11,7 +11,9 @@ you expose it to the world.</p>
 
 <p>You server will be available under a main hostname but may expose multiple public
 hostnames. Every e-mail domain that points to this server must have one of the
-hostnames in its <code>MX</code> record. Hostnames must be coma-separated.</p>
+hostnames in its <code>MX</code> record. Hostnames must be coma-separated. If you're having
+trouble accessing your admin interface, make sure it is the first entry here (and possibly the
+same as your <code>DOMAIN</code> entry from earlier.</p>
 
 <div class="form-group">
   <label>Public hostnames</label>


### PR DESCRIPTION
## Enhancement - Hints in setup, references in setup & DNS docs

Unrelated: This PR makes changes to the Flask setup utilities to suggest ordering the `HOSTNAMES` 
entry so that the first entry is the admin panel's domain (at least in my experience that's what fixed my
issues)

It also makes changes to the documentation, referencing that more than the usual DNS
entries need to be set (and the admin panel used) if they've enabled DMARC/SPF/DKIM.

### Related issue(s)
- My original issue #1002

## Prerequistes

- [x] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.

## Assistance
I'm unsure if the hints for HOSTNAME ordering are simply because of how the config is gulped in
by the current tooling, or if it's a bug that the frontend only accepts connections from the first host...

I also don't know what commands in the CLI would replicate the steps taken on the admin dashboard.

Further, I don't know what you'd put in the changelog.