### PR TITLE
Fix postfix queue permissions

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -66,6 +66,5 @@ multiprocessing.Process(target=start_podop).start()
 os.system("/usr/libexec/postfix/post-install meta_directory=/etc/postfix create-missing")
 # Before starting postfix, we need to check permissions on /queue
 # in the event that postfix,postdrop id have changed
-os.system("chown -R postfix /queue/{active,bounce,corrupt,defer,deferred,flush,hold,incoming,maildrop,pid,private,public,saved,trace}")
-os.system("chgrp -R postdrop /queue/{maildrop,public}")
+os.system("postfix set-permissions")
 os.system("postfix start-fg")

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -66,6 +66,6 @@ multiprocessing.Process(target=start_podop).start()
 os.system("/usr/libexec/postfix/post-install meta_directory=/etc/postfix create-missing")
 # Before starting postfix, we need to check permissions on /queue
 # in the event that postfix,postdrop id have changed
-os.system("chown postfix -R /queue/{active,bounce,corrupt,defer,deferred,flush,hold,incoming,maildrop,pid,private,public,saved,trace}")
-os.system("chown postdrop -R /queue/{maildrop,public}")
+os.system("chown -R postfix /queue/{active,bounce,corrupt,defer,deferred,flush,hold,incoming,maildrop,pid,private,public,saved,trace}")
+os.system("chgrp -R postdrop /queue/{maildrop,public}")
 os.system("postfix start-fg")

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -64,4 +64,8 @@ if "RELAYUSER" in os.environ:
 # Run Podop and Postfix
 multiprocessing.Process(target=start_podop).start()
 os.system("/usr/libexec/postfix/post-install meta_directory=/etc/postfix create-missing")
+# Before starting postfix, we need to check permissions on /queue
+# in the event that postfix,postdrop id have changed
+os.system("chown postfix -R /queue/{active,bounce,corrupt,defer,deferred,flush,hold,incoming,maildrop,pid,private,public,saved,trace}")
+os.system("chown postdrop -R /queue/{maildrop,public}")
 os.system("postfix start-fg")

--- a/towncrier/newsfragments/1486.bugfix
+++ b/towncrier/newsfragments/1486.bugfix
@@ -1,0 +1,1 @@
+Check postfix mailqueue permissions before start-up 


### PR DESCRIPTION
## What type of PR?
bug-fix (by anticipation of a potential change in base image)

## What does this PR do?
We need to check /queue permissions before starting postfix.
In case of postfix/postdrop uid/gid change, postfix would fail to start

### Related issue(s)
closes #1486 

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly
