### PR TITLE
Support domain literals (fix #1087)

### DIFF
--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -2,10 +2,13 @@ from mailu import models
 from mailu.internal import internal
 
 import flask
+import re
 
 
 @internal.route("/postfix/domain/<domain_name>")
 def postfix_mailbox_domain(domain_name):
+    if re.match("^\[.*\]$", domain_name):
+        return flask.abort(404)
     domain = models.Domain.query.get(domain_name) or \
              models.Alternative.query.get(domain_name) or \
              flask.abort(404)
@@ -29,7 +32,7 @@ def postfix_alias_map(alias):
 
 @internal.route("/postfix/transport/<path:email>")
 def postfix_transport(email):
-    if email == '*':
+    if email == '*' or re.match("(^|.*@)\[.*\]$", email):
         return flask.abort(404)
     localpart, domain_name = models.Email.resolve_domain(email)
     relay = models.Relay.query.get(domain_name) or flask.abort(404)

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -27,7 +27,10 @@ class IdnaDomain(db.TypeDecorator):
     impl = db.String(80)
 
     def process_bind_param(self, value, dialect):
-        return idna.encode(value).decode("ascii").lower()
+        try:
+            return idna.encode(value).decode("ascii").lower()
+        except ValueError:
+            pass
 
     def process_result_value(self, value, dialect):
         return idna.decode(value)

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -27,10 +27,7 @@ class IdnaDomain(db.TypeDecorator):
     impl = db.String(80)
 
     def process_bind_param(self, value, dialect):
-        try:
-            return idna.encode(value).decode("ascii").lower()
-        except ValueError:
-            pass
+        return idna.encode(value).decode("ascii").lower()
 
     def process_result_value(self, value, dialect):
         return idna.decode(value)

--- a/towncrier/newsfragments/1087.bugfix
+++ b/towncrier/newsfragments/1087.bugfix
@@ -1,0 +1,1 @@
+Support domain literals

--- a/towncrier/newsfragments/1087.bugfix
+++ b/towncrier/newsfragments/1087.bugfix
@@ -1,0 +1,1 @@
+Error handling in idna encoding

--- a/towncrier/newsfragments/1087.bugfix
+++ b/towncrier/newsfragments/1087.bugfix
@@ -1,1 +1,0 @@
-Error handling in idna encoding


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
This PR adds error handling for idna enocding. With telnet you now get a "Bad sender address syntax"  message.

```
> telnet mail.example.com 25

Connected to example.com.
Escape character is '^]'.
220 mail.example.com ESMTP ready
EHLO dummy.example.com
250-mail.example.com
250 STARTTLS
MAIL FROM: does-not-exist@[116.203.165.200]
250 2.0.0 OK
RCPT TO: some-user@example.com
501 5.1.7 Bad sender address syntax
Connection closed by foreign host.
```


### Related issue(s)
fix #1087

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
