### PR TITLE
[SUGGESTION] fix for nginx-0.22.0 controller

### DIFF
--- a/docs/kubernetes/mailu/admin-ingress.yaml
+++ b/docs/kubernetes/mailu/admin-ingress.yaml
@@ -35,7 +35,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: letsencrypt-stage
-    ingress.kubernetes.io/rewrite-target: "/ui"
+    ingress.kubernetes.io/rewrite-target: "/ui/$1"
     ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Forwarded-Prefix /admin;
   labels:
@@ -51,7 +51,7 @@ spec:
   - host: "mail.example.com"
     http:
       paths:
-      - path: "/admin/ui"
+      - path: "/admin/ui/?(.*)"
         backend:
           serviceName: admin
           servicePort: 80
@@ -64,7 +64,7 @@ metadata:
   annotations:
     kubernetes.io/tls-acme: "true"
     certmanager.k8s.io/cluster-issuer: letsencrypt-stage
-    ingress.kubernetes.io/rewrite-target: "/static"
+    ingress.kubernetes.io/rewrite-target: "/static/$1"
     ingress.kubernetes.io/configuration-snippet: |
       proxy_set_header X-Forwarded-Prefix /admin;
   labels:
@@ -80,7 +80,7 @@ spec:
   - host: "mail.example.com"
     http:
       paths:
-      - path: "/admin/static"
+      - path: "/admin/static/?(.*)"
         backend:
           serviceName: admin
           servicePort: 80


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
As of a breaking change in nginx ingress controller 0.22 (see https://github.com/kubernetes/ingress-nginx/releases/tag/nginx-0.22.0 ) the rewrite annotation syntax has changed and results in an endless 308 redirect for admin ans static resources. Sadly this change breaks nginx-controllers < 0.22 . 