### PR TITLE
Use POD_ADDRESS_RANGE for postfix mynetworks if set

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -17,7 +17,7 @@ queue_directory = /queue
 message_size_limit = {{ MESSAGE_SIZE_LIMIT }}
 
 # Relayed networks
-mynetworks = 127.0.0.1/32 [::1]/128 {{ SUBNET }} {{ RELAYNETS }}
+mynetworks = 127.0.0.1/32 [::1]/128 {{ POD_ADDRESS_RANGE or SUBNET }} {{ RELAYNETS }}
 
 # Empty alias list to override the configuration variable and disable NIS
 alias_maps =

--- a/towncrier/newsfragments/1209.fix
+++ b/towncrier/newsfragments/1209.fix
@@ -1,0 +1,1 @@
+On kubernetes allow POD_ADDRESS_RANGE to relay over postfix (allows to send vacations)


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

On Postfix, we already use POD_ADDRESS_RANGE for smtpd_authorized_xclient_hosts. This must also be used for mynetworks, otherwise it's not possible to send mails from other mailu pods (e.g. vacation mails from dovecot).

### Related issue(s)

- closes #1210

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
