### PR TITLE
Admin ui path

### DIFF
--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -42,7 +42,7 @@ def create_app_from_config(config):
 
     # Import views
     from mailu import ui, internal
-    app.register_blueprint(ui.ui, url_prefix='/ui')
+    app.register_blueprint(ui.ui, url_prefix=app.config.get('ADMIN_UI_PATH'))
     app.register_blueprint(internal.internal, url_prefix='/internal')
 
     return app

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -60,7 +60,8 @@ DEFAULT_CONFIG = {
     'HOST_FRONT': 'front',
     'HOST_AUTHSMTP': os.environ.get('HOST_SMTP', 'smtp'),
     'SUBNET': '192.168.203.0/24',
-    'POD_ADDRESS_RANGE': None
+    'POD_ADDRESS_RANGE': None,
+    'ADMIN_UI_PATH': os.environ.get('ADMIN_UI_PATH', '/ui'),
 }
 
 class ConfigManager(dict):

--- a/docs/kubernetes/mailu/admin-ingress.yaml
+++ b/docs/kubernetes/mailu/admin-ingress.yaml
@@ -26,6 +26,7 @@ spec:
         backend:
           serviceName: admin
           servicePort: 80
+
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -35,9 +36,6 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: letsencrypt-stage
-    ingress.kubernetes.io/rewrite-target: "/ui"
-    ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-Forwarded-Prefix /admin;
   labels:
     app: mailu
     role: mail
@@ -52,35 +50,6 @@ spec:
     http:
       paths:
       - path: "/admin/ui"
-        backend:
-          serviceName: admin
-          servicePort: 80
----
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: mailu-admin-static-ingress
-  namespace: mailu-mailserver
-  annotations:
-    kubernetes.io/tls-acme: "true"
-    certmanager.k8s.io/cluster-issuer: letsencrypt-stage
-    ingress.kubernetes.io/rewrite-target: "/static"
-    ingress.kubernetes.io/configuration-snippet: |
-      proxy_set_header X-Forwarded-Prefix /admin;
-  labels:
-    app: mailu
-    role: mail
-    tier: backend
-spec:
-  tls:
-  - hosts:
-    - "mail.example.com"
-    secretName: letsencrypt-certs-all # If unsure how to generate these, check out https://github.com/ployst/docker-letsencrypt
-  rules:
-  - host: "mail.example.com"
-    http:
-      paths:
-      - path: "/admin/static"
         backend:
           serviceName: admin
           servicePort: 80

--- a/docs/kubernetes/mailu/configmap.yaml
+++ b/docs/kubernetes/mailu/configmap.yaml
@@ -117,9 +117,13 @@
     # Web settings
     ###################################
 
-    # Path to the admin interface if enabled
+    # Public path to the admin interface if enabled
     # Kubernetes addition: You need to change ALL the ingresses, when you want this URL to be different!!!
     WEB_ADMIN: "/admin"
+
+    # Path where the admin web interface is listening. Must be WEB_ADMIN followed by /ui to allow portable ingress definitions.
+    # Kubernetes addition: You need to change ALL the ingresses, when you want this URL to be different!!!
+    ADMIN_UI_PATH: "/admin/ui"
 
     # Path to the webmail if enabled
     # Currently, this is not used, because we intended to use a different subdomain: webmail.example.com

--- a/towncrier/newsfragments/1117.feature
+++ b/towncrier/newsfragments/1117.feature
@@ -1,0 +1,1 @@
+Make the location of the admin ui configurable via ADMIN_UI_PATH env variable. Update kubernetes settings and ingress accordingly.


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Makes the mapping of the admin ui configurable. For kubernetes it should run at /admin/ui, not at /ui so that default ingress settings without rewriting can be used.

### Related issue(s)

- should replace PR #1045

## Prerequistes

- [x] In case of feature or enhancement: documentation updated accordingly
