### PR TITLE
Fix rspamd-learn when moving mail from/to junk folder

### DIFF
--- a/core/dovecot/conf/bin/ham
+++ b/core/dovecot/conf/bin/ham
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-tee >(rspamc -h ${ANTISPAM_ADDRESS} -P mailu learn_ham /dev/stdin) \
-    | rspamc -h ${ANTISPAM_ADDRESS} -P mailu -f 13 fuzzy_add /dev/stdin

--- a/core/dovecot/conf/bin/spam
+++ b/core/dovecot/conf/bin/spam
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-tee >(rspamc -h ${ANTISPAM_ADDRESS} -P mailu learn_spam /dev/stdin) \
-    >(rspamc -h ${ANTISPAM_ADDRESS} -P mailu -f 11 fuzzy_add /dev/stdin)

--- a/core/dovecot/conf/ham.script
+++ b/core/dovecot/conf/ham.script
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+tee >(rspamc -h {{ ANTISPAM_ADDRESS }} -P mailu learn_ham /dev/stdin) \
+    | rspamc -h {{ ANTISPAM_ADDRESS }} -P mailu -f 13 fuzzy_add /dev/stdin

--- a/core/dovecot/conf/spam.script
+++ b/core/dovecot/conf/spam.script
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+tee >(rspamc -h {{ ANTISPAM_ADDRESS }} -P mailu learn_spam /dev/stdin) \
+    >(rspamc -h {{ ANTISPAM_ADDRESS }} -P mailu -f 11 fuzzy_add /dev/stdin)

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -37,7 +37,7 @@ os.makedirs("/conf/bin", exist_ok=True)
 for script_file in glob.glob("/conf/*.script"):
     out_file = os.path.join("/conf/bin/", os.path.basename(script_file).replace('.script',''))
     conf.jinja(script_file, os.environ, out_file)
-    os.chmod(out_file, 0555)
+    os.chmod(out_file, 0o555)
 
 # Run Podop, then postfix
 multiprocessing.Process(target=start_podop).start()

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -33,14 +33,11 @@ if os.environ["WEBMAIL"] != "none":
 for dovecot_file in glob.glob("/conf/*.conf"):
     conf.jinja(dovecot_file, os.environ, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))
 
-try:
-    os.mkdir("/conf/bin")
-except FileExistsError:
-    pass
+os.makedirs("/conf/bin", exist_ok=True)
 for script_file in glob.glob("/conf/*.script"):
     out_file = os.path.join("/conf/bin/", os.path.basename(script_file).replace('.script',''))
     conf.jinja(script_file, os.environ, out_file)
-    os.chmod(out_file, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
+    os.chmod(out_file, 0555)
 
 # Run Podop, then postfix
 multiprocessing.Process(target=start_podop).start()

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python3
 
 import os
-import stat
 import glob
 import multiprocessing
 import logging as log

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import os
+import stat
 import glob
 import multiprocessing
 import logging as log
@@ -31,6 +32,15 @@ if os.environ["WEBMAIL"] != "none":
 
 for dovecot_file in glob.glob("/conf/*.conf"):
     conf.jinja(dovecot_file, os.environ, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))
+
+try:
+    os.mkdir("/conf/bin")
+except FileExistsError:
+    pass
+for script_file in glob.glob("/conf/*.script"):
+    out_file = os.path.join("/conf/bin/", os.path.basename(script_file).replace('.script',''))
+    conf.jinja(script_file, os.environ, out_file)
+    os.chmod(out_file, stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP | stat.S_IROTH | stat.S_IXOTH)
 
 # Run Podop, then postfix
 multiprocessing.Process(target=start_podop).start()

--- a/towncrier/newsfragments/1177.bug
+++ b/towncrier/newsfragments/1177.bug
@@ -1,0 +1,1 @@
+Fix piping mail into rspamd when moving from/to junk-folder


### PR DESCRIPTION
Before, the ham/spam scripts got the rspamd-ip/port from the environment.
However, when checking the environment of these processes now, it seems
cleared. Maybe the new dovecot version now clears environment? — I couldn’t
find a hint.

In any case, using the common mechanism of injecting the ip/port from where
it’s definately known by the already-used jinja2-mechanism seems reasonably
safe.

## What type of PR?
bug-fix

## What does this PR do?
Instead of relying on dovecot passing our environment cleanly to sieve-called scripts, this explicitly injects the antispam ip/port into the spam/ham scripts used when moving files from/to the spam-folder. This required some management of the files, such as setting proper permissions after the jinja-run.

### Related issue(s)
fixes #1177 

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
