### PR TITLE
use HTTP/1.1 for proxyied connections

### DIFF
--- a/core/nginx/conf/proxy.conf
+++ b/core/nginx/conf/proxy.conf
@@ -3,3 +3,4 @@ proxy_set_header Host $http_host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+proxy_http_version 1.1;

--- a/towncrier/newsfragments/1070.feature
+++ b/towncrier/newsfragments/1070.feature
@@ -1,0 +1,1 @@
+use HTTP/1.1 for proxyied connections


### PR DESCRIPTION
## What type of PR?
Feature/Enhancement

## What does this PR do?
[by default nginx uses HTTP/1.0 when proxying connections](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_http_version), this PR changes that to HTTP/1.1 so keep-alive and other efficiency-improvements are available

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
