### PR TITLE
Allow subnet with host bit set in setup

### DIFF
--- a/setup/server.py
+++ b/setup/server.py
@@ -91,7 +91,7 @@ def build_app(path):
         data = flask.request.form.copy()
         data['uid'] = str(uuid.uuid4())
         try:
-            data['dns'] = str(ipaddress.IPv4Network(data['subnet'])[-2])
+            data['dns'] = str(ipaddress.IPv4Network(data['subnet'], strict=False)[-2])
         except ValueError as err:
             return "Error while generating files: " + str(err)
         db.set(data['uid'], json.dumps(data))

--- a/towncrier/newsfragments/1083.bugfix
+++ b/towncrier/newsfragments/1083.bugfix
@@ -1,0 +1,1 @@
+Allow subnet with host bit set in setup


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
This allows to set the host bit in the subnet while using the [setup](https://setup.mailu.io/1.6/). The host bits are now masked out to determine the appropriate network address. This means that e.g. `172.17.0.1/12` is now considered as `172.17.0.0/12`.
So new users are not confused by error messages while setup a new Mailu instance (as you can see the multiple requests in the Matrix chat).

ref: https://docs.python.org/3/library/ipaddress.html#ipaddress.IPv4Network

### Related issue(s)
closes #1083 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
