### PR TITLE
[Roundcube] DKIM sign message delivery reports

### DIFF
--- a/towncrier/newsfragments/1381.fix
+++ b/towncrier/newsfragments/1381.fix
@@ -1,1 +1,1 @@
-Enable the From header for message delivery reports in Roundcube and ensure DKIM Signature 
+Enable the From header for message delivery report in Roundcube and ensure DKIM Signature 

--- a/towncrier/newsfragments/1381.fix
+++ b/towncrier/newsfragments/1381.fix
@@ -1,0 +1,1 @@
+Enable the From header for message delivery reports in Roundcube and ensure DKIM Signature 

--- a/webmails/roundcube/config.inc.php
+++ b/webmails/roundcube/config.inc.php
@@ -56,3 +56,6 @@ $config['skin'] = 'elastic';
 
 // Enigma gpg plugin
 $config['enigma_pgp_homedir'] = '/data/gpg';
+
+// Set From header for DKIM signed message delivery reports
+$config['mdn_use_from'] = true;


### PR DESCRIPTION
This PR enables the From header for message delivery reports in Roundcube.
This ensures that the message delivery report is DKIM signed and therefore not not blocked or considered spam by receiving mailservers.
