### PR TITLE
Disable Health checks on swarm mode

### DIFF
--- a/setup/flavors/stack/docker-compose.yml
+++ b/setup/flavors/stack/docker-compose.yml
@@ -43,6 +43,8 @@ services:
       - "{{ root }}/dkim:/dkim"
     deploy:
       replicas: {{ admin_replicas }}
+    healthcheck:
+      disable: true
 
   imap:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}dovecot:${MAILU_VERSION:-{{ version }}}
@@ -52,6 +54,8 @@ services:
       - "{{ root }}/overrides:/overrides"
     deploy:
       replicas: {{ imap_replicas }}
+    healthcheck:
+      disable: true
 
   smtp:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}postfix:${MAILU_VERSION:-{{ version }}}
@@ -61,6 +65,8 @@ services:
       - "{{ root }}/overrides:/overrides"
     deploy:
       replicas: {{ smtp_replicas }}
+    healthcheck:
+      disable: true
 
   antispam:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}rspamd:${MAILU_VERSION:-{{ version }}}
@@ -71,6 +77,8 @@ services:
       - "{{ root }}/overrides/rspamd:/etc/rspamd/override.d"
     deploy:
       replicas: 1
+    healthcheck:
+      disable: true
 
   # Optional services
   {% if antivirus_enabled %}
@@ -81,6 +89,8 @@ services:
       - "{{ root }}/filter:/data"
     deploy:
       replicas: 1
+    healthcheck:
+      disable: true
   {% endif %}
 
   {% if webdav_enabled %}
@@ -91,6 +101,8 @@ services:
       - "{{ root }}/dav:/data"
     deploy:
       replicas: 1
+    healthcheck:
+      disable: true
   {% endif %}
 
   {% if fetchmail_enabled %}
@@ -101,6 +113,8 @@ services:
       - "{{ root }}/data:/data"
     deploy:
       replicas: 1
+    healthcheck:
+      disable: true
   {% endif %}
 
   {% if webmail_type != 'none' %}
@@ -111,6 +125,8 @@ services:
       - "{{ root }}/webmail:/data"
     deploy:
       replicas: 1
+    healthcheck:
+      disable: true
   {% endif %}
 
   {% if db_flavor == 'postgresql' and postgresql == 'internal' %}
@@ -119,6 +135,8 @@ services:
     env_file: {{ env }}
     volumes:
       - "{{ root }}/data/psql_backup:/backup"
+    healthcheck:
+      disable: true
   {% endif %}
 
 networks:

--- a/towncrier/newsfragments/1289.bugfix
+++ b/towncrier/newsfragments/1289.bugfix
@@ -1,0 +1,1 @@
+Disable Health checks on swarm mode


### PR DESCRIPTION
ref: https://github.com/moby/moby/issues/35451

## What type of PR?
bug-fix

## What does this PR do?
Modify the docker-compose.yml template used by setup (swarm flavor) to disable Health checks on swarm mode for each service

### Related issue(s)
closes #1289

## Prerequistes
- [x]  add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
