### PR TITLE
Upgrading to a 2048-bit DKIM key

### DIFF
--- a/core/admin/mailu/dkim.py
+++ b/core/admin/mailu/dkim.py
@@ -5,7 +5,7 @@ They are thus represented as ASCII armored PEM.
 from OpenSSL import crypto
 
 
-def gen_key(key_type=crypto.TYPE_RSA, bits=1024):
+def gen_key(key_type=crypto.TYPE_RSA, bits=2048):
     """ Generate and return a new RSA key.
     """
     key = crypto.PKey()


### PR DESCRIPTION
## What type of PR?

Enhancement

## What does this PR do?

Upgrades to a 2048-bit DKIM key from the currently used and outdated 1024-bit DKIM key.

### Related issue(s)
- #1301 