### PR TITLE
Update to address issue #1178 (HTTP headers)

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -70,6 +70,10 @@ http {
       {% endif %}
       {% endif %}
 
+      # Remove headers to prevent duplication and information disclosure
+      proxy_hide_header X-XSS-Protection;
+      proxy_hide_header X-Powered-By;
+      
       add_header X-Frame-Options 'SAMEORIGIN';
       add_header X-Content-Type-Options 'nosniff';
       add_header X-Permitted-Cross-Domain-Policies 'none';


### PR DESCRIPTION
This change should remove the duplicate `x-xss-protection` header and also the `x-powered-by` header.  Hopefully a pull request to main is appropriate, but may be worth back porting to 1.7.

Tested config by modifying live 1.7 nginx config and reloading.  Has had the desired outcome of removing the headers.

```/etc/nginx # nginx -t -c /etc/nginx/nginx.conf 
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
/etc/nginx # nginx -s reload
```

These steps were based on:
- https://serverfault.com/questions/928912/how-do-i-remove-a-server-added-header-from-proxied-location
- https://serverfault.com/questions/929571/overwrite-http-headers-comming-back-from-a-web-application-server-proxied-in-ngi
- http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_hide_header

## What type of PR?

Enhancement

## What does this PR do?
Removes duplicate and unneeded headers.  See issue #1178 

### Related issue(s)
- issue: #1178 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ X ] In case of feature or enhancement: documentation updated accordingly
- [ X ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
