### PR TITLE
Refactor the rate limiting code

### DIFF
--- a/core/admin/mailu/internal/__init__.py
+++ b/core/admin/mailu/internal/__init__.py
@@ -1,23 +1,7 @@
-from mailu.limiter import RateLimitExceeded
-
-from mailu import utils
-from flask import current_app as app
-
-import socket
 import flask
 
 
 internal = flask.Blueprint('internal', __name__, template_folder='templates')
-
-
-@internal.app_errorhandler(RateLimitExceeded)
-def rate_limit_handler(e):
-    response = flask.Response()
-    response.headers['Auth-Status'] = 'Authentication rate limit from one source exceeded'
-    response.headers['Auth-Error-Code'] = '451 4.3.2'
-    if int(flask.request.headers['Auth-Login-Attempt']) < 10:
-        response.headers['Auth-Wait'] = '3'
-    return response
 
 
 from mailu.internal.views import *

--- a/core/admin/mailu/utils.py
+++ b/core/admin/mailu/utils.py
@@ -20,7 +20,7 @@ def handle_needs_login():
     )
 
 # Rate limiter
-limiter = limiter.Limiter()
+limiter = limiter.LimitWraperFactory()
 
 # Application translation
 babel = flask_babel.Babel()

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -38,7 +38,7 @@ POSTMASTER=admin
 TLS_FLAVOR=cert
 
 # Authentication rate limit (per source IP address)
-AUTH_RATELIMIT=10/minute;1000/hour
+AUTH_RATELIMIT=10/minute
 
 # Opt-out of statistics, replace with "True" to opt out
 DISABLE_STATISTICS=False
@@ -67,6 +67,10 @@ ANTIVIRUS=none
 # Default: accept messages up to 50MB
 # Max attachment size will be 33% smaller
 MESSAGE_SIZE_LIMIT=50000000
+
+# Message rate limit for outgoing messages
+# This limit is per user
+MESSAGE_RATELIMIT=100/day
 
 # Networks granted relay permissions
 # Use this with care, all hosts in this networks will be able to send mail without authentication!

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -46,7 +46,6 @@ rules does also apply to auth requests coming from ``SUBNET``, especially for th
 If you disable this, ensure that the rate limit on the webmail is enforced in a different
 way (e.g. roundcube plug-in), otherwise an attacker can simply bypass the limit using webmail.
 
-
 The ``TLS_FLAVOR`` sets how Mailu handles TLS connections. Setting this value to
 ``notls`` will cause Mailu not to server any web content! More on :ref:`tls_flavor`.
 
@@ -56,6 +55,10 @@ Mail settings
 The ``MESSAGE_SIZE_LIMIT`` is the maximum size of a single email. It should not
 be too low to avoid dropping legitimate emails and should not be too high to
 avoid filling the disks with large junk emails.
+
+The ``MESSAGE_RATELIMIT`` is the limit of messages a single user can send. This is
+meant to fight outbound spam in case of compromised or malicious account on the
+server.
 
 The ``RELAYNETS`` are network addresses for which mail is relayed for free with
 no authentication required. This should be used with great care. If you want other

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -30,8 +30,8 @@ POSTMASTER={{ postmaster }}
 TLS_FLAVOR={{ tls_flavor }}
 
 # Authentication rate limit (per source IP address)
-{% if auth_ratelimit_pm > '0' and auth_ratelimit_ph > '0' %}
-AUTH_RATELIMIT={{ auth_ratelimit_pm }}/minute;{{ auth_ratelimit_ph }}/hour 
+{% if auth_ratelimit_pm > '0' %}
+AUTH_RATELIMIT={{ auth_ratelimit_pm }}/minute
 {% endif %}
 
 # Opt-out of statistics, replace with "True" to opt out

--- a/setup/templates/steps/config.html
+++ b/setup/templates/steps/config.html
@@ -47,11 +47,10 @@ Or in plain english: if receivers start to classify your mail as spam, this post
 
 <div class="form-group">
   <label>Authentication rate limit (per source IP address)</label>
-<!--   Validates number input only -->
+  <!--   Validates number input only -->
   <p><input class="form-control" style="width: 7%; display: inline;" type="number" name="auth_ratelimit_pm" 
-  		value="10" required >/minute;
-  <input class="form-control" style="width: 7%; display: inline;;" type="number" name="auth_ratelimit_ph"
-  		value="1000" required >/hour</p>
+  		value="10" required > / minute
+  </p>
 </div>
 
 <div class="form-check form-check-inline">


### PR DESCRIPTION
## What type of PR?

Enhancement

## What does this PR do?

Rate limiting was already redesigned to use Python limits. This
introduced some unexpected behavior, including the fact that only
one criteria is supported per limiter. Docs and setup utility are
updated with this in mind.

Also, the code was made more generic, so limiters can be delivered
for something else than authentication. Authentication-specific
code was moved directly to the authentication routine.

### Related issue(s)

No specific issue.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
