### PR TITLE
Modify fetchmail Dockerfile to use debian as base image

### DIFF
--- a/optional/fetchmail/Dockerfile
+++ b/optional/fetchmail/Dockerfile
@@ -1,32 +1,25 @@
-# First stage: Build
-ARG DISTRO=alpine:3.10
-FROM $DISTRO as builder
-
-# build dependencies
-RUN apk add --no-cache curl tar xz autoconf git gettext build-base openssl openssl-dev
-
-RUN curl -L 'https://sourceforge.net/projects/fetchmail/files/branch_7-alpha/fetchmail-7.0.0-alpha6.tar.xz/download' | tar xJ
-RUN cd fetchmail-7.0.0-alpha6 && \
-    sed -i -e 's/SSLv3_client_method/SSLv23_client_method/' socket.c && \
-    ./configure --with-ssl --prefix /usr/local --disable-nls && \
-    make
-
-ARG DISTRO=alpine:3.10
+ARG DISTRO=debian:buster-slim
 FROM $DISTRO
 
-# python3 shared with most images
-RUN apk add --no-cache \
-    python3 py3-pip bash \
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Minimum python3 shared with most images
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3 python3-pip python3-setuptools curl \
+  && rm -rf /var/lib/apt/lists \
   && pip3 install --upgrade pip
 
 # Image specific layers under this line
-RUN apk add --no-cache ca-certificates openssl \
- && pip3 install requests
+RUN pip3 install requests
+# We want fetchmail>=6.4.2 (ssl wrapped mode autoprobe)
+# buster only provides 6.4.0
+RUN echo "deb http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list \
+  && apt-get update && apt-get install -y --no-install-recommends \
+  fetchmail libssl1.1 openssl netbase ca-certificates \
+  && rm -rf /var/lib/apt/lists
 
-COPY --from=builder /fetchmail-7.0.0-alpha6/fetchmail /usr/local/bin
 COPY fetchmail.py /fetchmail.py
 
-RUN adduser -D fetchmail
 USER fetchmail
 
 CMD ["/fetchmail.py"]

--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -56,7 +56,7 @@ def run(debug):
         for fetch in fetches:
             fetchmailrc = ""
             options = "options antispam 501, 504, 550, 553, 554"
-            options += " sslmode wrapped" if fetch["tls"] else ""
+            options += " ssl" if fetch["tls"] else ""
             options += " keep" if fetch["keep"] else " fetchall"
             fetchmailrc += RC_LINE.format(
                 user_email=escape_rc_string(fetch["user_email"]),


### PR DESCRIPTION
Change from branch_7-alpha to branch_6.4 as devel focussed on branch_6.4 in 2019
see https://sourceforge.net/projects/fetchmail/files/

"ssl-wrapped mode" is detected automatically since fetchmail 6.4.2
 As stated in fetchmail 6.4.2 release notes:

> fetchmailconf now autoprobes SSL-wrapped connections (ports 993 and 995 for IMAP and POP3) as well and by preference.

## What type of PR?
To check feasibility to use debian-slim as base image

## What does this PR do?
- Modify Dockerfile to use debian as base image for the fetchmail service
- Also changing from branch_7-alpha to branch_6.4, as 6.4 is more up to date than 7-alpha.
- The issue around "ssl wrapped mode detection", leading to a specific option "ssslmode wrapped" in 7-alpha seems to be fixed in 6.4.2