### PR TITLE
front: advertise real capabilites of mail-backends

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -193,6 +193,11 @@ mail {
     ssl_session_cache shared:SSLMAIL:50m;
     {% endif %}
 
+    # Advertise real capabilites of backends (postfix/dovecot)
+    smtp_capabilities PIPELINING SIZE {{ MESSAGE_SIZE_LIMIT }} ETRN ENHANCEDSTATUSCODES 8BITMIME DSN CHUNKING;
+    pop3_capabilities TOP UIDL RESP-CODES PIPELINING AUTH-RESP-CODE USER;
+    imap_capabilities IMAP4 IMAP4rev1 UIDPLUS SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+;
+
     # Default SMTP server for the webmail (no encryption, but authentication)
     server {
       listen 10025;

--- a/towncrier/newsfragments/1160.feature
+++ b/towncrier/newsfragments/1160.feature
@@ -1,0 +1,1 @@
+Advertise correct mail capabilities through the front-container, this also enables support for PIPELINING in mail-protocols and IMAP IDLE which is a (potential) performance gain.


### PR DESCRIPTION
## What type of PR?
Feature/Enhancement/Bug-Fix

## What does this PR do?
configures nginx in a way that it advertises the real SMTP/IMAP/POP3 capabilities supported by postfix/dovecot instead of just the bare minimum

### Related issue(s)
- #1159 - when this PR is merged IMAP IDLE will be enabled with a 2 minute idle interval as is default in dovecot

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
