### PR TITLE
Update password in commandline

### DIFF
--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -86,6 +86,26 @@ def user(localpart, domain_name, password, hash_scheme=None):
 
 
 @mailu.command()
+@click.argument('localpart')
+@click.argument('domain_name')
+@click.argument('password')
+@click.argument('hash_scheme', required=False)
+@flask_cli.with_appcontext
+def password(localpart, domain_name, password, hash_scheme=None):
+    """ Change the password of an user
+    """
+    email = '{0}@{1}'.format(localpart, domain_name)
+    user   = models.User.query.get(email)
+    if hash_scheme is None:
+        hash_scheme = app.config['PASSWORD_SCHEME']
+    if user:
+        user.set_password(password, hash_scheme=hash_scheme)
+    else:
+        print("User " + email + " not found.")
+    db.session.commit()
+
+
+@mailu.command()
 @click.argument('domain_name')
 @click.option('-u', '--max-users')
 @click.option('-a', '--max-aliases')

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -6,6 +6,7 @@ Managing users and aliases can be done from CLI using commands:
 * alias
 * alias-delete
 * domain
+* password
 * user
 * user-import
 * user-delete
@@ -33,6 +34,14 @@ domain
 .. code-block:: bash
 
   docker-compose exec admin flask mailu domain example.net
+
+
+password
+--------
+
+.. code-block:: bash
+
+  docker-compose exec admin flask mailu password myuser example.net 'password123'
 
 
 user

--- a/towncrier/newsfragments/1066.feature
+++ b/towncrier/newsfragments/1066.feature
@@ -1,0 +1,1 @@
+Update user password in commandline


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?
Adds the ability to set/reset a user's password from the Mailu command line. Similar to the user command:
```
docker-compose exec admin flask mailu password myuser example.net 'password123'
```
With this we can reset the demo server password every few minutes (#987)

### Related issue(s)
closes #1066

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
