### PR TITLE
Setup, compose: add note about reverse DNS

### DIFF
--- a/setup/templates/steps/compose/03_expose.html
+++ b/setup/templates/steps/compose/03_expose.html
@@ -52,7 +52,9 @@ avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</co
 hostnames. Every e-mail domain that points to this server must have one of the
 hostnames in its <code>MX</code> record. Hostnames must be comma-separated. If you're having
 trouble accessing your admin interface, make sure it is the first entry here (and possibly the
-same as your <code>DOMAIN</code> entry from earlier.</p>
+same as your <code>DOMAIN</code> entry from earlier). Also make sure that the first entry in
+this list resolves to the IP address of your server, and that the reverse DNS entry for
+the IP address of your server resolves to this first entry in this list.</p>
 
 <div class="form-group">
   <label>Public hostnames</label>


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?

If the [mailu setup utility](https://setup.mailu.io/master/) is used with the Compose flavor, in step 4 a list of public host names needs to be provided:
![Screenshot from 2020-05-17 01-54-06](https://user-images.githubusercontent.com/1998084/82132563-5227d780-97e1-11ea-85ed-fa5d5108e24e.png)
The [first entry in this list is configured as hostname by postfix](https://github.com/Mailu/Mailu/blob/ddac2672fcdb7b47b468d314daeb8e2ee3db8a85/core/postfix/conf/main.cf#L10). That is crucial: if the reverse DNS entry for that host is not the same as this first entry in this list, it will be a mismatch between rDNS and HELO, which will lead to bad scoring in many spam filters.

This commit clarifies that point.
It also fixes a missing parenthesis.

### Related issue(s)

- (none)

## Prerequistes

- (none applicable)