### PR TITLE
Use redis 5 on k8s & add selector

### DIFF
--- a/docs/kubernetes/mailu/redis.yaml
+++ b/docs/kubernetes/mailu/redis.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: mailu-mailserver
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: mailu-redis
+      role: mail
+      tier: backend
   template:
     metadata:
       labels:
@@ -13,29 +18,28 @@ spec:
         tier: backend
     spec:
       containers:
-      - name: redis
-        image: redis:4.0-alpine
-        imagePullPolicy: Always
-        volumeMounts:
-          - mountPath: /data
-            name: redisdata
-        ports:
-          - containerPort: 6379
-            name: redis
-            protocol: TCP
-        resources:
-          requests:
-            memory: 200Mi
-            cpu: 100m
-          limits:
-            memory: 300Mi
-            cpu: 200m
+        - name: redis
+          image: redis:5-alpine
+          imagePullPolicy: Always
+          volumeMounts:
+            - mountPath: /data
+              name: redisdata
+          ports:
+            - containerPort: 6379
+              name: redis
+              protocol: TCP
+          resources:
+            requests:
+              memory: 200Mi
+              cpu: 100m
+            limits:
+              memory: 300Mi
+              cpu: 200m
       volumes:
         - name: redisdata
           persistentVolumeClaim:
             claimName: redis-hdd
 ---
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -51,6 +55,6 @@ spec:
     role: mail
     tier: backend
   ports:
-  - name: redis
-    port: 6379
-    protocol: TCP
+    - name: redis
+      port: 6379
+      protocol: TCP

--- a/towncrier/newsfragments/1308.misc
+++ b/towncrier/newsfragments/1308.misc
@@ -1,0 +1,1 @@
+Use Redis 5.0 in kubernetes manifests


### PR DESCRIPTION
## What type of PR?
Enhancement

## What does this PR do?
This PR is updating Redis to version 5 in the kubernetes manifests. It is already used in the compose and swarm files, so I don't expect any incompatibilities. There is no necessary migration, you just can't go back.
In addition I added a selector to the manifest and applied a consistent formatting.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
