### PR TITLE
Introduce environment variable to control dovecot full-text-search

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -21,7 +21,10 @@ mail_access_groups = mail
 maildir_stat_dirs = yes
 mailbox_list_index = yes
 mail_vsize_bg_after_count = 100
-mail_plugins = $mail_plugins quota quota_clone zlib fts fts_xapian
+mail_plugins = $mail_plugins quota quota_clone zlib{{ ' ' }}
+  {%- if (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] -%}
+  fts fts_xapian
+  {%- endif %}
 default_vsz_limit = 2GB
 
 namespace inbox {
@@ -39,11 +42,13 @@ plugin {
   quota_vsizes = yes
   quota_clone_dict = proxy:/tmp/podop.socket:quota
 
+  {% if (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
   fts = xapian
   fts_xapian = partial=2 full=30
   fts_autoindex = yes
   fts_enforced = yes
   fts_autoindex_exclude = \Trash
+  {% endif %}
 
   {% if COMPRESSION in [ 'gz', 'bz2' ] %}
   zlib_save = {{ COMPRESSION }}

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -102,6 +102,9 @@ COMPRESSION=
 # change compression-level, default: 6 (value: 1-9)
 COMPRESSION_LEVEL=
 
+# IMAP full-text search is enabled by default. Set the following variable to off in order to disable the feature.
+# FULL_TEXT_SEARCH=off
+
 ###################################
 # Web settings
 ###################################

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,6 +83,9 @@ later classify incoming mail based on the custom part.
 The ``DMARC_RUA`` and ``DMARC_RUF`` are DMARC protocol specific values. They hold
 the localpart for DMARC rua and ruf email addresses.
 
+Full-text search is enabled for IMAP is enabled by default. This feature can be disabled
+(e.g. for performance reasons) by setting the optional variable ``FULL_TEXT_SEARCH`` to ``off``.
+
 Web settings
 ------------
 

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -91,6 +91,9 @@ COMPRESSION={{ compression }}
 # change compression-level, default: 6 (value: 1-9)
 COMPRESSION_LEVEL={{ compression_level }}
 
+# IMAP full-text search is enabled by default. Set the following variable to off in order to disable the feature.
+# FULL_TEXT_SEARCH=off
+
 ###################################
 # Web settings
 ###################################

--- a/towncrier/newsfragments/1538.feature
+++ b/towncrier/newsfragments/1538.feature
@@ -1,0 +1,1 @@
+Introduce option to disable dovecot full-text-search by an enviroment variable. 


### PR DESCRIPTION
## What type of PR?

Enhancement

## What does this PR do?

In #1320 a full-text-search feature was enabled in Dovecot by default. Since this can have a big impact on performance, I think it's preferable to offer an option to disable the feature if it is not needed. This PR doesn't change the default behavior (FTS on).

### Related issue(s)
- #1320

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordinagly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
