### PR TITLE
Backport to 1.7: Radicale: Use pip package instead of alpine repo

### DIFF
--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash py3-multidict \
+    python3 py3-pip git bash py3-multidict py3-yarl \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash py3-multidict \
+    python3 py3-pip git bash py3-multidict py3-yarl \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/optional/postgresql/Dockerfile
+++ b/optional/postgresql/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip bash \
+    python3 py3-pip bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 
-RUN echo "@testing http://nl.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories \
- && apk add --no-cache radicale@testing curl bash
+RUN apk add --no-cache curl bash python3 \
+ && pip3 install radicale
 
 COPY radicale.conf /radicale.conf
 

--- a/services/rspamd/Dockerfile
+++ b/services/rspamd/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/services/unbound/Dockerfile
+++ b/services/unbound/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.10
 # python3 shared with most images
 RUN apk add --no-cache \
-    python3 py3-pip git bash \
+    python3 py3-pip git bash py3-multidict \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/towncrier/newsfragments/1255.bugfix
+++ b/towncrier/newsfragments/1255.bugfix
@@ -1,0 +1,1 @@
+Use pip package for radicale to fix failing builds caused by [alpine]upstream package rebuild against different python version

--- a/webmails/rainloop/Dockerfile
+++ b/webmails/rainloop/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.3-apache
 #Shared layer between rainloop and roundcube
 RUN apt-get update && apt-get install -y \
-  python3 curl python3-pip git \
+  python3 curl python3-pip git python3-multidict \
   && rm -rf /var/lib/apt/lists \
   && echo "ServerSignature Off" >> /etc/apache2/apache2.conf
 

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -1,7 +1,7 @@
 FROM php:7.3-apache
 #Shared layer between rainloop and roundcube
 RUN apt-get update && apt-get install -y \
-  python3 curl python3-pip git \
+  python3 curl python3-pip git python3-multidict \
   && rm -rf /var/lib/apt/lists \
   && echo "ServerSignature Off" >> /etc/apache2/apache2.conf
 


### PR DESCRIPTION
Backport of already-master-merged https://github.com/Mailu/Mailu/pull/1256 (same commit without merge-commit)

Blocks another 1.7 backport: https://github.com/Mailu/Mailu/pull/1279