### PR TITLE
Harmonization of the various docker-compose.yml templates

### DIFF
--- a/docs/compose/docker-compose.yml
+++ b/docs/compose/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     - "$BIND_ADDRESS6:587:587"
     volumes:
       - "$ROOT/certs:/certs"
-      - "$ROOT/overrides/nginx:/overrides"
+      - "$ROOT/overrides/nginx:/overrides:ro"
 
   redis:
     image: redis:alpine
@@ -45,7 +45,7 @@ services:
     env_file: .env
     volumes:
       - "$ROOT/mail:/mail"
-      - "$ROOT/overrides:/overrides"
+      - "$ROOT/overrides/dovecot:/overrides:ro"
     depends_on:
       - front
 
@@ -54,7 +54,8 @@ services:
     restart: always
     env_file: .env
     volumes:
-      - "$ROOT/overrides:/overrides"
+      - "$ROOT/mailqueue:/queue"
+      - "$ROOT/overrides/postfix:/overrides:ro"
     depends_on:
       - front
 
@@ -64,8 +65,8 @@ services:
     env_file: .env
     volumes:
       - "$ROOT/filter:/var/lib/rspamd"
-      - "$ROOT/dkim:/dkim"
-      - "$ROOT/overrides/rspamd:/etc/rspamd/override.d"
+      - "$ROOT/dkim:/dkim:ro"
+      - "$ROOT/overrides/rspamd:/etc/rspamd/override.d:ro"
     depends_on:
       - front
 

--- a/setup/flavors/stack/docker-compose.yml
+++ b/setup/flavors/stack/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     {% endfor %}
     volumes:
       - "{{ root }}/certs:/certs"
-      - "{{ root }}/overrides/nginx:/overrides"
+      - "{{ root }}/overrides/nginx:/overrides:ro"
     deploy:
       replicas: {{ front_replicas }}
 
@@ -49,7 +49,7 @@ services:
     env_file: {{ env }}
     volumes:
       - "{{ root }}/mail:/mail"
-      - "{{ root }}/overrides:/overrides"
+      - "{{ root }}/overrides/dovecot:/overrides:ro"
     deploy:
       replicas: {{ imap_replicas }}
 
@@ -58,7 +58,7 @@ services:
     env_file: {{ env }}
     volumes:
       - "{{ root }}/mailqueue:/queue"
-      - "{{ root }}/overrides:/overrides"
+      - "{{ root }}/overrides/postfix:/overrides:ro"
     deploy:
       replicas: {{ smtp_replicas }}
 
@@ -67,8 +67,8 @@ services:
     env_file: {{ env }}
     volumes:
       - "{{ root }}/filter:/var/lib/rspamd"
-      - "{{ root }}/dkim:/dkim"
-      - "{{ root }}/overrides/rspamd:/etc/rspamd/override.d"
+      - "{{ root }}/dkim:/dkim:ro"
+      - "{{ root }}/overrides/rspamd:/etc/rspamd/override.d:ro"
     deploy:
       replicas: 1
 

--- a/setup/flavors/stack/setup.html
+++ b/setup/flavors/stack/setup.html
@@ -4,7 +4,7 @@
 <p>Docker Stack expects a project file, named <code>docker-compose.yml</code>
 in a project directory. First create your project directory.</p>
 
-<pre><code>mkdir -p /{{ root }}/{redis,certs,data,dkim,mail,overrides/rspamd,overrides/nginx,filter,dav,webmail}
+<pre><code>mkdir -p {{ root }}/{redis,certs,data,dkim,mail,mailqueue,overrides/rspamd,overrides/postfix,overrides/dovecot,overrides/nginx,filter,dav,webmail}
 </pre></code>
 
 <p>Then download the project file. A side configuration file makes it easier


### PR DESCRIPTION
## What type of PR?
Mainly documentation and update of the docker-compose.yml templates

## What does this PR do?
- Update of setup/flavors/stack/docker-compose.yml and docs/compose/docker-compose.yml to keep parity with setup/flavors/compose/docker-compose.yml (last changes with pr1444)
- Also refresh of the mkdir command found in setup/flavors/stack/setup.html to cope with the creation of mailqueue; overrides/nginx, overrides/dovecot folders.

### Related issue(s)
None

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly

