### PR TITLE
Override to use server hostname + IP in outbound headers

### DIFF
--- a/core/postfix/conf/outclean_header_filter.cf
+++ b/core/postfix/conf/outclean_header_filter.cf
@@ -4,7 +4,11 @@
 # Remove the first line of the Received: header. Note that we cannot fully remove the Received: header
 # because OpenDKIM requires that a header be present when signing outbound mail. The first line is
 # where the user's home IP address would be.
+{%- if USE_SERVER_OUTCLEAN and HOST_OUTCLEAN and OUTCLEAN_ADDRESS %}
+/^\s*Received:[^\n]*(.*)/         REPLACE Received: from authenticated-user ({{ HOST_OUTCLEAN }} [{{ OUTCLEAN_ADDRESS }}])$1
+{%- else %}
 /^\s*Received:[^\n]*(.*)/         REPLACE Received: from authenticated-user (PRIMARY_HOSTNAME [PUBLIC_IP])$1
+{%- endif %}
 
 # Remove other typically private information.
 /^\s*User-Agent:/        IGNORE

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -31,11 +31,20 @@ def is_valid_postconf_line(line):
     return not line.startswith("#") \
             and not line == ''
 
+def get_outclean_host():
+    hostnames = os.environ["HOSTNAMES"]
+    if hostnames:
+        return hostnames.split(",")[0]
+
 # Actual startup script
 os.environ["FRONT_ADDRESS"] = system.get_host_address_from_environment("FRONT", "front")
 os.environ["ADMIN_ADDRESS"] = system.get_host_address_from_environment("ADMIN", "admin")
 os.environ["ANTISPAM_MILTER_ADDRESS"] = system.get_host_address_from_environment("ANTISPAM_MILTER", "antispam:11332")
 os.environ["LMTP_ADDRESS"] = system.get_host_address_from_environment("LMTP", "imap:2525")
+
+# Advanced setting to set mail server as originating message IP
+os.environ["HOST_OUTCLEAN"] = get_outclean_host()
+os.environ["OUTCLEAN_ADDRESS"] = system.get_host_address_from_environment("OUTCLEAN", "")
 
 for postfix_file in glob.glob("/conf/*.cf"):
     conf.jinja(postfix_file, os.environ, os.path.join("/etc/postfix", os.path.basename(postfix_file)))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -140,6 +140,11 @@ See the `python docs`_ for more information.
 
 .. _`python docs`: https://docs.python.org/3.6/library/logging.html#logging-levels
 
+The ``USE_SERVER_OUTCLEAN`` setting is used to set the server hostname and IP
+in outbound mail headers rather than the anonymized 'PUBLIC_HOSTNAME [PUBLIC_IP]'
+used by default.  May be helpful in preventing messages being marked as spam.
+Disabled by default -- set to ``True`` to enable.
+
 Antivirus settings
 ------------------
 


### PR DESCRIPTION
## What type of PR?
Enhancement

## What does this PR do?
Allows users to set the server IP and hostname in the outgoing "Received" header rather than "PUBLIC_HOSTNAME [PUBLIC_IP]".

### Related issue(s)
https://github.com/Mailu/Mailu/issues/191

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
