### PR TITLE
Allow local IPv6 connections to Postgres

### DIFF
--- a/optional/postgresql/conf/pg_hba.conf
+++ b/optional/postgresql/conf/pg_hba.conf
@@ -82,6 +82,7 @@ local   all             all                                     peer map=local
 host    mailu           mailu           {{ SUBNET }}            md5
 host    postgres        health          127.0.0.1/32            trust
 # IPv6 local connections:
+host    mailu           mailu           {{ SUBNET6 }}           md5
 host    all             all             ::1/128                 reject
 # Allow replication connections from localhost, by a user with the
 # replication privilege.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix postgres connection not working when IPv6 is enabled