### PR TITLE
Postgresql: default SUBNET6 in pg_hba

### DIFF
--- a/optional/postgresql/conf/pg_hba.conf
+++ b/optional/postgresql/conf/pg_hba.conf
@@ -82,7 +82,7 @@ local   all             all                                     peer map=local
 host    mailu           mailu           {{ SUBNET }}            md5
 host    postgres        health          127.0.0.1/32            trust
 # IPv6 local connections:
-host    mailu           mailu           {{ SUBNET6 }}           md5
+host    mailu           mailu           {{ SUBNET6|default('::1/128') }}    md5
 host    all             all             ::1/128                 reject
 # Allow replication connections from localhost, by a user with the
 # replication privilege.

--- a/towncrier/newsfragments/1479.bug
+++ b/towncrier/newsfragments/1479.bug
@@ -1,0 +1,1 @@
+Allow IPv6 authenticated connections in PostgreSQL pg_hba.conf


### PR DESCRIPTION
## What type of PR?

Bug fix

## What does this PR do?

When PostgreSQL for Mailu is used in IPv4 only, without IPv6, `SUBNET6` is unset and causes an empty field in the `pg_hba.conf` file.  PostgreSQL refuses to start in this case.

### Related issue(s)
- Bug was introduced in #1257, merged recently
- 1.7 user reported PostgreSQL connection errors on IPv6 in #1479
- #1257 was Backported to 1.7 in #1469 
- Users on 1.7 reported this broke IPv4 installation in #1479 
- Backport was reverted in #1480 

Sorry for the mess :unamused: 

**Note: ** if this patch seems to be stable, I will re-initiate the backport.

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
