### PR TITLE
Improve traefik-certdumper - run.sh and documentation

### DIFF
--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -178,7 +178,7 @@ One such example is ``mailu/traefik-certdumper``, which has been adapted for use
     volumes:
       # Folder, which contains the acme.json
       - "/data/traefik:/traefik"
-      # Folder, where your.doma.in.crt and your.doma.in.key will be written
+      # Folder, where cert.pem and key.pem will be written
       - "/data/mailu/certs:/output"
 
 

--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -182,15 +182,16 @@ One such example is ``mailu/traefik-certdumper``, which has been adapted for use
       - "/data/traefik/certs:/output"
 
 
-Assuming you have ``volume-mounted`` your ``acme.json`` put to ``/data/traefik`` on your host. The dumper will then write out ``/data/traefik/certs/your.doma.in.crt``
-and ``/data/traefik/certs/your.doma.in.key`` whenever ``acme.json`` is updated. Yay! Now let’s mount this to our ``front`` container like:
+Assuming you have ``volume-mounted`` your ``acme.json`` put to ``/data/traefik`` on your host. The dumper will then write out ``/data/traefik/certs/cert.pem`` and ``/data/traefik/certs/key.pem`` whenever ``acme.json`` is updated.
+Yay! Now let’s mount this to our ``front`` container like:
 
 .. code-block:: yaml
 
     volumes:
-      - "$ROOT/overrides/nginx:/overrides"
       - /data/traefik/certs/$TRAEFIK_DOMAIN.crt:/certs/cert.pem
       - /data/traefik/certs/$TRAEFIK_DOMAIN.key:/certs/key.pem
+
+This works, because we set ``TLS_FLAVOR=mail``, which picks up the key-certificate pair (e.g., ``cert.pem`` and ``key.pem``) from the certs folder in the root path (``/certs/``).
 
 .. _`Traefik`: https://traefik.io/
 

--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -179,17 +179,17 @@ One such example is ``mailu/traefik-certdumper``, which has been adapted for use
       # Folder, which contains the acme.json
       - "/data/traefik:/traefik"
       # Folder, where your.doma.in.crt and your.doma.in.key will be written
-      - "/data/traefik/certs:/output"
+      - "/data/mailu/certs:/output"
 
 
-Assuming you have ``volume-mounted`` your ``acme.json`` put to ``/data/traefik`` on your host. The dumper will then write out ``/data/traefik/certs/cert.pem`` and ``/data/traefik/certs/key.pem`` whenever ``acme.json`` is updated.
+Assuming you have ``volume-mounted`` your ``acme.json`` put to ``/data/traefik`` on your host. The dumper will then write out ``/data/mailu/certs/cert.pem`` and ``/data/mailu/certs/key.pem`` whenever ``acme.json`` is updated.
 Yay! Now let’s mount this to our ``front`` container like:
 
 .. code-block:: yaml
 
     volumes:
-      - /data/traefik/certs/$TRAEFIK_DOMAIN.crt:/certs/cert.pem
-      - /data/traefik/certs/$TRAEFIK_DOMAIN.key:/certs/key.pem
+      - /data/mailu/certs:/certs
+      - /data/mailu/certs:/certs
 
 This works, because we set ``TLS_FLAVOR=mail``, which picks up the key-certificate pair (e.g., ``cert.pem`` and ``key.pem``) from the certs folder in the root path (``/certs/``).
 

--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -189,7 +189,6 @@ Yay! Now let’s mount this to our ``front`` container like:
 
     volumes:
       - /data/mailu/certs:/certs
-      - /data/mailu/certs:/certs
 
 This works, because we set ``TLS_FLAVOR=mail``, which picks up the key-certificate pair (e.g., ``cert.pem`` and ``key.pem``) from the certs folder in the root path (``/certs/``).
 

--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -176,20 +176,21 @@ One such example is ``mailu/traefik-certdumper``, which has been adapted for use
     # !!! Also don’t forget to add "TRAEFIK_DOMAIN=[...]" to your .env!
       - DOMAIN=$TRAEFIK_DOMAIN
     volumes:
+      # Folder, which contains the acme.json
       - "/data/traefik:/traefik"
-      - "$ROOT/certs:/output"
+      # Folder, where your.doma.in.crt and your.doma.in.key will be written
+      - "/data/traefik/certs:/output"
 
 
-
-Assuming you have ``volume-mounted`` your ``acme.json`` put to ``/data/traefik`` on your host. The dumper will then write out ``/data/traefik/ssl/your.doma.in.crt``
-and ``/data/traefik/ssl/your.doma.in.key`` whenever ``acme.json`` is updated. Yay! Now let’s mount this to our ``front`` container like:
+Assuming you have ``volume-mounted`` your ``acme.json`` put to ``/data/traefik`` on your host. The dumper will then write out ``/data/traefik/certs/your.doma.in.crt``
+and ``/data/traefik/certs/your.doma.in.key`` whenever ``acme.json`` is updated. Yay! Now let’s mount this to our ``front`` container like:
 
 .. code-block:: yaml
 
     volumes:
       - "$ROOT/overrides/nginx:/overrides"
-      - /data/traefik/ssl/$TRAEFIK_DOMAIN.crt:/certs/cert.pem
-      - /data/traefik/ssl/$TRAEFIK_DOMAIN.key:/certs/key.pem
+      - /data/traefik/certs/$TRAEFIK_DOMAIN.crt:/certs/cert.pem
+      - /data/traefik/certs/$TRAEFIK_DOMAIN.key:/certs/key.pem
 
 .. _`Traefik`: https://traefik.io/
 

--- a/optional/traefik-certdumper/run.sh
+++ b/optional/traefik-certdumper/run.sh
@@ -5,8 +5,10 @@ function dump() {
 
     traefik-certs-dumper file --crt-name "cert" --crt-ext ".pem" --key-name "key" --key-ext ".pem" --domain-subdir --dest /tmp/work --source /traefik/acme.json > /dev/null
 
-    if diff -q /tmp/work/${DOMAIN}/cert.pem /output/cert.pem >/dev/null && \
-	    diff -q /tmp/work/${DOMAIN}/key.pem /output/key.pem >/dev/null ; then
+    if [[ -f /tmp/work/${DOMAIN}/cert.pem && -f /tmp/work/${DOMAIN}/key.pem && -f /output/cert.pem && -f /output/key.pem ]] && \
+	diff -q /tmp/work/${DOMAIN}/cert.pem /output/cert.pem >/dev/null && \
+	diff -q /tmp/work/${DOMAIN}/key.pem /output/key.pem >/dev/null ; \
+    then
 	echo "$(date) Certificate and key still up to date, doing nothing"
     else
 	echo "$(date) Certificate or key differ, updating"


### PR DESCRIPTION
## What type of PR?

Bug fix and documentation

## What does this PR do?

On the first run, the `run.sh` script shows the error `diff: can't stat '/output/cert.pem': No such file or directory`, because the file does not exist in the folder `/output` yet. This bugfix ensures, that the diff is only called, when all required files are available.

Additionally, the corresponding documentation was updated, since the `run.sh` writes the two files `cert.pem` and `key.pem`, and not `your.doma.in.crt` and `your.doma.in.key`. Also some volume fixes.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly