### PR TITLE
Parameterize dkim selector

### DIFF
--- a/core/rspamd/conf/dkim_selectors.map
+++ b/core/rspamd/conf/dkim_selectors.map
@@ -1,0 +1,1 @@
+{{ DOMAIN }} {% if DKIM_SELECTOR %}{{ DKIM_SELECTOR }}{% else %}dkim{% endif %}

--- a/core/rspamd/conf/dkim_signing.conf
+++ b/core/rspamd/conf/dkim_signing.conf
@@ -2,3 +2,7 @@ try_fallback = true;
 path = "/dkim/$domain.$selector.key";
 use_esld = false;
 allow_username_mismatch = true;
+selector = "dkim";
+{% if DKIM_SELECTOR %}
+selector_map = "/etc/rspamd/local.d/dkim_selectors.map";
+{% endif %}"


### PR DESCRIPTION
## What type of PR?
Enhancement
(Feature, enhancement, bug-fix, documentation)

## What does this PR do?
Configures rspamd to sign emails using user provided `DKIM_SELECTOR` instead of using the default `dkim` selector even when `DKIM_SELECTOR` is defined..
### Related issue(s)
- Auto close an issue like: closes #1345 
This should prove useful to people that have existing mail servers apart from mailu for the same domain.
