### PR TITLE
Postsrsd to avoid SPF rejects when Mailu used as MTA

### DIFF
--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
 RUN pip3 install git+https://github.com/usrpro/MailuStart.git#egg=mailustart
 # Image specific layers under this line
 
-RUN apk add --no-cache postfix postfix-pcre rsyslog \
+RUN apk add --no-cache postfix postfix-pcre postsrsd rsyslog \
  && pip3 install podop
 
 COPY conf /conf

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -112,4 +112,7 @@ milter_default_action = tempfail
 ###############
 # Extra Settings
 ###############
-
+sender_canonical_maps = tcp:localhost:10001
+sender_canonical_classes = envelope_sender
+recipient_canonical_maps = tcp:localhost:10002
+recipient_canonical_classes = envelope_recipient, header_recipient

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -30,6 +30,7 @@ os.environ["FRONT_ADDRESS"] = resolve(os.environ.get("FRONT_ADDRESS", "front"))
 os.environ["ADMIN_ADDRESS"] = resolve(os.environ.get("ADMIN_ADDRESS", "admin"))
 os.environ["HOST_ANTISPAM"] = resolve(os.environ.get("HOST_ANTISPAM", "antispam:11332"))
 os.environ["HOST_LMTP"] = resolve(os.environ.get("HOST_LMTP", "imap:2525"))
+os.environ["DOMAIN"] = resolve(os.environ.get("DOMAIN", "localhost"))
 
 for postfix_file in glob.glob("/conf/*.cf"):
     convert(postfix_file, os.path.join("/etc/postfix", os.path.basename(postfix_file)))
@@ -50,7 +51,9 @@ for map_file in glob.glob("/overrides/*.map"):
 
 convert("/conf/rsyslog.conf", "/etc/rsyslog.conf")
 
-# Run Podop and Postfix
+# Generate SRS Secret file, start SRS, run Podop and Postfix
+os.system("dd if=/dev/urandom bs=18 count=1 | base64 > /etc/postsrsd.secret")
+os.system("postsrsd -d " + os.environ["DOMAIN"] + " -s /etc/postsrsd.secret &")
 multiprocessing.Process(target=start_podop).start()
 if os.path.exists("/var/run/rsyslogd.pid"):
     os.remove("/var/run/rsyslogd.pid")


### PR DESCRIPTION
This PR should resolve #328
It implements Postsrsd with Mailu Postfix so that emails from alias are not rejected under SPF protocol.
