### PR TITLE
Typo fix in templates for stack and compose

### DIFF
--- a/setup/templates/steps/compose/03_expose.html
+++ b/setup/templates/steps/compose/03_expose.html
@@ -50,7 +50,7 @@ avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</co
 
 <p>You server will be available under a main hostname but may expose multiple public
 hostnames. Every e-mail domain that points to this server must have one of the
-hostnames in its <code>MX</code> record. Hostnames must be coma-separated. If you're having
+hostnames in its <code>MX</code> record. Hostnames must be comma-separated. If you're having
 trouble accessing your admin interface, make sure it is the first entry here (and possibly the
 same as your <code>DOMAIN</code> entry from earlier.</p>
 

--- a/setup/templates/steps/stack/03_expose.html
+++ b/setup/templates/steps/stack/03_expose.html
@@ -11,7 +11,7 @@ you expose it to the world.</p>
 
 <p>You server will be available under a main hostname but may expose multiple public
 hostnames. Every e-mail domain that points to this server must have one of the
-hostnames in its <code>MX</code> record. Hostnames must be coma-separated. If you're having
+hostnames in its <code>MX</code> record. Hostnames must be comma-separated. If you're having
 trouble accessing your admin interface, make sure it is the first entry here (and possibly the
 same as your <code>DOMAIN</code> entry from earlier.</p>
 


### PR DESCRIPTION
## What type of PR?
**Template typo fix**

Definitely a quick PR to look at

## What does this PR do?

**Fixes two typos in templates**
_coma_->_comma_ in 
_setup/templates/steps/stack/03_expose.html_ 
and 
_setup/templates/steps/compose/03_expose.html_

### Related issue(s)

**N/A**

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.

**N/A**


