### PR TITLE
Use Radicale 3.x for webdav service

### DIFF
--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -2,13 +2,13 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 
 RUN apk add --no-cache curl bash python3 \
- && pip3 install radicale==2.1.12
+ && pip3 install radicale
 
 COPY radicale.conf /radicale.conf
 
 EXPOSE 5232/tcp
 VOLUME ["/data"]
 
-CMD radicale -f -S -C /radicale.conf
+CMD radicale -S -C /radicale.conf
 
 HEALTHCHECK CMD curl -f -L http://localhost:5232/ || exit 1

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -2,7 +2,7 @@ ARG DISTRO=alpine:3.10
 FROM $DISTRO
 
 RUN apk add --no-cache curl bash python3 \
- && pip3 install radicale
+ && pip3 install radicale~=3.0
 
 COPY radicale.conf /radicale.conf
 

--- a/optional/radicale/radicale.conf
+++ b/optional/radicale/radicale.conf
@@ -1,15 +1,13 @@
 [server]
 hosts = 0.0.0.0:5232, [::]:5232
-daemon = False
 ssl = False
-dns_lookup = False
-realm = Radicale - Password Required
 
 [encoding]
 request = utf-8
 stock = utf-8
 
 [auth]
+realm = Radicale - Password Required
 type = http_x_remote_user
 
 [rights]

--- a/towncrier/newsfragments/1512.misc
+++ b/towncrier/newsfragments/1512.misc
@@ -1,0 +1,1 @@
+Use Radicale 3.x for webdav service


### PR DESCRIPTION
- remove -f flag in Dockerfile CMD
- remove deprecated daemon and dns_lookup settings from radicale.conf
- move realm setting from [server] to [auth] in radicale.conf
- add newsfragment

## What type of PR?
Miscellaneous

## What does this PR do?
Modifications in Dockerfile and radicale.conf to get Radicale 3.0 service building properly.
Functional tests would be needed before merge.

### Related issue(s)
- closes #1512 

## Prerequistes
- [X] In case of feature or enhancement: documentation updated accordingly
