### PR TITLE
Stick radicale to 2.1.12 version

### DIFF
--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 
 RUN apk add --no-cache curl bash python3 \
- && pip3 install radicale
+ && pip3 install radicale=2.1.12
 
 COPY radicale.conf /radicale.conf
 

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 
 RUN apk add --no-cache curl bash python3 \
- && pip3 install radicale=2.1.12
+ && pip3 install radicale==2.1.12
 
 COPY radicale.conf /radicale.conf
 


### PR DESCRIPTION
As 3.0 is breaking compatibility with 2.1 branch

## What type of PR?
Sticking radicale to 2.1.12, while we investigate changes to use radicale 3.0

## What does this PR do?
Dockerfile modification to add ==2.1.12

### Related issue(s)
- #1512 