### PR TITLE
Allow user to install, remove and activate roundcube plugins

### DIFF
--- a/tests/compose/roundcube/Dockerfile
+++ b/tests/compose/roundcube/Dockerfile
@@ -1,0 +1,39 @@
+FROM mailu/roundcube:master
+
+###Begin Package additions###
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libfreetype6-dev \
+    libicu-dev \
+    libjpeg62-turbo-dev \
+    libldap2-dev \
+    libpng-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    libmcrypt-dev \
+    python3-jinja2 \
+    gpg \
+    zlib1g-dev \
+    unzip \
+    libzip4 \
+    ; \
+    debMultiarch="$(dpkg-architecture --query DEB_BUILD_MULTIARCH)"; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-png-dir=/usr --with-jpeg-dir=/usr; \
+    docker-php-ext-configure ldap --with-libdir="lib/$debMultiarch"; \
+    docker-php-ext-install \
+    exif \
+    gd \
+    intl \
+    ldap \
+    pdo_mysql \
+    pdo_pgsql \
+    pdo_sqlite \
+    zip \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+###End Package additions###
+
+CMD /start.py
+HEALTHCHECK CMD curl -f -L http://localhost/ || exit 1

--- a/tests/compose/roundcube/docker-compose.yml
+++ b/tests/compose/roundcube/docker-compose.yml
@@ -79,11 +79,23 @@ services:
 
   # Webmail
   webmail:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}roundcube:${MAILU_VERSION:-master}
-    restart: always
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}roundcube:rc
+    build: .
+    # restart: always
     env_file: mailu.env
+    environment:
+      - INSTALL_RC_PLUGINS=sblaisot/automatic_addressbook roundcube/carddav johndoh/contextmenu
+      # Plugins that generate errors: endroid/qr-code
+      # Plugins that require mysql: texxasrulez/calendar
+      # Optional env_variable to remove undesired plugins
+      # - REMOVE_RC_PLUGINS=texxasrulez/calendar
+      - IMAP_ADDRESS=imap
+      - SMTP_ADDRESS=smtp
+    ports:
+      - "811:80"
     volumes:
       - "/mailu/webmail:/data"
+      - "./plugins.py:/var/www/html/plugins.py"
     depends_on:
       - imap
 

--- a/tests/compose/roundcube/mailu.env
+++ b/tests/compose/roundcube/mailu.env
@@ -16,7 +16,7 @@
 
 # Mailu version to run (1.0, 1.1, etc. or master)
 #VERSION=master
-
+VERSION=1.7
 # Set to a randomly generated 16 bytes string
 SECRET_KEY=PGGO2JRQ59QV3DW7
 
@@ -140,3 +140,8 @@ REAL_IP_FROM=
 
 # choose wether mailu bounces (no) or rejects (yes) mail when recipient is unknown (value: yes, no)
 REJECT_UNLISTED_RECIPIENT=
+
+INITIAL_ADMIN_ACCOUNT=admin
+INITIAL_ADMIN_DOMAIN=mailu.io
+INITIAL_ADMIN_PW=pass
+INITIAL_ADMIN_MODE=update

