### PR TITLE
Change default password scheme to PBKDF2 (#1194)

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -51,7 +51,7 @@ DEFAULT_CONFIG = {
     'RECAPTCHA_PUBLIC_KEY': '',
     'RECAPTCHA_PRIVATE_KEY': '',
     # Advanced settings
-    'PASSWORD_SCHEME': 'BLF-CRYPT',
+    'PASSWORD_SCHEME': 'PBKDF2',
     'LOG_LEVEL': 'WARNING',
     # Host settings
     'HOST_IMAP': 'imap',

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -143,8 +143,8 @@ DOMAIN_REGISTRATION=true
 COMPOSE_PROJECT_NAME={{ compose_project_name or 'mailu' }}
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME={{ password_scheme or 'BLF-CRYPT' }}
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+PASSWORD_SCHEME={{ password_scheme or 'PBKDF2' }}
 
 # Header to take the real ip from
 REAL_IP_HEADER={{ real_ip_header }}

--- a/tests/compose/core/mailu.env
+++ b/tests/compose/core/mailu.env
@@ -129,8 +129,8 @@ WEBSITE=https://mailu.io
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=BLF-CRYPT
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from
 REAL_IP_HEADER=

--- a/tests/compose/fetchmail/mailu.env
+++ b/tests/compose/fetchmail/mailu.env
@@ -129,8 +129,8 @@ WEBSITE=https://mailu.io
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=BLF-CRYPT
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from
 REAL_IP_HEADER=

--- a/tests/compose/filters/mailu.env
+++ b/tests/compose/filters/mailu.env
@@ -129,8 +129,8 @@ WEBSITE=https://mailu.io
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=BLF-CRYPT
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from
 REAL_IP_HEADER=

--- a/tests/compose/rainloop/mailu.env
+++ b/tests/compose/rainloop/mailu.env
@@ -129,8 +129,8 @@ WEBSITE=https://mailu.io
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=BLF-CRYPT
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from
 REAL_IP_HEADER=

--- a/tests/compose/roundcube/mailu.env
+++ b/tests/compose/roundcube/mailu.env
@@ -129,8 +129,8 @@ WEBSITE=https://mailu.io
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=BLF-CRYPT
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from
 REAL_IP_HEADER=

--- a/tests/compose/webdav/mailu.env
+++ b/tests/compose/webdav/mailu.env
@@ -129,8 +129,8 @@ WEBSITE=https://mailu.io
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, CRYPT)
-PASSWORD_SCHEME=BLF-CRYPT
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from
 REAL_IP_HEADER=

--- a/towncrier/newsfragments/1194.feature
+++ b/towncrier/newsfragments/1194.feature
@@ -1,0 +1,1 @@
+Change default password scheme to PBKDF2


### PR DESCRIPTION
## What type of PR?
enhancement

## What does this PR do?
This PR change the default password scheme to PBKDF2. It is already changed in some places (e.g. [docs/compose/.env](https://github.com/Mailu/Mailu/blob/master/docs/compose/.env#L142)).

### Related issue(s)
closes #1194 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
