### PR TITLE
Do not override values in /usr/local/etc/php/conf.d/roundcube.ini

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -32,6 +32,8 @@ RUN apt-get update && apt-get install -y \
  && cd html \
  && rm -rf CHANGELOG INSTALL LICENSE README.md UPGRADING composer.json-dist installer \
  && sed -i 's,mod_php5.c,mod_php7.c,g' .htaccess \
+ && sed -i 's,^php_value.*post_max_size,#&,g' .htaccess \
+ && sed -i 's,^php_value.*upload_max_filesize,#&,g' .htaccess \
  && chown -R www-data: logs temp \
  && rm -rf /var/lib/apt/lists
 


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Commen the `upload_max_filesize` and `post_max_size` values from .htaccess, which lets the values in /usr/local/etc/php/conf.d/roundcube.ini take effect

### Related issue(s)
#1248 
