### PR TITLE
Remove SPF type SPF record #1394

### DIFF
--- a/core/admin/mailu/ui/templates/domain/details.html
+++ b/core/admin/mailu/ui/templates/domain/details.html
@@ -34,8 +34,7 @@
 <tr>
   <th>{% trans %}DNS SPF entries{% endtrans %}</th>
   <td><pre>
-{{ domain.name }}. 600 IN TXT "v=spf1 mx a:{{ hostname }} -all"
-{{ domain.name }}. 600 IN SPF "v=spf1 mx a:{{ hostname }} -all"</pre></td>
+{{ domain.name }}. 600 IN TXT "v=spf1 mx a:{{ hostname }} -all"</pre></td>
 </tr>
 {% if domain.dkim_publickey %}
 <tr>

--- a/towncrier/newsfragments/1394.bugfix
+++ b/towncrier/newsfragments/1394.bugfix
@@ -1,0 +1,1 @@
+Show SPF records in accordance with RFC 7208: Previously we instructed admins to create SPF and TXT records, where only TXT records are correct now. !! Attention !! You need to manually remove the SPF-typed records and keep only TXT in your DNS.


### PR DESCRIPTION
As mentioned in #1394 - In accordance with RFC 7208, offer only TXT RRs for SPF.
Agree with @Nebukadneza - but not sure how to go about telling people to remove the old record...

## What type of PR?

Documentation

## What does this PR do?
Removes the recommendation to add a SPF RR for SPF records, as this is no longer RFC complaint and often causes issues to maintain two records.

### Related issue(s)
- closes #1394

## Prerequistes
None
