### PR TITLE
Add initial admin account to kubernetes example

### DIFF
--- a/docs/kubernetes/mailu/configmap.yaml
+++ b/docs/kubernetes/mailu/configmap.yaml
@@ -143,6 +143,11 @@
     # Advanced settings
     ###################################
 
+    # Create an admin account if it does not exist yet. It will also create the email domain for the account.
+    # INITIAL_ADMIN_ACCOUNT: "admin"
+    # INITIAL_ADMIN_DOMAIN: "example.com"
+    # INITIAL_ADMIN_PW: "s3cr3t"
+
     # Docker-compose project name, this will prepended to containers names.
     COMPOSE_PROJECT_NAME: "mailu"
 


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?

Add INITIAL_ADMIN_* example to kubernetes configmap.yaml

### Related issue(s)

- closes #1201

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- docs example only