### PR TITLE
upgrade alpine base-image

### DIFF
--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -1,17 +1,18 @@
-FROM alpine:3.8
+FROM alpine:3.9
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip git bash \
   && pip3 install --upgrade pip
+# Shared layer between admin, rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart
 # Image specific layers under this line
 RUN mkdir -p /app
 WORKDIR /app
 
 COPY requirements-prod.txt requirements.txt
-RUN apk add --no-cache libressl curl postgresql-libs mariadb-connector-c \
+RUN apk add --no-cache openssl curl postgresql-libs mariadb-connector-c \
  && apk add --no-cache --virtual build-dep \
- libressl-dev libffi-dev python3-dev build-base postgresql-dev mariadb-connector-c-dev \
+ openssl-dev libffi-dev python3-dev build-base postgresql-dev mariadb-connector-c-dev \
  && pip3 install -r requirements.txt \
  && apk del --no-cache build-dep
 

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.8
+FROM alpine:3.9
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip git bash \
   && pip3 install --upgrade pip
-# Shared layer between rspamd, postfix, dovecot, unbound and nginx
+# Shared layer between admin, rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart
+# Shared layer between dovecot and postfix
+RUN pip3 install podop
 # Image specific layers under this line
 RUN apk add --no-cache \
-  dovecot dovecot-pigeonhole-plugin rspamd-client bash \
-  && pip3 install podop \
+  dovecot dovecot-lmtpd dovecot-pop3d dovecot-submissiond dovecot-pigeonhole-plugin rspamd-client \
   && mkdir /var/lib/dovecot
 
 COPY conf /conf

--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.8
+FROM alpine:3.9
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip git bash \
   && pip3 install --upgrade pip
-# Shared layer between rspamd, postfix, dovecot, unbound and nginx
+# Shared layer between admin, rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart
 # Image specific layers under this line
 RUN apk add --no-cache certbot nginx nginx-mod-mail openssl curl \

--- a/core/none/Dockerfile
+++ b/core/none/Dockerfile
@@ -1,5 +1,5 @@
 # This is an idle image to dynamically replace any component if disabled.
 
-FROM alpine:3.8
+FROM alpine:3.9
 
 CMD sleep 1000000d

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,14 +1,15 @@
-FROM alpine:3.8
+FROM alpine:3.9
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip git bash \
   && pip3 install --upgrade pip
-# Shared layer between rspamd, postfix, dovecot, unbound and nginx
+# Shared layer between admin, rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart
+# Shared layer between dovecot and postfix
+RUN pip3 install podop
 # Image specific layers under this line
 
-RUN apk add --no-cache postfix postfix-pcre rsyslog \
- && pip3 install podop
+RUN apk add --no-cache postfix postfix-pcre rsyslog
 
 COPY conf /conf
 COPY start.py /start.py

--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip bash \

--- a/optional/traefik-certdumper/Dockerfile
+++ b/optional/traefik-certdumper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 RUN apk --no-cache add inotify-tools jq openssl util-linux bash docker
 # while not strictly documented, this script seems to always(?) support previous acme.json versions too

--- a/services/fetchmail/Dockerfile
+++ b/services/fetchmail/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip bash \

--- a/services/rspamd/Dockerfile
+++ b/services/rspamd/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.8
+FROM alpine:3.9
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip git bash \
   && pip3 install --upgrade pip
-# Shared layer between rspamd, postfix, dovecot, unbound and nginx
+# Shared layer between admin, rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart
 # Image specific layers under this line
 RUN apk add --no-cache rspamd rspamd-controller rspamd-proxy rspamd-fuzzy ca-certificates curl

--- a/services/unbound/Dockerfile
+++ b/services/unbound/Dockerfile
@@ -1,9 +1,9 @@
-FROM alpine:3.8
+FROM alpine:3.9
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip git bash \
   && pip3 install --upgrade pip
-# Shared layer between rspamd, postfix, dovecot, unbound and nginx
+# Shared layer between admin, rspamd, postfix, dovecot, unbound and nginx
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart
 # Image specific layers under this line
 RUN apk add --no-cache unbound curl bind-tools \


### PR DESCRIPTION
Upgrades the alpine image from 3.8 to 3.9 on all containers __except__ postgres

Postgres container upgrade would pull in a new major version of postgres which requires some (manual) work the make to old data readable by the new version

Also I changed `libressl` to `openssl` because alpine 3.9 has switched back to the OG openssl :D