### PR TITLE
Install gnupg in docker image to prevent errors due to missing gpg binary

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -100,7 +100,7 @@ smtpd_helo_required = yes
 
 smtpd_client_restrictions =
   permit_mynetworks,
-  check_sender_access ${podop}senderaccess,
+# check_sender_access ${podop}senderaccess,
   reject_non_fqdn_sender,
   reject_unknown_sender_domain,
   reject_unknown_recipient_domain,

--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -7,7 +7,7 @@ smtp      inet  n       -       n       -       -       smtpd
 # Internal SMTP service
 10025     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=yes
-  -o smtpd_client_restrictions=reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit
+#  -o smtpd_client_restrictions=reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit
   -o smtpd_reject_unlisted_recipient={% if REJECT_UNLISTED_RECIPIENT %}{{ REJECT_UNLISTED_RECIPIENT }}{% else %}no{% endif %}
   -o cleanup_service_name=outclean
 outclean  unix n       -       n       -       0       cleanup

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -20,7 +20,7 @@ ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1
 
 RUN apt-get update && apt-get install -y \
       zlib1g-dev libzip4 libzip-dev libpq-dev \
-      python3-jinja2 \
+      python3-jinja2 gnupg \
  && docker-php-ext-install zip pdo_mysql pdo_pgsql \
  && echo date.timezone=UTC > /usr/local/etc/php/conf.d/timezone.ini \
  && rm -rf /var/www/html/ \


### PR DESCRIPTION
Not sure how all the requirements below work, but it is

- a bug-fix
- a minor change