### PR TITLE
Added carddav-plugin for roundcube webmail

### DIFF
--- a/towncrier/newsfragments/1298.feature
+++ b/towncrier/newsfragments/1298.feature
@@ -1,0 +1,1 @@
+Added CardDAV-Plugin for webmail roundcube.

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -18,6 +18,8 @@ RUN pip3 install socrate
 
 ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.4.1/roundcubemail-1.4.1-complete.tar.gz
 
+ENV CARDDAV_URL https://github.com/blind-coder/rcmcarddav/releases/download/v3.0.3/carddav-3.0.3.tar.bz2
+
 RUN apt-get update && apt-get install -y \
       zlib1g-dev libzip4 libzip-dev \
       python3-jinja2 \
@@ -26,9 +28,13 @@ RUN apt-get update && apt-get install -y \
  && rm -rf /var/www/html/ \
  && cd /var/www \
  && curl -L -O ${ROUNDCUBE_URL} \
+ && curl -L -O ${CARDDAV_URL} \
  && tar -xf *.tar.gz \
+ && tar -xf *.tar.bz2 \
  && rm -f *.tar.gz \
+ && rm -f *.tar.bz2 \
  && mv roundcubemail-* html \
+ && mv carddav html/plugins/ \
  && cd html \
  && rm -rf CHANGELOG INSTALL LICENSE README.md UPGRADING composer.json-dist installer \
  && sed -i 's,mod_php5.c,mod_php7.c,g' .htaccess \

--- a/webmails/roundcube/config.inc.php
+++ b/webmails/roundcube/config.inc.php
@@ -16,7 +16,8 @@ $config['plugins'] = array(
     'zipdownload',
     'markasjunk',
     'managesieve',
-    'enigma'
+    'enigma',
+    'carddav'
 );
 
 $front = getenv('FRONT_ADDRESS') ? getenv('FRONT_ADDRESS') : 'front';


### PR DESCRIPTION
## Feature

This PR enables the carddav contacts plugin for integration remote contact-repositories based on CardDAV.

## What does this PR do?

This PR enables the carddav contacts plugin for integration remote contact-repositories based on CardDAV.

### Related issue(s)
- Related #1230, at least for CardDAV.


## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly (not needed since the plugins of webmail is not mentioned in the docs.)
- [x] Changelog-entry added
