### PR TITLE
Unset HOST_ANTISPAM in k8s yamls

### DIFF
--- a/docs/kubernetes/mailu/configmap.yaml
+++ b/docs/kubernetes/mailu/configmap.yaml
@@ -164,6 +164,7 @@
     HOST_WEBMAIL: "webmail.mailu-mailserver.svc.cluster.local"
     HOST_ADMIN: "admin.mailu-mailserver.svc.cluster.local"
     HOST_WEBDAV: "webdav.mailu-mailserver.svc.cluster.local:5232"
-    HOST_ANTISPAM: "antispam.mailu-mailserver.svc.cluster.local:11332"
+# Setting HOST_ANTISPAM will break things in v 1.7 unless https://github.com/Mailu/Mailu/pull/1211 is back-ported
+#    HOST_ANTISPAM: "antispam.mailu-mailserver.svc.cluster.local:11332"
     HOST_ANTIVIRUS: "antivirus.mailu-mailserver.svc.cluster.local:3310"
     HOST_REDIS: "redis.mailu-mailserver.svc.cluster.local"


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?

Remove HOST_ANSTISPAM from k8s docs, add a warning that it will break the deployment.

## Prerequistes

- [x] In case of feature or enhancement: documentation updated accordingly
