### PR TITLE
Allow build of tagged versions and pre-releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ branches:
     - '1.6'
     - '1.7'
     - master
+    # version tags, e.g. 1.7.1
+    - /^1\.[567]\.\d+$/
+    # pre-releases, e.g. 1.8-pre1
+    - /^1\.8-pre\d+$/
 
 sudo: required
 services: docker


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

- Enable travis builds for version tags in the format 1.7.1 (for 1.5.x, 1.6.x and 1.7.x)
- Enable travis builds for version tags in the format 1.8-pre1

### Related issue(s)
- #1182
- closes #1245

## Prerequistes

None, it just enables the builds, no code/feature changed yet.