### PR TITLE
Ignore newlines and comment-lines in postfix overrides

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -27,6 +27,10 @@ def start_podop():
         ("senderlogin", "url", url + "sender/login/§")
     ])
 
+def is_valid_postconf_line(line):
+    return not line.startswith("#") \
+            and not line == ''
+
 # Actual startup script
 os.environ["FRONT_ADDRESS"] = system.get_host_address_from_environment("FRONT", "front")
 os.environ["ADMIN_ADDRESS"] = system.get_host_address_from_environment("ADMIN", "admin")
@@ -38,11 +42,13 @@ for postfix_file in glob.glob("/conf/*.cf"):
 
 if os.path.exists("/overrides/postfix.cf"):
     for line in open("/overrides/postfix.cf").read().strip().split("\n"):
-        os.system('postconf -e "{}"'.format(line))
+        if is_valid_postconf_line(line):
+            os.system('postconf -e "{}"'.format(line))
 
 if os.path.exists("/overrides/postfix.master"):
     for line in open("/overrides/postfix.master").read().strip().split("\n"):
-        os.system('postconf -Me "{}"'.format(line))
+        if is_valid_postconf_line(line):
+            os.system('postconf -Me "{}"'.format(line))
 
 for map_file in glob.glob("/overrides/*.map"):
     destination = os.path.join("/etc/postfix", os.path.basename(map_file))

--- a/towncrier/newsfragments/1098.misc
+++ b/towncrier/newsfragments/1098.misc
@@ -1,0 +1,1 @@
+Ignore newlines and comment-lines in postfix overrides - this means you can now make your override configfiles much more readable.


### PR DESCRIPTION
## What type of PR?
enhancement

## What does this PR do?
To make postfix override files understandable and readable, users may
want to insert empty newlines and #-commented lines in their postfix
override files too. This will now ignore such bogus-lines and not send
them to `postconf`, which produced ugly errors in the past.

### Related issue(s)
closes #1098

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
