### PR TITLE
Use pyyaml safe_load instead of load

### DIFF
--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -177,7 +177,7 @@ def config_update(verbose=False, delete_objects=False):
     """sync configuration with data from YAML-formatted stdin"""
     import yaml
     import sys
-    new_config = yaml.load(sys.stdin)
+    new_config = yaml.safe_load(sys.stdin)
     # print new_config
     domains = new_config.get('domains', [])
     tracked_domains = set()


### PR DESCRIPTION



## What type of PR?
enhancement

## What does this PR do?
Since load in unsafe (ref: https://msg.pyyaml.org/load),
switch the only occurrance of `yaml.load` that i could
find to safe_load.

### Related issue(s)
closes #1085

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
