### PR TITLE
Radicale: Use pip package instead of alpine repo

### DIFF
--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -1,8 +1,8 @@
 ARG DISTRO=alpine:3.10
 FROM $DISTRO
 
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
- && apk add --no-cache radicale@testing curl bash
+RUN apk add --no-cache curl bash python3 \
+ && pip3 install radicale
 
 COPY radicale.conf /radicale.conf
 

--- a/towncrier/newsfragments/1255.bugfix
+++ b/towncrier/newsfragments/1255.bugfix
@@ -1,0 +1,1 @@
+Use pip package for radicale to fix failing builds caused by [alpine]upstream package rebuild against different python version


### PR DESCRIPTION
Required to fix failing builds caused by [alpine]upstream package rebuild against different python version

## What type of PR?
bug-fix

## What does this PR do?
Use pip package instead of alpine repo to build radicale

### Related issue(s)
closes #1255 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- ❎ In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
