### PR TITLE
Fix #1109

### DIFF
--- a/services/rspamd/conf/antivirus.conf
+++ b/services/rspamd/conf/antivirus.conf
@@ -3,6 +3,6 @@ clamav {
   attachments_only = true;
   symbol = "CLAM_VIRUS";
   type = "clamav";
-  servers = "antivirus:3310";
+  servers = "{{ HOST_ANTIVIRUS }}";
 }
 {% endif %}

--- a/services/rspamd/start.py
+++ b/services/rspamd/start.py
@@ -12,6 +12,7 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 os.environ["FRONT_ADDRESS"] = system.resolve_address(os.environ.get("FRONT_ADDRESS", "front"))
 
 if "HOST_REDIS" not in os.environ: os.environ["HOST_REDIS"] = "redis"
+if "HOST_ANTIVIRUS" not in os.environ: os.environ["HOST_ANTIVIRUS"] = "antivirus:3310"
 
 for rspamd_file in glob.glob("/conf/*"):
     conf.jinja(rspamd_file, os.environ, os.path.join("/etc/rspamd/local.d", os.path.basename(rspamd_file)))


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
It moves the hardcoded antivirus:3310 host/port to the env variable HOST_ANTIVIRUS which defaults to the original value "antivirus:3310"

### Related issue(s)
- closes #1109

## Prerequistes
None, it's a minor change with backward compatible defaults.