### PR TITLE
Modify rspamd Dockerfile to use debian as base image

### DIFF
--- a/core/rspamd/Dockerfile
+++ b/core/rspamd/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=debian:stable-slim
+ARG DISTRO=debian:buster-slim
 FROM $DISTRO
 # python3 shared with most images
 RUN apt-get update && apt-get install -y --no-install-recommends\

--- a/core/rspamd/Dockerfile
+++ b/core/rspamd/Dockerfile
@@ -1,17 +1,19 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=debian:stable-slim
 FROM $DISTRO
 # python3 shared with most images
-RUN apk add --no-cache \
-    python3 py3-pip git bash py3-multidict \
+RUN apt-get update && apt-get install -y --no-install-recommends\
+  python3 curl python3-pip git python3-multidict python3-yarl\
+  python3-wheel python3-setuptools\
+  && rm -rf /var/lib/apt/lists \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube
 RUN pip3 install socrate==0.2.0
 
 # Image specific layers under this line
-RUN apk add --no-cache rspamd rspamd-controller rspamd-proxy rspamd-fuzzy ca-certificates curl
-
-RUN mkdir /run/rspamd
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends\
+  rspamd ca-certificates curl\
+  && rm -rf /var/lib/apt/lists
 
 COPY conf/ /conf
 COPY start.py /start.py

--- a/core/rspamd/start.py
+++ b/core/rspamd/start.py
@@ -20,4 +20,4 @@ for rspamd_file in glob.glob("/conf/*"):
     conf.jinja(rspamd_file, os.environ, os.path.join("/etc/rspamd/local.d", os.path.basename(rspamd_file)))
 
 # Run rspamd
-os.execv("/usr/sbin/rspamd", ["rspamd", "-i", "-f"])
+os.execv("/usr/bin/rspamd", ["rspamd", "-i", "-f"])


### PR DESCRIPTION
## What type of PR?
To check feasibility to use debian-slim as base image

## What does this PR do?
Modify Dockerfile to use debian as base image for the antispam service

### Related issue(s)
Would allow to build an arm64 architecture (rspamd is currently broken on alpine arm64).See #1421 