### PR TITLE
Install py3-multidict from repository before installing socrate

### DIFF
--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash py3-multidict \
+    python3 py3-pip git bash py3-multidict py3-yarl \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash py3-multidict \
+    python3 py3-pip git bash py3-multidict py3-yarl \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/rspamd/Dockerfile
+++ b/core/rspamd/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/optional/postgresql/Dockerfile
+++ b/optional/postgresql/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip bash \
+    python3 py3-pip bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/optional/unbound/Dockerfile
+++ b/optional/unbound/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/webmails/rainloop/Dockerfile
+++ b/webmails/rainloop/Dockerfile
@@ -10,7 +10,7 @@ FROM ${ARCH}php:7.3-apache as build_other
 FROM build_${QEMU}
 #Shared layer between rainloop and roundcube
 RUN apt-get update && apt-get install -y \
-  python3 curl python3-pip git \
+  python3 curl python3-pip git python3-multidict \
   && rm -rf /var/lib/apt/lists \
   && echo "ServerSignature Off" >> /etc/apache2/apache2.conf
 

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -9,7 +9,7 @@ FROM ${ARCH}php:7.3-apache as build_other
 FROM build_${QEMU}
 #Shared layer between rainloop and roundcube
 RUN apt-get update && apt-get install -y \
-  python3 curl python3-pip git \
+  python3 curl python3-pip git python3-multidict \
   && rm -rf /var/lib/apt/lists \
   && echo "ServerSignature Off" >> /etc/apache2/apache2.conf
 


### PR DESCRIPTION
 to avoid the need of gcc during build

## What type of PR?

bug-fix

## What does this PR do?

Install py3-multidict on Docker images where socrate is used. Otherwise the build fails on socrate >=2.5 due to missing gcc
