### PR TITLE
Fixed Nginx configuration documentation regarding reverse proxy

### DIFF
--- a/towncrier/newsfragments/1028.doc
+++ b/towncrier/newsfragments/1028.doc
@@ -1,0 +1,1 @@
+Updated documentation regarding reverse proxy configuration (serving mailu behind a reverse proxy)


### PR DESCRIPTION
The current version of the example configuration seems not to work. In my opinion the letsencrypt certificates have to be configured and http has to be forwarded as well to allow obtaining letsencrypt certificates.

This configuration works for Nginx as reverse proxy before Mailu (I am serving mailu on a subdomain mail.myhost.com).

Did I not understand something, or is it possible the documentation was missing this?

## What type of PR?

documentation

## What does this PR do?

Fixes the documentation to allow serving Mailu behind a reverse proxy.

### Related issue(s)
No issue created, just tried to share the experience I had when installing mailu.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
