### PR TITLE
Enable access log of admin service only for log levels of INFO and finer

### DIFF
--- a/core/admin/start.py
+++ b/core/admin/start.py
@@ -1,6 +1,10 @@
 #!/usr/bin/python3
 
 import os
+import logging as log
+import sys
+
+log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "INFO"))
 
 os.system("flask mailu advertise")
 os.system("flask db upgrade")
@@ -11,6 +15,14 @@ password = os.environ.get("INITIAL_ADMIN_PW")
 
 if account is not None and domain is not None and password is not None:
     mode = os.environ.get("INITIAL_ADMIN_MODE", default="ifmissing")
+    log.info("Creating initial admin accout %s@%s with mode %s",account,domain,mode)
     os.system("flask mailu admin %s %s '%s' --mode %s" % (account, domain, password, mode))
 
-os.system("gunicorn -w 4 -b :80 --access-logfile - --error-logfile - --preload 'mailu:create_app()'")
+start_command="".join([
+    "gunicorn -w 4 -b :80 ",
+    "--access-logfile - " if (log.root.level<=log.INFO) else "",
+    "--error-logfile - ",
+    "--preload ",
+    "'mailu:create_app()'"])
+
+os.system(start_command)

--- a/towncrier/newsfragments/1197.feature
+++ b/towncrier/newsfragments/1197.feature
@@ -1,0 +1,1 @@
+Enable access log of admin service only for log levels of INFO and finer


### PR DESCRIPTION
## What type of PR?

bug fix

## What does this PR do?

### Related issue(s)
- closes #1197

## Prerequistes

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
