### PR TITLE
expose pop3 port, remove imap-ssl from dovecot in kubernetes manifest

### DIFF
--- a/docs/kubernetes/mailu/imap.yaml
+++ b/docs/kubernetes/mailu/imap.yaml
@@ -32,6 +32,7 @@ spec:
         ports:
           - containerPort: 2102
           - containerPort: 2525
+          - containerPort: 110
           - containerPort: 143
           - containerPort: 993
           - containerPort: 4190
@@ -68,6 +69,9 @@ spec:
     protocol: TCP
   - name: imap-transport
     port: 2525
+    protocol: TCP
+  - name: pop3
+    port: 110
     protocol: TCP
   - name: imap-default
     port: 143

--- a/docs/kubernetes/mailu/imap.yaml
+++ b/docs/kubernetes/mailu/imap.yaml
@@ -30,12 +30,16 @@ spec:
             name: maildata
             subPath: overrides
         ports:
-          - containerPort: 2102
-          - containerPort: 2525
-          - containerPort: 110
-          - containerPort: 143
-          - containerPort: 993
-          - containerPort: 4190
+          - name: imap-auth
+            containerPort: 2102
+          - name: imap-transport
+            containerPort: 2525
+          - name: pop3
+            containerPort: 110
+          - name: imap-default
+            containerPort: 143
+          - name: sieve
+            containerPort: 4190
         resources:
           requests:
             memory: 1Gi
@@ -75,9 +79,6 @@ spec:
     protocol: TCP
   - name: imap-default
     port: 143
-    protocol: TCP
-  - name: imap-ssl
-    port: 993
     protocol: TCP
   - name: sieve
     port: 4190


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Exposes provided pop3 service in service definition to get useable by front