### PR TITLE
Modify postfix Dockerfile to use debian as base image

### DIFF
--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -15,7 +15,7 @@ RUN pip3 install "podop>0.2.5"
 
 # Image specific layers under this line
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends\
-  postfix postfix-pcre sasl2-bin libsasl2-modules\
+  postfix postfix-pcre sasl2-bin libsasl2-modules netcat\
   && rm -rf /var/lib/apt/lists  
 
 COPY conf /conf

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -66,6 +66,5 @@ multiprocessing.Process(target=start_podop).start()
 os.system("/usr/libexec/postfix/post-install meta_directory=/etc/postfix create-missing")
 # Before starting postfix, we need to check permissions on /queue
 # in the event that postfix,postdrop id have changed
-os.system("chown -R postfix /queue/{active,bounce,corrupt,defer,deferred,flush,hold,incoming,maildrop,pid,private,public,saved,trace}")
-os.system("chgrp -R postdrop /queue/{maildrop,public}")
+os.system("postfix set-permissions")
 os.system("postfix start-fg")

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -66,6 +66,6 @@ multiprocessing.Process(target=start_podop).start()
 os.system("/usr/libexec/postfix/post-install meta_directory=/etc/postfix create-missing")
 # Before starting postfix, we need to check permissions on /queue
 # in the event that postfix,postdrop id have changed
-os.system("chown postfix -R /queue/{active,bounce,corrupt,defer,deferred,flush,hold,incoming,maildrop,pid,private,public,saved,trace}")
-os.system("chown postdrop -R /queue/{maildrop,public}")
+os.system("chown -R postfix /queue/{active,bounce,corrupt,defer,deferred,flush,hold,incoming,maildrop,pid,private,public,saved,trace}")
+os.system("chgrp -R postdrop /queue/{maildrop,public}")
 os.system("postfix start-fg")

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -64,4 +64,8 @@ if "RELAYUSER" in os.environ:
 # Run Podop and Postfix
 multiprocessing.Process(target=start_podop).start()
 os.system("/usr/libexec/postfix/post-install meta_directory=/etc/postfix create-missing")
+# Before starting postfix, we need to check permissions on /queue
+# in the event that postfix,postdrop id have changed
+os.system("chown postfix -R /queue/{active,bounce,corrupt,defer,deferred,flush,hold,incoming,maildrop,pid,private,public,saved,trace}")
+os.system("chown postdrop -R /queue/{maildrop,public}")
 os.system("postfix start-fg")

--- a/towncrier/newsfragments/1486.bugfix
+++ b/towncrier/newsfragments/1486.bugfix
@@ -1,0 +1,1 @@
+Check postfix mailqueue permissions before start-up 


### PR DESCRIPTION
## What type of PR?
To check feasibility to use debian-slim as base image

## What does this PR do?
Modify Dockerfile to use debian as base image for the postfix service

### Related issue(s)
- Would allow to have DANE working, see #707 #1478 

I do not consider 707 as closed yet because missing fragment and documentation for the variable to be added as per 1478. If we go toward this debian image, I will add those pieces