### PR TITLE
alpine 3.12 as base image

### DIFF
--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -1,5 +1,5 @@
 # First stage to build assets
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 ARG ARCH=""
 FROM ${ARCH}node:8 as assets
 COPY --from=balenalib/rpi-alpine:3.10 /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static

--- a/core/admin/requirements-prod.txt
+++ b/core/admin/requirements-prod.txt
@@ -38,7 +38,8 @@ python-editor==1.0.4
 pytz==2019.1
 PyYAML==5.1
 redis==3.2.1
-six==1.12.0
+#alpine3:12 provides six==1.15.0
+#six==1.12.0
 socrate==0.1.1
 SQLAlchemy==1.3.3
 srslib==0.1.4
@@ -46,6 +47,6 @@ tabulate==0.8.3
 tenacity==5.0.4
 validators==0.12.6
 visitor==0.1.3
-Werkzeug==0.15.3
+Werkzeug==0.15.5
 WTForms==2.2.1
 WTForms-Components==0.10.4

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO as builder
 WORKDIR /tmp
 RUN apk add git build-base automake autoconf libtool dovecot-dev xapian-core-dev icu-dev

--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/core/none/Dockerfile
+++ b/core/none/Dockerfile
@@ -1,6 +1,6 @@
 # This is an idle image to dynamically replace any component if disabled.
 
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 
 CMD sleep 1000000d

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/core/rspamd/Dockerfile
+++ b/core/rspamd/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.11
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/optional/fetchmail/Dockerfile
+++ b/optional/fetchmail/Dockerfile
@@ -1,17 +1,4 @@
-# First stage: Build
-ARG DISTRO=alpine:3.10
-FROM $DISTRO as builder
-
-# build dependencies
-RUN apk add --no-cache curl tar xz autoconf git gettext build-base openssl openssl-dev
-
-RUN curl -L 'https://sourceforge.net/projects/fetchmail/files/branch_7-alpha/fetchmail-7.0.0-alpha6.tar.xz/download' | tar xJ
-RUN cd fetchmail-7.0.0-alpha6 && \
-    sed -i -e 's/SSLv3_client_method/SSLv23_client_method/' socket.c && \
-    ./configure --with-ssl --prefix /usr/local --disable-nls && \
-    make
-
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 
 # python3 shared with most images
@@ -20,13 +7,11 @@ RUN apk add --no-cache \
   && pip3 install --upgrade pip
 
 # Image specific layers under this line
-RUN apk add --no-cache ca-certificates openssl \
+RUN apk add --no-cache fetchmail ca-certificates openssl \
  && pip3 install requests
 
-COPY --from=builder /fetchmail-7.0.0-alpha6/fetchmail /usr/local/bin
 COPY fetchmail.py /fetchmail.py
 
-RUN adduser -D fetchmail
 USER fetchmail
 
 CMD ["/fetchmail.py"]

--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -56,7 +56,7 @@ def run(debug):
         for fetch in fetches:
             fetchmailrc = ""
             options = "options antispam 501, 504, 550, 553, 554"
-            options += " sslmode wrapped" if fetch["tls"] else ""
+            options += " ssl" if fetch["tls"] else ""
             options += " keep" if fetch["keep"] else " fetchall"
             fetchmailrc += RC_LINE.format(
                 user_email=escape_rc_string(fetch["user_email"]),

--- a/optional/postgresql/Dockerfile
+++ b/optional/postgresql/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube
-RUN pip3 install socrate
+RUN pip3 install socrate==0.2.0
 
 # Image specific layers under this line
 RUN apk add --no-cache \

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -1,7 +1,13 @@
 ARG DISTRO=alpine:3.12
 FROM $DISTRO
 
-RUN apk add --no-cache curl bash python3 \
+# python3 shared with most images
+RUN apk add --no-cache \
+    python3 py3-pip bash \
+  && pip3 install --upgrade pip
+
+# Image specific layers under this line
+RUN apk add --no-cache curl \
  && pip3 install radicale==2.1.12
 
 COPY radicale.conf /radicale.conf

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 
 RUN apk add --no-cache curl bash python3 \

--- a/optional/unbound/Dockerfile
+++ b/optional/unbound/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.10
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
@@ -6,7 +6,7 @@ RUN apk add --no-cache \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube
-RUN pip3 install socrate
+RUN pip3 install socrate==0.2.0
 
 # Image specific layers under this line
 RUN apk add --no-cache unbound curl bind-tools \


### PR DESCRIPTION
## What type of PR?
Keep in sync with alpine devel
alpine 3.12 was [released](https://alpinelinux.org/posts/Alpine-3.12.0-released.html) on  29 May 2020.
Update for the main services:
nginx 1.18 (vs 1.16)
dovecot 2.3.10 (unchanged)
postfix 3.5.2 (vs 3.4.7)
rspamd 2.5 (vs 1.9.4)
clamav 0.102/3 (vs 0.101.5)
fetchmail 6.4.5
 
## What does this PR do?
Mostly Dockerfile modification
