### PR TITLE
Add xapian full-text-search plugin to dovecot

### DIFF
--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,5 +1,5 @@
-ARG DISTRO=alpine:3.10 as builder
-FROM $DISTRO
+ARG DISTRO=alpine:3.10
+FROM $DISTRO as builder
 WORKDIR /tmp
 RUN apk add git build-base automake autoconf libtool dovecot-dev xapian-core-dev icu-dev
 RUN git clone https://github.com/grosjo/fts-xapian.git \

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /tmp
 RUN apk add git build-base automake autoconf libtool dovecot-dev xapian-core-dev icu-dev
 RUN git clone https://github.com/grosjo/fts-xapian.git \
   && cd fts-xapian \
-  # && git checkout 1.2.7 \ # TODO: when upstream releases 1.2.7, use that
+  && git checkout 1.2.7 \
   && autoreconf -vi \
   && PANDOC=false ./configure --with-dovecot=/usr/lib/dovecot \
   && make \

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.10 as builder
 FROM $DISTRO
 WORKDIR /tmp
 RUN apk add git build-base automake autoconf libtool dovecot-dev xapian-core-dev icu-dev
@@ -27,7 +27,7 @@ RUN apk add --no-cache \
   dovecot dovecot-lmtpd dovecot-pop3d dovecot-submissiond dovecot-pigeonhole-plugin rspamd-client xapian-core \
   && mkdir /var/lib/dovecot
 
-COPY --from=0 /usr/lib/dovecot/lib21_fts_xapian_plugin.* /usr/lib/dovecot/
+COPY --from=builder /usr/lib/dovecot/lib21_fts_xapian_plugin.* /usr/lib/dovecot/
 
 COPY conf /conf
 COPY start.py /start.py

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,5 +1,16 @@
 ARG DISTRO=alpine:3.10
 FROM $DISTRO
+WORKDIR /tmp
+RUN apk add git build-base automake autoconf libtool dovecot-dev xapian-core-dev icu-dev
+RUN git clone https://github.com/grosjo/fts-xapian.git \
+  && cd fts-xapian \
+  # && git checkout 1.2.7 \ # TODO: when upstream releases 1.2.7, use that
+  && autoreconf -vi \
+  && PANDOC=false ./configure --with-dovecot=/usr/lib/dovecot \
+  && make \
+  && make install
+
+FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip git bash py3-multidict py3-yarl \
@@ -13,8 +24,10 @@ RUN pip3 install "podop>0.2.5"
 
 # Image specific layers under this line
 RUN apk add --no-cache \
-  dovecot dovecot-lmtpd dovecot-pop3d dovecot-submissiond dovecot-pigeonhole-plugin rspamd-client \
+  dovecot dovecot-lmtpd dovecot-pop3d dovecot-submissiond dovecot-pigeonhole-plugin rspamd-client xapian-core \
   && mkdir /var/lib/dovecot
+
+COPY --from=0 /usr/lib/dovecot/lib21_fts_xapian_plugin.* /usr/lib/dovecot/
 
 COPY conf /conf
 COPY start.py /start.py

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -21,7 +21,8 @@ mail_access_groups = mail
 maildir_stat_dirs = yes
 mailbox_list_index = yes
 mail_vsize_bg_after_count = 100
-mail_plugins = $mail_plugins quota quota_clone zlib
+mail_plugins = $mail_plugins quota quota_clone zlib fts fts_xapian
+default_vsz_limit = 2GB
 
 namespace inbox {
   inbox = yes
@@ -37,6 +38,12 @@ plugin {
   quota = count:User quota
   quota_vsizes = yes
   quota_clone_dict = proxy:/tmp/podop.socket:quota
+
+  fts = xapian
+  fts_xapian = partial=2 full=30
+  fts_autoindex = yes
+  fts_enforced = yes
+  fts_autoindex_exclude = \Trash
 
   {% if COMPRESSION in [ 'gz', 'bz2' ] %}
   zlib_save = {{ COMPRESSION }}

--- a/towncrier/newsfragments/1320.feature
+++ b/towncrier/newsfragments/1320.feature
@@ -1,0 +1,1 @@
+Allow users to use server-sided full-text-search again by adding the dovecot fts-xapian plugin


### PR DESCRIPTION
## What type of PR?
Enhancement

## What does this PR do?
Currently we are not able to offer our users a FTS experience after the
demise of lucene due to unfixed coredumps with musl/alpine.
We now add lucene, the only remaining maintained small/lean FTS plugin
for dovecot. It is quite simple to add to our stack: A two-stage docker
build is used to compile the fts plugin in the first stage, and copy
over only the resulting plugin-artifact to the second stage, which is
our usual dovecot container. Configuration is also minimal.

There was a upstream issue where bodies were not able to be searched for subwords, but fortunately it was fixed quite quickly. We currently need to wait for a new release to use a stable tag in our `Dockerfile`.

### Related issue(s)
- https://github.com/Mailu/Mailu/pull/1176
- https://github.com/Mailu/Mailu/pull/1297
- https://github.com/Mailu/Mailu/issues/751
- **Upstream-issues which is the cause for the `TODO` in the `Dockerfile`**: https://github.com/grosjo/fts-xapian/issues/32

## Prerequistes
- [ ] Wait for upstream to prepare new release after https://github.com/grosjo/fts-xapian/issues/32 — so that we can use a stable tag in our `Dockerfile`
- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
