### PR TITLE
Fix traefik-certdumper for Traefik v2

### DIFF
--- a/optional/traefik-certdumper/run.sh
+++ b/optional/traefik-certdumper/run.sh
@@ -3,7 +3,7 @@
 function dump() {
     echo "$(date) Dumping certificates"
 
-    traefik-certs-dumper file --crt-name "cert" --crt-ext ".pem" --key-name "key" --key-ext ".pem" --domain-subdir --dest /tmp/work --source /traefik/acme.json > /dev/null
+    traefik-certs-dumper file --crt-name "cert" --crt-ext ".pem" --key-name "key" --key-ext ".pem" --version v2 --domain-subdir --dest /tmp/work --source /traefik/acme.json > /dev/null
 
     if [[ -f /tmp/work/${DOMAIN}/cert.pem && -f /tmp/work/${DOMAIN}/key.pem && -f /output/cert.pem && -f /output/key.pem ]] && \
 	diff -q /tmp/work/${DOMAIN}/cert.pem /output/cert.pem >/dev/null && \


### PR DESCRIPTION
Running Traefik v2, the current container doesn't export certificates from acme.json anymore. Can be fixed by adding `--version v2`, but I'm not sure if that should be the default now, or an env variable? Feel free to merge if v2 format should be the default moving forward.

Without `--version v2`, this is what I get:
```
certdumper_1  | Wed Nov 13 20:59:22 UTC 2019 Dumping certificates
certdumper_1  | Wed Nov 13 20:59:22 UTC 2019 Certificate or key differ, updating
certdumper_1  | mv: can't rename '/tmp/work/mydomain.com/*.pem': No such file or directory
```

## What type of PR?
bug-fix

## What does this PR do?
Makes the container work with Traefik v2
