### PR TITLE
replace hardcoded attachment size in roundcube's .htaccess

### DIFF
--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -7,9 +7,15 @@ from socrate import conf
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
-os.environ["MAX_FILESIZE"] = str(int(int(os.environ.get("MESSAGE_SIZE_LIMIT"))*0.66/1048576))
+max_filesize = str(int(int(os.environ.get("MESSAGE_SIZE_LIMIT"))*0.66/1048576))
+os.environ["MAX_FILESIZE"] = max_filesize
 
 conf.jinja("/php.ini", os.environ, "/usr/local/etc/php/conf.d/roundcube.ini")
+
+# Replace default values in /var/www/html/.htaccess (upload_max_filesize=5M, post_max_size=6M)
+os.system("sed -E -i 's/^php_value[[:space:]]+upload_max_filesize .*$/php_value   upload_max_filesize   %sM/g' /var/www/html/.htaccess" % (max_filesize))
+os.system("sed -E -i 's/^php_value[[:space:]]+post_max_size .*$/php_value   post_max_size         %sM/g' /var/www/html/.htaccess" % (int(int(max_filesize)*1.05)))
+
 
 # Fix some permissions
 os.system("mkdir -p /data/gpg")


### PR DESCRIPTION
with a dynamically calculated value based on the environment value MESSAGE_SIZE_LIMIT

Current defaults from roundcube-1.3.9:

- upload_max_filesize=5M
- post_max_size=6M

## What type of PR?
Bug Fix

## What does this PR do?
Fixes the attachment size limit of Roundcube to be (dynamically) based on the environment variable `MESSAGE_SIZE_LIMIT` also in `.htaccess` file. Current behaviour: ignores the environment variable and limits the attachment/message size to 5MB/6MB respectively.