### PR TITLE
ClamAV Debian based build

### DIFF
--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -1,11 +1,9 @@
-ARG DISTRO=alpine:3.11
+ARG DISTRO=debian:buster-slim
 FROM $DISTRO
-# python3 shared with most images
-RUN apk add --no-cache \
-    python3 py3-pip bash \
-  && pip3 install --upgrade pip
-# Image specific layers under this line
-RUN apk add --no-cache clamav rsyslog wget clamav-libunrar
+
+RUN apt-get update && apt-get install -y \
+  python3 clamav-daemon rsyslog netcat \
+  && rm -rf /var/lib/apt/lists
 
 COPY conf /etc/clamav
 COPY start.py /start.py


### PR DESCRIPTION
## What type of PR?

Hopefully a bugfix

## What does this PR do?

For two years, on and off, users have been plagued by disk fills by ClamAV / fresh-clam. A clear root cause was never found, but suspicions have been raised towards Alpine's Libc implementation.

This PR features ClamAV based on a Debian image.

I'm currently not affected by this bug and I'm unable to reproduce, like others on the Team. However, this is an experiment for the affected users. Once this PR is build by Bors / travis the images are available on Dockerhub. Users willing to test need to change the image name for the `anitvirus` service to:

````
  # Optional services
  antivirus:
    #image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}clamav:${MAILU_VERSION:-master}
    image: mailutest/clamav:pr-1482

````

Please report back to this PR if this solved the issues.

Note that only feedback from users with sufficient RAM are considered. Full Mailu stack + ClamAV needs 2GB. Space for the OS needs to be considered. So typically minimal 3GB total RAM. Or 2GB with sufficient [swap](https://wiki.archlinux.org/index.php/Swap) (will perform poorly, but prevents OOM kill).

### Related issue(s)
- #470 and #1419 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

**Will be done if experiment succeeds and Team agrees move to Debian**

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
