### PR TITLE
Add a title to Mailu-Admin pages

### DIFF
--- a/core/admin/mailu/ui/templates/base.html
+++ b/core/admin/mailu/ui/templates/base.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{{ url_for('.static', filename='vendor.css') }}">
     <link rel="stylesheet" href="{{ url_for('.static', filename='app.css') }}">
+    <title>Mailu-Admin - {{ config["SITENAME"] }}</title>
   </head>
   <body class="hold-transition skin-blue sidebar-mini">
     <div class="wrapper">


### PR DESCRIPTION
## What type of PR?

Enhancement

## What does this PR do?

This simply adds a title to be displayed in the browser tab for Mailu-Admin pages.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.

Considering this is only a one-line change I don't think these apply.

-----

I made the title `Mailu-Admin - SITENAME` – if this seems unfitting feel free to change it to something different.