### PR TITLE
Fix the encoding of incoming user email and password

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -37,8 +37,14 @@ def handle_authentication(headers):
     # Authenticated user
     elif method == "plain":
         server, port = get_server(headers["Auth-Protocol"], True)
-        user_email = urllib.parse.unquote(headers["Auth-User"])
-        password = urllib.parse.unquote(headers["Auth-Pass"])
+        # According to RFC2616 section 3.7.1 and PEP 3333, HTTP headers should
+        # be ASCII and are generally considered ISO8859-1. However when passing
+        # the password, nginx does not transcode the input UTF string, thus
+        # we need to manually decode.
+        raw_user_email = urllib.parse.unquote(headers["Auth-User"])
+        user_email = raw_user_email.encode("iso8859-1").decode("utf8")
+        raw_password = urllib.parse.unquote(headers["Auth-Pass"])
+        password = raw_password.encode("iso8859-1").decode("utf8")
         ip = urllib.parse.unquote(headers["Client-Ip"])
         user = models.User.query.get(user_email)
         status = False

--- a/towncrier/newsfragments/1139.fix
+++ b/towncrier/newsfragments/1139.fix
@@ -1,0 +1,1 @@
+Fix the password encoding upon authentication


### PR DESCRIPTION
## What type of PR?

Bug fix

## What does this PR do?

As described in the changes, RFC2616 states that header should be considered ISO8859-1 in HTTP, which obviously nginx does not really care about when forwarding the password from SMTP authentication to the backend. Hence, we need to encode-then-decode passwords to get the proper value in case a special char is in there.

### Related issue(s)
- This fixes #1139 
- This is also related to #1281 
- This is also related to #1139

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