--- a/tests/compose/roundcube/plugins.py
+++ b/tests/compose/roundcube/plugins.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+
+import os
+import re
+import sys
+import subprocess
+import shutil
+from socrate import conf
+import logging as log
+
+
+# Assign plugin env variables to local variables
+REMOVE_RC_PLUGINS   = os.environ.get("REMOVE_RC_PLUGINS")
+INSTALL_RC_PLUGINS  = os.environ.get("INSTALL_RC_PLUGINS")
+ACTIVATE_RC_PLUGINS = os.environ.get("ACTIVATE_RC_PLUGINS", \
+  re.sub('[^\s]+?/', '', INSTALL_RC_PLUGINS) \
+  if INSTALL_RC_PLUGINS else None)
+plugin_error        = False
+# Check Composer
+if shutil.which('composer') is not None:
+  print("Composer Installed")
+else:
+  print("Composer Not Found. Installing..")
+  os.system("curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer")
+
+# Create composer.json if it does not exist
+if os.path.isfile('composer.json'):
+    print ("composer.json exists")
+else:
+    print ("Creating composer.json")
+    os.system("cp composer.json-dist composer.json")
+
+# Remove plugins from composer.json if REMOVE_RC_PLUGINS environment variable is set
+if REMOVE_RC_PLUGINS:
+  print(f'Removing plugins {REMOVE_RC_PLUGINS}')
+  subprocess.check_call(['php', '-d', 'disable_functions=', '/usr/bin/composer', '--no-update', '--no-interaction', 'remove'] \
+  + f'{REMOVE_RC_PLUGINS}'.split(),stderr=subprocess.STDOUT)
+
+
+# Add plugins to composer.json if INSTALL_RC_PLUGINS environment variable is set
+if INSTALL_RC_PLUGINS:
+  print(f'Adding plugins {INSTALL_RC_PLUGINS}')
+  subprocess.check_call(['php', '-d', 'disable_functions=', '/usr/bin/composer', '--prefer-dist', '--prefer-stable', '--no-update', \
+  '--update-no-dev', '--no-interaction', '--optimize-autoloader', '--apcu-autoloader', 'require'] \
+  + f"{INSTALL_RC_PLUGINS}".split() ,stderr=subprocess.STDOUT)
+
+
+# Update plugins based on composer.json This installs and copies the plugins into the plugin directory
+if INSTALL_RC_PLUGINS or REMOVE_RC_PLUGINS: 
+  # Ensure composer.lock is updated
+  try:
+    print("Updating composer.lock")
+    subprocess.check_call(['php', '-d', 'disable_functions=', '/usr/bin/composer', 'update', '--lock', '--prefer-dist', '--no-dev', '--no-interaction'],stderr=subprocess.STDOUT)
+  except subprocess.CalledProcessError as e:
+    print(e)
+    print(f'composer.lock update failed. Please review your plugins list')
+    plugin_error = True
+  if not plugin_error:
+    try:
+      print('Installing/Updating roundcube plugins')
+      result=subprocess.check_call(['php', '-d', 'disable_functions=', '/usr/bin/composer', '--prefer-dist', '--no-dev', '--no-interaction', \
+      '--optimize-autoloader', '--apcu-autoloader', 'install'],stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:
+      print(e)
+      print(f'roundcube plugins install failed')
+      plugin_error = True
+
+if ACTIVATE_RC_PLUGINS:
+  print(f'Activating Roundcube plugins {ACTIVATE_RC_PLUGINS}')
+  DEFAULT_RC_PLUGINS="archive zipdownload markasjunk managesieve enigma"
+  RC_PLUGINS = f"{ACTIVATE_RC_PLUGINS}".split() + f"{DEFAULT_RC_PLUGINS}".split()
+  # List of user defined plugins may be updated. We need to remove any existing entries and add them later.
+  os.system("sed '/##\[USER/{:a;N;/END\]##/!ba};//d' config/config.inc.php > config/config.inc.php.temp")
+  
+  os.system("echo '##[USER_PLUGINS_START]##' >> config/config.inc.php.temp")
+  
+  os.system(f'echo "\$config[\'plugins\'] = {RC_PLUGINS};" >> config/config.inc.php.temp')
+  
+  os.system("echo '##[USER_PLUGINS_END]##' >> config/config.inc.php.temp")
+  
+  os.system("php -l config/config.inc.php.temp")
+  try:
+    print('Checking config is OK..')
+    result=subprocess.check_call(['php', '-l', 'config/config.inc.php.temp'],stderr=subprocess.STDOUT)
+    print(f'Config OK :-)')
+    os.system("cp config/config.inc.php.temp config/config.inc.php")
+  except subprocess.CalledProcessError as e:
+    plugin_error = True
+    print(f'Config error. Aborting activation..')
+    print(f'Please check ACTIVATE_RC_PLUGINS env variable is in the format ACTIVATE_RC_PLUGINS=plugin1 plugin2')
+else:
+  # This is a convenient reset if ACTIVATE_RC_PLUGINS is not defined.
+  # Roundcube will revert back to default plugins.
+  # This also means the user has to explicitly state additional plugins in use.
+  print(f'Resetting plugins to default')
+  os.system("sed -i '/##\[USER/{:a;N;/END\]##/!ba};//d' config/config.inc.php")

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -40,9 +40,12 @@ RUN apt-get update && apt-get install -y \
 COPY php.ini /php.ini
 COPY config.inc.php /var/www/html/config/
 COPY start.py /start.py
+COPY rc-entrypoint.sh /rc-entrypoint.sh
 
 EXPOSE 80/tcp
 VOLUME ["/data"]
+
+ENTRYPOINT /rc-entrypoint.sh
 
 CMD /start.py
 

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -45,7 +45,7 @@ COPY rc-entrypoint.sh /rc-entrypoint.sh
 EXPOSE 80/tcp
 VOLUME ["/data"]
 
-ENTRYPOINT /rc-entrypoint.sh
+ENTRYPOINT ["/rc-entrypoint.sh"]
 
 CMD /start.py
 

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -41,6 +41,7 @@ COPY php.ini /php.ini
 COPY config.inc.php /var/www/html/config/
 COPY start.py /start.py
 COPY rc-entrypoint.sh /rc-entrypoint.sh
+RUN chmod a+x /rc-entrypoint.sh
 
 EXPOSE 80/tcp
 VOLUME ["/data"]

--- a/webmails/roundcube/rc-entrypoint.sh
+++ b/webmails/roundcube/rc-entrypoint.sh
@@ -61,6 +61,9 @@ if [[ ! -z "${ACTIVATE_RC_PLUGINS}" ]]; then
   # Convert ACTIVATE_RC_PLUGINS to comma separated list
   RC_PLUGINS_LIST="'${ACTIVATE_RC_PLUGINS//[[:space:]]/', '}'"
   
+  # List of user defined plugins may be updated. We need to remove any existing entries and add them later.
+  sed '/##\[USER/{:a;N;/END\]##/!ba};//d' config/config.inc.php > config/updated.config.inc.php
+
   echo "##[USER_PLUGINS_START]##" >> config/updated.config.inc.php
   echo "\$config['plugins'] = array(${RC_PLUGINS_LIST}, ${DEFAULT_RC_PLUGINS_LIST});" >> config/updated.config.inc.php
   echo "##[USER_PLUGINS_END]##" >> config/updated.config.inc.php

--- a/webmails/roundcube/rc-entrypoint.sh
+++ b/webmails/roundcube/rc-entrypoint.sh
@@ -54,23 +54,23 @@ if [[ ! -z "${ACTIVATE_RC_PLUGINS}" ]]; then
 
   # Define default plugins shipped with this Roundcube Installation
   DEFAULT_RC_PLUGINS="archive zipdownload markasjunk managesieve enigma"
-  DEFAULT_RC_PLUGINS_LIST="'${DEFAULT_RC_PLUGINS//[[:space:]]/', '}'"
+  DEFAULT_RC_PLUGINS_LIST="'${DEFAULT_RC_PLUGINS//[[:space:]]/''\', \'}'"
   
   echo "Activating Roundcube plugins ${ACTIVATE_RC_PLUGINS}"
   
   # Convert ACTIVATE_RC_PLUGINS to comma separated list
-  RC_PLUGINS_LIST="'${ACTIVATE_RC_PLUGINS//[[:space:]]/', '}'"
+  RC_PLUGINS_LIST="'${ACTIVATE_RC_PLUGINS//[[:space:]]/''\', \'}'"
   
   # List of user defined plugins may be updated. We need to remove any existing entries and add them later.
-  sed '/##\[USER/{:a;N;/END\]##/!ba};//d' config/config.inc.php > config/updated.config.inc.php
+  sed '/##\[USER/{:a;N;/END\]##/!ba};//d' config/config.inc.php > config/config.inc.php.updated
 
-  echo "##[USER_PLUGINS_START]##" >> config/updated.config.inc.php
-  echo "\$config['plugins'] = array(${RC_PLUGINS_LIST}, ${DEFAULT_RC_PLUGINS_LIST});" >> config/updated.config.inc.php
-  echo "##[USER_PLUGINS_END]##" >> config/updated.config.inc.php
+  echo "##[USER_PLUGINS_START]##" >> config/config.inc.php.updated
+  echo "\$config['plugins'] = array(${RC_PLUGINS_LIST}, ${DEFAULT_RC_PLUGINS_LIST});" >> config/config.inc.php.updated
+  echo "##[USER_PLUGINS_END]##" >> config/config.inc.php.updated
   # Abort activation of new plugins if updated config has an error
-  if php -l config/updated.config.inc.php; then
+  if php -l config/config.inc.php.updated; then
     echo "Config OK :-)"
-    \cp config/updated.config.inc.php config/config.inc.php
+    \cp config/config.inc.php.updated config/config.inc.php
   else
     echo "Config error. Aborting activation.."
     echo "Please check ACTIVATE_RC_PLUGINS env variable is in the format ACTIVATE_RC_PLUGINS=plugin1 plugin2"

--- a/webmails/roundcube/rc-entrypoint.sh
+++ b/webmails/roundcube/rc-entrypoint.sh
@@ -2,13 +2,16 @@
 
 #Switch to roundcube directory 
 cd /var/www/html
- 
-# Check if composer is installed and install if missing
-if [[ ! -x "$(command -v composer)" ]]; then
-  echo "Composer not found. Installing.."
-  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
-else
-  echo "Composer Installed."
+
+# Skip installation if not required
+if [[ ! -z "${INSTALL_RC_PLUGINS}" ]] || [[ ! -z "${REMOVE_RC_PLUGINS}" ]]; then
+  # Check if composer is installed and install if missing
+  if [[ ! -x "$(command -v composer)" ]]; then
+    echo "Composer not found. Installing.."
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+  else
+    echo "Composer Installed."
+  fi
 fi
 
 # Create composer.json if it does not exist

--- a/webmails/roundcube/rc-entrypoint.sh
+++ b/webmails/roundcube/rc-entrypoint.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+#Switch to roundcube directory 
+cd /var/www/html
+ 
+# Check if composer is installed and install if missing
+if [[ ! -x "$(command -v composer)" ]]; then
+  echo "Composer not found. Installing.."
+  curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
+else
+  echo "Composer Installed."
+fi
+
+# Create composer.json if it does not exist
+if [[ ! -f composer.json  ]]; then
+  echo "Creating composer.json"
+  cp composer.json-dist composer.json
+else
+  echo "File composer.json exists."
+fi
+
+# Remove plugins from composer.json if REMOVE_RC_PLUGINS environment variable is set
+if [[ ! -z "${REMOVE_RC_PLUGINS}" ]]; then
+  echo "Removing plugins ${REMOVE_RC_PLUGINS}"
+  php -d "disable_functions=" /usr/bin/composer --no-update --no-interaction remove \
+  ${REMOVE_RC_PLUGINS}
+fi
+
+# Add plugins to composer.json if INSTALL_RC_PLUGINS environment variable is set
+if [[ ! -z "${INSTALL_RC_PLUGINS}" ]]; then
+  echo "Adding plugins ${INSTALL_RC_PLUGINS}"
+  php -d "disable_functions=" /usr/bin/composer --prefer-dist --prefer-stable --no-update --update-no-dev \
+  --no-interaction --optimize-autoloader --apcu-autoloader require \
+  ${INSTALL_RC_PLUGINS}
+fi
+
+
+# Update plugins based on composer.json This installs/copies the plugins into the plugin directory
+if [[ ! -z "${INSTALL_RC_PLUGINS}" ]] || [[ ! -z "${REMOVE_RC_PLUGINS}" ]]; then
+  echo "Installing/Updating roundcube plugins"
+  php -d "disable_functions=" /usr/bin/composer --prefer-dist --no-dev \
+  --no-interaction --optimize-autoloader --apcu-autoloader install
+fi
+
+# Activate plugins
+# This is most sensitive and should be done with care so as not to break the config script.
+# We should check this config is valid before we proceed.
+if [[ ! -z "${ACTIVATE_RC_PLUGINS}" ]]; then
+
+  # Define default plugins shipped with this Roundcube Installation
+  DEFAULT_RC_PLUGINS="archive zipdownload markasjunk managesieve enigma"
+  DEFAULT_RC_PLUGINS_LIST="'${DEFAULT_RC_PLUGINS//[[:space:]]/', '}'"
+  
+  echo "Activating Roundcube plugins ${ACTIVATE_RC_PLUGINS}"
+  
+  # Convert ACTIVATE_RC_PLUGINS to comma separated list
+  RC_PLUGINS_LIST="'${ACTIVATE_RC_PLUGINS//[[:space:]]/', '}'"
+  
+  
+  sed "s/\$config\['plugins'\].*;/\$config['plugins'] = array(${RC_PLUGINS_LIST}, ${DEFAULT_RC_PLUGINS_LIST});/" config/config.inc.php > config/updated.config.inc.php
+  # Abort activation of new plugins if updated config has an error
+  if php -l config/updated.config.inc.php; then
+    echo "Config OK :-)"
+    \cp config/updated.config.inc.php config/config.inc.php
+  else
+    echo "Config error. Aborting activation.."
+    echo "Please check ACTIVATE_RC_PLUGINS env variable is in the format ACTIVATE_RC_PLUGINS=plugin1 plugin2"
+  fi
+  
+else
+  # This is a convenient reset if ACTIVATE_RC_PLUGINS is not defined.
+  # Roundcube will revert back to default plugins.
+  # This also means the user has to explicitly state additional plugins in use.
+  sed -i "s/\$config\['plugins'\].*;/\$config['plugins'] = array($DEFAULT_RC_PLUGINS_LIST);/" config/config.inc.php
+fi
+
+# Proceed with command defined in CMD
+exec "$@"


### PR DESCRIPTION
## What type of PR?
Feature
(Feature, enhancement, bug-fix, documentation)

## What does this PR do?
This PR allows users to install RoundCube Plugins and activate them using environment variables.
It is designed to be entirely optional and to not interfere with the core roundcube installation.
At this time, it only installs plugins that are available on https://plugins.roundcube.net/ using composer method.
The user is required to provide the following environment variables;
**INSTALL_RC_PLUGINS**
**REMOVE_RC_PLUGINS**
**ACTIVATE_RC_PLUGINS**
All the variables above are space delimited strings, e.g.
```
INSTALL_RC_PLUGINS="kolab/calendar roundcube/carddav"
REMOVE_RC_PLUGINS="johndoh/contextmenu johndoh/swipe"
ACTIVATE_RC_PLUGINS="calendar carddav"
```
You can provide any, all or none of the environment variables.
Providing none of the variables starts up core Mailu as usual.
You can always reset you instance to run core Mailu by removing these environment variables.
Any changes to any of the variables will require the container be restarted.

**Points to consider**

- If acceptable, Mailu core could include git and composer in the roundcube image
- A volume mount pointing to /var/www/html/plugins should be created to persist plugins installed. This can be done from the docker-compose.yml file.
- Complex requirements for plugins e.g. Plugins requiring authentication, Complex versioning e.t.c will be left to the users implementation by creating a custom entrypoint script. We should have a WIKI with user contributed scripts to address these cases.
- The entrypoint script included in Mailu should take utmost care to always guarantee that Mailu will start despite any errors that may occur in plugin installation.
- Finally, the plugin functionality should stay true to Mailu guidelines in the sense that mail is not dependent on any of these plugins but the user nonetheless finds them useful. Therefore the burden for ensuring the plugins work as desired will belong to the user. Mailu should only offer basic infrastructure on how to implement this.

**Update 1**
I have confirmed that mailu/roundcube image already has git installed. In addition to composer I would like to make a suggestion for a minimum set of packages and php extensions that should be baked into the image. This list is derived from packages that roundcube itself suggests.
**Packages**
```
libfreetype6-dev
libicu-dev
libjpeg62-turbo-dev
libldap2-dev
libpng-dev
libpq-dev
libsqlite3-dev
libzip-dev
libmcrypt-dev
python3-jinja2
zlib1g-dev
unzip
libzip4
```
**PHP Extensions**
```
exif
gd 
intl
ldap
pdo_mysql
pdo_pgsql
pdo_sqlite
zip
```
### Related issue(s)
- Related to https://github.com/Mailu/Mailu/pull/1298/
- Closes Issue https://github.com/Mailu/Mailu/issues/545

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.
@kaiyou , @sholl