### PR TITLE
Update nginx.conf

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -33,6 +33,8 @@ http {
       default $http_x_forwarded_proto;
       ''      $scheme;
     }
+    
+    include /overrides/*.conf;
 
     # Main HTTP server
     server {
@@ -57,6 +59,8 @@ http {
       listen 443 ssl http2;
       listen [::]:443 ssl http2;
 
+      server_name mail.*;
+            
       include /etc/nginx/tls.conf;
       ssl_session_cache shared:SSLHTTP:50m;
       add_header Strict-Transport-Security 'max-age=31536000';
@@ -91,8 +95,6 @@ http {
         return 403;
       }
       {% else %}
-
-      include /overrides/*.conf;
 
       # Actual logic
       {% if WEB_WEBMAIL != '/' %}


### PR DESCRIPTION
Moving overrides/*.conf in the http section and adding server_name to mail server.

What type of PR?
Enhancement

What does this PR do?
Since "front" is de facto a proxy server, by simply moving the overrides .conf in the http section, the developer has much more flexibility in the integration in custom web servers. Furthermore, the main logic listen exlusively on server_name mail

Related issue(s)
Mailu#1528