### PR TITLE
nginx config.py: Don't resolve hosts

### DIFF
--- a/core/nginx/config.py
+++ b/core/nginx/config.py
@@ -14,15 +14,6 @@ with open("/etc/resolv.conf") as handle:
     content = handle.read().split()
     args["RESOLVER"] = content[content.index("nameserver") + 1]
 
-args["HOST_ADMIN"] = system.resolve_address(args.get("HOST_ADMIN", "admin"))
-args["HOST_ANTISPAM"] = system.resolve_address(args.get("HOST_ANTISPAM", "antispam:11334"))
-args["HOST_WEBMAIL"] = args.get("HOST_WEBMAIL", "webmail")
-if args["WEBMAIL"] != "none":
-    args["HOST_WEBMAIL"] = system.resolve_address(args.get("HOST_WEBMAIL"))
-args["HOST_WEBDAV"] = args.get("HOST_WEBDAV", "webdav:5232")
-if args["WEBDAV"] != "none":
-    args["HOST_WEBDAV"] = system.resolve_address(args.get("HOST_WEBDAV"))
-
 # TLS configuration
 cert_name = os.getenv("TLS_CERT_FILENAME", default="cert.pem")
 keypair_name = os.getenv("TLS_KEYPAIR_FILENAME", default="key.pem")


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

It disables static name resolution in config.py because both, docker and kubernetes dynamically updates host ips. Nginx uses the resolver to properly resolve hostnames at runtime.

### Related issue(s)

- none

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

None, it's a minor change.