### PR TITLE
Don't remove the address extension in postfix

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -277,12 +277,14 @@ class Email(object):
         if not user and localpart_stripped:
             user = User.query.get('{}@{}'.format(localpart_stripped, domain_name))
         if user:
+            email = '{}@{}'.format(localpart, domain_name)
+
             if user.forward_enabled:
                 destination = user.forward_destination
                 if user.forward_keep or ignore_forward_keep:
-                    destination.append(user.email)
+                    destination.append(email)
             else:
-                destination = [user.email]
+                destination = [email]
             return destination
 
         pure_alias = Alias.resolve(localpart, domain_name)


### PR DESCRIPTION
## What type of PR?
Bugfix

## What does this PR do?
Currently when the mail address is looked up by Postfix (using the admin
part) the address extension is removed. This is due to the address
extension being removed to look up the user, and afterwards returning
the users mail address. But by not returning the mail address including
the address extension it also isn't part anymore in the LMTP
communication to Dovecot. So Dovecot doesn't know about the extension,
and in turn the address extension can't be used in Sieve mail filtering.

This change fixes that by returning the original address by just
concatinating the "localpart" and domain again when the user is found.

### Related issue(s)
Fixes #982

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
