### PR TITLE
Modify Dockerfile to use debian as base image (clamav, radicale, none)

### DIFF
--- a/core/none/Dockerfile
+++ b/core/none/Dockerfile
@@ -1,6 +1,5 @@
 # This is an idle image to dynamically replace any component if disabled.
-
-ARG DISTRO=alpine:3.10
+ARG DISTRO=debian:buster-slim
 FROM $DISTRO
 
 CMD sleep 1000000d

--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -1,11 +1,24 @@
-ARG DISTRO=alpine:3.11
+ARG DISTRO=debian:buster-slim
 FROM $DISTRO
-# python3 shared with most images
-RUN apk add --no-cache \
-    python3 py3-pip bash \
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Minimum python3 shared with most images
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3 python3-pip python3-setuptools curl \
+  && rm -rf /var/lib/apt/lists \
   && pip3 install --upgrade pip
+
 # Image specific layers under this line
-RUN apk add --no-cache clamav rsyslog wget clamav-libunrar
+# libclamunrar9 is in non-free
+RUN sed -i /etc/apt/sources.list \
+        -e "s#buster main#buster main non-free#g" \
+        -e "s#buster/updates main#buster/updates main non-free#g" \
+        -e "s#buster-updates main#buster-updates main non-free#g"
+    
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  clamav-daemon libclamunrar9 netcat \
+  && rm -rf /var/lib/apt/lists
 
 COPY conf /etc/clamav
 COPY start.py /start.py

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -1,8 +1,16 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=debian:buster-slim
 FROM $DISTRO
 
-RUN apk add --no-cache curl bash python3 \
- && pip3 install radicale
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Minimum python3 shared with most images
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  python3 python3-pip python3-setuptools curl \
+  && rm -rf /var/lib/apt/lists \
+  && pip3 install --upgrade pip
+
+# Image specific layers under this line
+RUN pip3 install radicale
 
 COPY radicale.conf /radicale.conf
 

--- a/optional/unbound/Dockerfile
+++ b/optional/unbound/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip3 install socrate==0.2.0
 
 # Image specific layers under this line
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
   unbound dnsutils \
   && curl -o /etc/unbound/root.hints https://www.internic.net/domain/named.cache \
   && chown root:unbound /etc/unbound \


### PR DESCRIPTION
## What type of PR?
To check feasibility to use debian-slim as base image

## What does this PR do?
Modify Dockerfiles for clamav, none, radicale to use debian-slim
Clean-up of unbound Dockerfile (DEBIAN_FRONTEND)