### PR TITLE
Docs to avoid Update of letsencrypt certificates not possible

### DIFF
--- a/docs/compose/setup.rst
+++ b/docs/compose/setup.rst
@@ -43,6 +43,11 @@ values:
   When using *Letsencrypt!* you have to make sure that the DNS ``A`` and ``AAAA`` records for the
   all hostnames mentioned in the ``HOSTNAMES`` variable match with the ip adresses of you server.
   Or else certificate generation will fail! See also: :ref:`dns_setup`.
+  
+  Also notice that when changing the ``TLS_FLAVOR`` from ``letsencrypt`` back to ``cert`` you need to 
+  delete the ``mailu/certs/letsencrypt`` folder.
+  
+.. _issues: https://github.com/Mailu/Mailu/issues/1164
 
 Bind address
 ````````````

--- a/docs/compose/setup.rst
+++ b/docs/compose/setup.rst
@@ -45,7 +45,8 @@ values:
   Or else certificate generation will fail! See also: :ref:`dns_setup`.
   
   Also notice that when changing the ``TLS_FLAVOR`` from ``letsencrypt`` back to ``cert`` you need to 
-  delete the ``mailu/certs/letsencrypt`` folder.
+  delete the ``mailu/certs/letsencrypt`` folder. This also is necessary when changing config parameters
+  letsencrypt depends on like host or domain names.
   
 .. _issues: https://github.com/Mailu/Mailu/issues/1164
 

--- a/towncrier/newsfragments/1164.doc
+++ b/towncrier/newsfragments/1164.doc
@@ -1,0 +1,1 @@
+Added hint that letsencrypt folder needs to be deleted after changing TLS_FLAVOR setting from letsencrypt back to cert


### PR DESCRIPTION
Documentation update to avoid problem described in #1164

## What type of PR?

documentation

## What does this PR do?

### Related issue(s)
closes #1164

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
