### PR TITLE
add DEFAULT_DOMAIN feature

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -43,6 +43,7 @@ DEFAULT_CONFIG = {
     'DKIM_SELECTOR': 'dkim',
     'DKIM_PATH': '/dkim/{domain}.{selector}.key',
     'DEFAULT_QUOTA': 1000000000,
+    'DEFAULT_DOMAIN': None,
     # Web settings
     'SITENAME': 'Mailu',
     'WEBSITE': 'https://mailu.io',

--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -46,6 +46,10 @@ def handle_authentication(headers):
         raw_password = urllib.parse.unquote(headers["Auth-Pass"])
         password = raw_password.encode("iso8859-1").decode("utf8")
         ip = urllib.parse.unquote(headers["Client-Ip"])
+
+        if not ('@' in user_email ) and app.config["DEFAULT_DOMAIN"]:
+            user_email = user_email + "@" + app.config["DEFAULT_DOMAIN"]
+
         user = models.User.query.get(user_email)
         status = False
         if user:

--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -45,6 +45,11 @@ def postfix_sender_login(sender):
     if localpart is None:
         return flask.abort(404)
     destination = models.Email.resolve_destination(localpart, domain_name, True)
+    # postfix has "smtpd_sasl_local_domain = my.defaultdomain.com" it allows to auth
+    # domainless users but it does not work in 'check_sender_access ${podop}senderaccess'.
+    # Have no idea how to do workaround. Only this dirty hack (simply add local part to
+    # the allowed senders list):
+    destination.append(localpart)
     return flask.jsonify(",".join(destination)) if destination else flask.abort(404)
 
 

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -6,7 +6,9 @@ protocols = imap pop3 lmtp sieve
 postmaster_address = {{ POSTMASTER }}@{{ DOMAIN }}
 hostname = {{ HOSTNAMES.split(",")[0] }}
 submission_host = {{ FRONT_ADDRESS }}
-
+{% if DEFAULT_DOMAIN %}
+auth_default_realm = {{ DEFAULT_DOMAIN }}
+{% endif %}
 ###############
 # Mailboxes
 ###############

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -9,7 +9,9 @@ maillog_file = /dev/stdout
 mydomain = {{ DOMAIN }}
 myhostname = {{ HOSTNAMES.split(",")[0] }}
 myorigin = $mydomain
-
+{% if DEFAULT_DOMAIN %}
+smtpd_sasl_local_domain = {{ DEFAULT_DOMAIN }}
+{% endif %}
 # Queue location
 queue_directory = /queue
 

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -98,6 +98,9 @@ COMPRESSION=
 # change compression-level, default: 6 (value: 1-9)
 COMPRESSION_LEVEL=
 
+# Default domain for usernames whithout domain part
+DEFAULT_DOMAIN=
+
 ###################################
 # Web settings
 ###################################

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -80,6 +80,14 @@ later classify incoming mail based on the custom part.
 The ``DMARC_RUA`` and ``DMARC_RUF`` are DMARC protocol specific values. They hold
 the localpart for DMARC rua and ruf email addresses.
 
+The ``DEFAULT_DOMAIN`` is a default domain name which is used when username contains no
+domain part. Some old mail systems do not use format ``username@domain.com`` but use
+only ``username``. To help with migration from such system to Mailu variable
+``DEFAULT_DOMAIN`` can be used. It allows to avoid client side reconfiguration but
+``DEFAULT_DOMAIN`` can be only one. ``username`` and ``username@domain.com`` work
+in the same way and connect user to the same mailbox if ``DEFAULT_DOMAIN="domain.com"``.
+Variable is optional and used only when defined and only for domainless usernames.
+
 Web settings
 ------------
 

--- a/docs/kubernetes/mailu/configmap.yaml
+++ b/docs/kubernetes/mailu/configmap.yaml
@@ -113,6 +113,9 @@
     WELCOME_SUBJECT: "Welcome to your new email account"
     WELCOME_BODY: "Welcome to your new email account, if you can read this, then it is configured properly!"
 
+    # Default domain for username whithout domain part
+    # DEFAULT_DOMAIN=
+
     ###################################
     # Web settings
     ###################################


### PR DESCRIPTION
## What type of PR?
feature

## What does this PR do?
PR adds env variable DEFAULT_DOMAIN for domainless login names

### Related issue(s)
- Mention an issue like:  #1339

## Prerequistes
- [*] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
