### PR TITLE
Allow smtp auth login for TLS port (similar to SSL port)

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -251,7 +251,7 @@ mail {
       starttls only;
       {% endif %}
       protocol smtp;
-      smtp_auth plain;
+      smtp_auth plain login;
     }
 
     {% if TLS %}


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Changes smtp_auth from "plain" to "plain login" for port 587 (make it equal to port 465).

### Related issue(s)
- none, trivial change

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- none, trivial change
