### PR TITLE
In setup/flavor, change DMARC RUA and RUF email default settings

### DIFF
--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -76,8 +76,8 @@ FETCHMAIL_DELAY={{ fetchmail_delay or '600' }}
 RECIPIENT_DELIMITER={{ recipient_delimiter or '+' }}
 
 # DMARC rua and ruf email
-DMARC_RUA={{ dmarc_rua or 'admin' }}
-DMARC_RUF={{ dmarc_ruf or 'admin' }}
+DMARC_RUA={{ dmarc_rua or postmaster }}
+DMARC_RUF={{ dmarc_ruf or postmaster }}
 
 # Welcome email, enable and set a topic and body if you wish to send welcome
 # emails to all users.

--- a/towncrier/newsfragments/1463.bugfix
+++ b/towncrier/newsfragments/1463.bugfix
@@ -1,0 +1,1 @@
+Defining POSTMASTER through setup tool apply also to DMARC_RUA and DMARC_RUF settings


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
This PR changes the default value used to set DMARC_RUA and DMARC_RUF:
DMARC_RUA and DMARC_RUF defaults will reuse the value defined for POSTMASTER,
instead of 'admin' as previously.
Please note that the setup tool doesn't allow (yet?) to define dmarc_rua nor dmarc_ruf, so the default value is indeed used for the time being.

### Related issue(s)
closes #1463 

## Prerequistes
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
