### PR TITLE
Fix docs warnings

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -14,7 +14,7 @@ COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY . /docs
 
 RUN mkdir -p /build/$VERSION \
- && sphinx-build /docs /build/$VERSION
+ && sphinx-build -W /docs /build/$VERSION
 
 EXPOSE 80/tcp
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -154,11 +154,11 @@ optional port number. Those variables are:
 - ``HOST_REDIS``: the container that is running the redis daemon (default: ``redis``)
 - ``HOST_WEBMAIL``: the container that is running the webmail (default: ``webmail``)
 
-The startup scripts will resolve HOST_* to their IP addresses and store the result in *_ADDRESS for further use.
+The startup scripts will resolve ``HOST_*`` to their IP addresses and store the result in ``*_ADDRESS`` for further use.
 
-Alternatively, *_ADDRESS can directly be set. In this case, the values of *_ADDRESS is kept and not
+Alternatively, ``*_ADDRESS`` can directly be set. In this case, the values of ``*_ADDRESS`` is kept and not
 resolved. This can be used to rely on DNS based service discovery with changing services IP addresses.
-When using *_ADDRESS, the hostnames must be full-qualified hostnames. Otherwise nginx will not be able to
+When using ``*_ADDRESS``, the hostnames must be full-qualified hostnames. Otherwise nginx will not be able to
 resolve the hostnames.
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,6 +60,7 @@ the version of Mailu that you are running.
     dns
     reverse
     database
+    rpi_build
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
## What type of PR?

Documentation

## What does this PR do?

1. Fix various build warnings from Sphinx that sneaked into the project over time, and fixed them. 
2. Enable the `-W` option for `sphinx-build` to elevate `warning` to `error` in order to make build fail in case of syntax errors. This will give a better feedback from Travis to Pull Requests with Documentation updates. They will now block in case of syntax errors, so we don;t have to cleanup afterwards.

### Related issue(s)
None

## Prerequistes
N/A
