### PR TITLE
Allow to enforce TLS for outbound

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -52,9 +52,10 @@ tls_high_cipherlist = EDH+CAMELLIA:EDH+aRSA:EECDH+aRSA+AESGCM:EECDH+aRSA+SHA256:
 tls_preempt_cipherlist = yes
 tls_ssl_options = NO_COMPRESSION
 
-# Outgoing TLS is more flexible because 1. not all receiving servers will
-# support TLS, 2. not all will have and up-to-date TLS stack.
-smtp_tls_security_level = may
+# By default, outgoing TLS is more flexible because
+# 1. not all receiving servers will support TLS,
+# 2. not all will have and up-to-date TLS stack.
+smtp_tls_security_level = {{ OUTBOUND_TLS_LEVEL|default('may') }}
 smtp_tls_mandatory_protocols = !SSLv2, !SSLv3
 smtp_tls_protocols =!SSLv2,!SSLv3
 smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,6 +69,10 @@ The ``RELAYHOST`` is an optional address of a mail server relaying all outgoing
 mail in following format: ``[HOST]:PORT``.
 ``RELAYUSER`` and ``RELAYPASSWORD`` can be used when authentication is needed.
 
+By default postfix uses "opportunistic TLS" for outbound mail. This can be changed
+by setting ``OUTBOUND_TLS_LEVEL`` to ``encrypt``. This setting is highly recommended
+if you are a relayhost that supports TLS.
+
 The ``FETCHMAIL_DELAY`` is a delay (in seconds) for the fetchmail service to
 go and fetch new email if available. Do not use too short delays if you do not
 want to be blacklisted by external services, but not too long delays if you

--- a/towncrier/1478.feature
+++ b/towncrier/1478.feature
@@ -1,0 +1,1 @@
+Allow to enforce TLS for outbound mail by setting OUTBOUND_TLS_LEVEL=encrypt for postfix.


### PR DESCRIPTION
 using OUTBOUND_TLS_LEVEL=encrypt (default is 'may')

## What type of PR?

enhancement

## What does this PR do?

Add an option to postfix to enforce outbound traffic to be TLS encrypted.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
