### PR TITLE
Certwatcher: Use polling observer to workaround some symlink limitations

### DIFF
--- a/core/nginx/certwatcher.py
+++ b/core/nginx/certwatcher.py
@@ -8,7 +8,7 @@ of TLS_FLAVOR=[mail, cert]
 from os.path import exists, split as path_split
 from os import system
 import time
-from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler, FileDeletedEvent, \
     FileCreatedEvent, FileModifiedEvent, FileMovedEvent
 
@@ -49,7 +49,7 @@ class ChangeHandler(FileSystemEventHandler):
 
 
 if __name__ == '__main__':
-    observer = Observer()
+    observer = PollingObserver()
     handler = ChangeHandler()
     observer.schedule(handler, "/certs", recursive=False)
     observer.start()


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

switch from inotify observer to polling observer to properly handle scenarios where the certs are symlinks to symlinks (e.g. on kubernetes with mounted secrets).

### Related issue(s)
- closes #1302

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

minor fix only
