### PR TITLE
Prefer specific alias over wildcard, regardless of case

### DIFF
--- a/towncrier/newsfragments/1387.bug
+++ b/towncrier/newsfragments/1387.bug
@@ -1,0 +1,1 @@
+Fix alias resolution in regard to case: A specifically matching alias of wrong case is now preferred over a wildcard alias that might have »eaten« it previously.


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Since direct addresses (not aliases) are case-insensitive since a while,
it makes sense for aliases to behave the same. Up until now, a wildcard
alias could trump a alias not-matching-the-case of the incoming address.
This clarifies this behavior.

## Notes
I realize that the if-hell down there isn’t nice. What it is, however, is quite clear and easy to read. I’m hoping that if anyone ever gets confused in the future, this will make the current behavior transparent. For me, that was more important than a minimal amount of statements/branches …

### Related issue(s)
closes #1387

## Prerequistes
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
