### PR TITLE
Update user_external example for nextcloud

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -265,7 +265,7 @@ I want to integrate Nextcloud 15 (and newer) with Mailu
   
 
 If a domain name (e.g. example.com) is specified, then this makes sure that only users from this domain will be allowed to login.
-After successfull login the domain part will be striped and the rest used as username in NextCloud. e.g. 'username@example.com' will be 'username' in NextCloud. Disable this behaviour by changing true (the fifth parameter) to false. 
+After successfull login the domain part will be striped and the rest used as username in Nextcloud. e.g. 'username@example.com' will be 'username' in Nextcloud. Disable this behaviour by changing true (the fifth parameter) to false. 
 
 *Issue reference:* `575`_.
 
@@ -301,7 +301,7 @@ I want to integrate Nextcloud 14 (and older) with Mailu
   ),
 
 If a domain name (e.g. example.com) is specified, then this makes sure that only users from this domain will be allowed to login.
-After successfull login the domain part will be striped and the rest used as username in NextCloud. e.g. 'username@example.com' will be 'username' in NextCloud.
+After successfull login the domain part will be striped and the rest used as username in Nextcloud. e.g. 'username@example.com' will be 'username' in Nextcloud.
 
 *Issue reference:* `575`_.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -245,9 +245,9 @@ correct syntax. The following file names will be taken as override configuration
 I want to integrate Nextcloud 15 (and newer) with Mailu
 ````````````````````````````````````````
 
-First of all you have to enable External user support from Nextcloud Apps interface
+1. Enable External user support from Nextcloud Apps interface
 
-In the end you need to configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax if you use at least Nextcloud 15.
+2. Configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax if you use at least Nextcloud 15.
 
 .. code-block:: bash
 
@@ -272,7 +272,7 @@ After successfull login the domain part will be striped and the rest used as use
 I want to integrate Nextcloud 14 (and older) with Mailu
 ````````````````````````````````````````
 
-First of all you have to install dependencies required to authenticate users via imap in Nextcloud
+1. Install dependencies required to authenticate users via imap in Nextcloud
 
 .. code-block:: bash
 
@@ -282,9 +282,9 @@ First of all you have to install dependencies required to authenticate users via
    && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
    && docker-php-ext-install imap
 
-Next, you have to enable External user support from Nextcloud Apps interface
+2. Enable External user support from Nextcloud Apps interface
 
-In the end you need to configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax for Nextcloud 14 (and below):
+3. Configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax for Nextcloud 14 (and below):
 
 .. code-block:: bash
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -242,7 +242,34 @@ correct syntax. The following file names will be taken as override configuration
 
 *Issue reference:* `206`_.
 
-I want to integrate Nextcloud with Mailu
+I want to integrate Nextcloud 15 (and newer) with Mailu
+````````````````````````````````````````
+
+First of all you have to enable External user support from Nextcloud Apps interface
+
+In the end you need to configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax if you use at least Nextcloud 15.
+
+.. code-block:: bash
+
+  <?php
+
+  /** Use this for Nextcloud 15 and newer **/
+  'user_backends' => array(
+      array(
+          'class' => 'OC_User_IMAP',
+          'arguments' => array(
+            '127.0.0.1', 993, 'ssl', 'example.com', true, false
+        ),
+      ),
+  ),
+  
+
+If a domain name (e.g. example.com) is specified, then this makes sure that only users from this domain will be allowed to login.
+After successfull login the domain part will be striped and the rest used as username in NextCloud. e.g. 'username@example.com' will be 'username' in NextCloud. You can disable this behaviour by changing true (the fifth parameter) to false. 
+
+*Issue reference:* `575`_.
+
+I want to integrate Nextcloud 14 (and older) with Mailu
 ````````````````````````````````````````
 
 First of all you have to install dependencies required to authenticate users via imap in Nextcloud
@@ -257,25 +284,7 @@ First of all you have to install dependencies required to authenticate users via
 
 Next, you have to enable External user support from Nextcloud Apps interface
 
-In the end you need to configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax if you use at least Nextcloud 15.
-
-.. code-block:: bash
-
-  <?php
-
-  /** Use this for Nextcloud 15 and newer **/
-  'user_backends' => array(
-      array(
-          'class' => 'OC_User_IMAP',
-          'arguments' => array(
-            '127.0.0.1', 993, 'ssl', 'example.com'
-        ),
-      ),
-  ),
-  
-
-For Nextcloud 14 and below use the following syntax:
-
+In the end you need to configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax for Nextcloud 14 (and below):
 
 .. code-block:: bash
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -265,7 +265,7 @@ I want to integrate Nextcloud 15 (and newer) with Mailu
   
 
 If a domain name (e.g. example.com) is specified, then this makes sure that only users from this domain will be allowed to login.
-After successfull login the domain part will be striped and the rest used as username in NextCloud. e.g. 'username@example.com' will be 'username' in NextCloud. You can disable this behaviour by changing true (the fifth parameter) to false. 
+After successfull login the domain part will be striped and the rest used as username in NextCloud. e.g. 'username@example.com' will be 'username' in NextCloud. Disable this behaviour by changing true (the fifth parameter) to false. 
 
 *Issue reference:* `575`_.
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -257,12 +257,31 @@ First of all you have to install dependencies required to authenticate users via
 
 Next, you have to enable External user support from Nextcloud Apps interface
 
-In the end you need to configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax:
+In the end you need to configure additional user backends in Nextcloud’s configuration config/config.php using the following syntax if you use at least Nextcloud 15.
 
 .. code-block:: bash
 
   <?php
 
+  /** Use this for Nextcloud 15 and newer **/
+  'user_backends' => array(
+      array(
+          'class' => 'OC_User_IMAP',
+          'arguments' => array(
+            '127.0.0.1', 993, 'ssl', 'example.com'
+        ),
+      ),
+  ),
+  
+
+For Nextcloud 14 and below use the following syntax:
+
+
+.. code-block:: bash
+
+  <?php
+
+  /** Use this for Nextcloud 14 and older **/
   'user_backends' => array(
       array(
           'class' => 'OC_User_IMAP',


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?

Update the user_external example for Nextcloud due an upstream change. PHP will remove the imap extension. Newer user_external releases requires a different configuration for imap.

### Related issue(s)
- https://github.com/nextcloud/user_external/issues/52

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
