### PR TITLE
Add port to relay if it contains a colon

### DIFF
--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -36,7 +36,11 @@ def postfix_transport(email):
         return flask.abort(404)
     localpart, domain_name = models.Email.resolve_domain(email)
     relay = models.Relay.query.get(domain_name) or flask.abort(404)
-    return flask.jsonify("smtp:[{}]".format(relay.smtp))
+    ret = "smtp:[{0}]".format(relay.smtp)
+    if ":" in relay.smtp:
+        split = relay.smtp.split(':')
+        ret = "smtp:[{0}]:{1}".format(split[0], split[1])
+    return flask.jsonify(ret)
 
 
 @internal.route("/postfix/sender/login/<path:sender>")

--- a/towncrier/newsfragments/1357.feature
+++ b/towncrier/newsfragments/1357.feature
@@ -1,0 +1,1 @@
+Relay a domain to a nonstandard SMTP port by adding ":<port_num>" to the remote hostname or IP address.


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Allows relaying domains to non-standard SMTP ports by appending `:port` to the destination host/IP. E.g., `mx1.internal:2525`

### Related issue(s)

Closes #1357 


## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
