### PR TITLE
Remove `reject_unverified_recipient` from `smtpd_client_restrictions`

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -104,7 +104,6 @@ smtpd_client_restrictions =
   reject_non_fqdn_sender,
   reject_unknown_sender_domain,
   reject_unknown_recipient_domain,
-  reject_unverified_recipient,
   permit
 
 smtpd_relay_restrictions =


### PR DESCRIPTION

## What type of PR?

Bug-fix

## What does this PR do?

It removes recipient verification, as it broke my catch-all address.

Fix for #1292, though I'm not sure if this is the right way to fix the issue. It was added in 175349a224c210bceefe918dbe16d66738de8104.

### Related issue(s)
Fix for #1292 and a revert of 175349a224c210bceefe918dbe16d66738de8104.
