### PR TITLE
 Relearn messages for fuzzy storage

### DIFF
--- a/core/dovecot/conf/ham.script
+++ b/core/dovecot/conf/ham.script
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 tee >(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu learn_ham /dev/stdin) \
-    | rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 13 fuzzy_add /dev/stdin
+	>(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 11 fuzzy_del /dev/stdin) \
+	| rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 13 fuzzy_add /dev/stdin

--- a/core/dovecot/conf/spam.script
+++ b/core/dovecot/conf/spam.script
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 tee >(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu learn_spam /dev/stdin) \
-    >(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 11 fuzzy_add /dev/stdin)
+    >(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 13 fuzzy_del /dev/stdin) \
+    | rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 11 fuzzy_add /dev/stdin

--- a/towncrier/newsfragments/1438.bugfix
+++ b/towncrier/newsfragments/1438.bugfix
@@ -1,0 +1,1 @@
+Cover relearning messages when moving bewteen Ham and Spam status


### PR DESCRIPTION
## What type of PR?
enhancement, bugfix

## What does this PR do?
This PR add a rspamc fuzzy_del to ham & spam scripts, in order to cover
[relearning](https://rspamd.com/doc/faq.html#can-i-relearn-messages-for-fuzzy-storage-or-for-statistics) from Junk list to Ham list and vice versa

### Related issue(s)
#1438

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Added 1438.bugfix
