### PR TITLE
Fix 1552 configurable folder names

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,3 +25,4 @@ Other contributors:
  - [Tim Mohlmann](https://github.com/muhlemmer) - [Contributions](https://github.com/Mailu/Mailu/commits?author=muhlemmer)
  - [Ionut Filip](https://github.com/ionutfilip) - [Contributions](https://github.com/Mailu/Mailu/commits?author=ionutfilip)
  - [Ichikawa Yuriko](https://github.com/IchikawaYukko) - [Contributions](https://github.com/Mailu/Mailu/commits?author=IchikawaYukko) Japanese translation
+ - [John Yeates](https://github.com/unikitty37) - [Contributions](https://github.com/Mailu/Mailu/commits?author=unikitty37)

--- a/core/admin/mailu/internal/templates/default.sieve
+++ b/core/admin/mailu/internal/templates/default.sieve
@@ -22,7 +22,7 @@ if header :index 2 :matches "Received" "from * by * for <*>; *"
 if spamtest :percent :value "gt" :comparator "i;ascii-numeric"  "{{ user.spam_threshold }}"
 {
   setflag "\\seen";
-  fileinto :create "Junk";
+  fileinto :create "{{ user.junk_folder }}";
   stop;
 }
 {% endif %}

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -334,6 +334,7 @@ class User(Base, Email):
     displayed_name = db.Column(db.String(160), nullable=False, default="")
     spam_enabled = db.Column(db.Boolean(), nullable=False, default=True)
     spam_threshold = db.Column(db.Integer(), nullable=False, default=80)
+    spam_folder = os.environ.get('JUNK_FOLDER', 'Junk')
 
     # Flask-login attributes
     is_authenticated = True

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -26,12 +26,23 @@ default_vsz_limit = 2GB
 
 namespace inbox {
   inbox = yes
-  {% for mailbox in ("Trash", "Drafts", "Sent", "Junk") %}
-  mailbox {{ mailbox }} {
+  mailbox "{{ TRASH_FOLDER | default('Trash') }}" {
     auto = subscribe
-    special_use = \{{ mailbox }}
+    special_use = \Trash
   }
-  {% endfor %}
+  mailbox "{{ DRAFTS_FOLDER | default('Drafts') }}" {
+    auto = subscribe
+    special_use = \Drafts
+  }
+  mailbox "{{ SENT_FOLDER | default('Sent') }}" {
+    auto = subscribe
+    special_use = \Sent
+  }
+}
+  mailbox "{{ JUNK_FOLDER | default('Junk') }}" {
+    auto = subscribe
+    special_use = \Junk
+  }
 }
 
 plugin {
@@ -155,11 +166,11 @@ plugin {
   sieve_spamtest_max_value = 15
 
   # Learn from spam
-  imapsieve_mailbox1_name = Junk
+  imapsieve_mailbox1_name = {{ JUNK_FOLDER | default('Junk') }}
   imapsieve_mailbox1_causes = COPY
   imapsieve_mailbox1_before = file:/conf/report-spam.sieve
   imapsieve_mailbox2_name = *
-  imapsieve_mailbox2_from = Junk
+  imapsieve_mailbox2_from = {{ JUNK_FOLDER | default('Junk') }}
   imapsieve_mailbox2_causes = COPY
   imapsieve_mailbox2_before = file:/conf/report-ham.sieve
 }

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -38,7 +38,6 @@ namespace inbox {
     auto = subscribe
     special_use = \Sent
   }
-}
   mailbox "{{ JUNK_FOLDER | default('Junk') }}" {
     auto = subscribe
     special_use = \Junk

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -83,6 +83,10 @@ later classify incoming mail based on the custom part.
 The ``DMARC_RUA`` and ``DMARC_RUF`` are DMARC protocol specific values. They hold
 the localpart for DMARC rua and ruf email addresses.
 
+The ``TRASH_FOLDER``, ``DRAFTS_FOLDER``, ``SENT_FOLDER``, and ``JUNK_FOLDER`` are used to
+override the names given to the IMAP special folders. If left blank, the defaults of ``Trash``,
+``Drafts``, ``Sent`` and ``Junk`` will be used.
+
 Web settings
 ------------
 
@@ -176,5 +180,3 @@ Alternatively, ``*_ADDRESS`` can directly be set. In this case, the values of ``
 resolved. This can be used to rely on DNS based service discovery with changing services IP addresses.
 When using ``*_ADDRESS``, the hostnames must be full-qualified hostnames. Otherwise nginx will not be able to
 resolve the hostnames.
-
-

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -91,6 +91,12 @@ COMPRESSION={{ compression }}
 # change compression-level, default: 6 (value: 1-9)
 COMPRESSION_LEVEL={{ compression_level }}
 
+# Default IMAP folder names, as subfolders of the inbox; leave blank for defaults (Trash/Drafts/Sent/Junk)
+TRASH_FOLDER=
+DRAFTS_FOLDER=
+SENT_FOLDER=
+JUNK_FOLDER=
+
 ###################################
 # Web settings
 ###################################
@@ -171,4 +177,3 @@ DB_PW={{ db_pw }}
 DB_HOST={{ db_url }}
 DB_NAME={{ db_name }}
 {% endif %}
-

--- a/towncrier/newsfragments/1552.feature
+++ b/towncrier/newsfragments/1552.feature
@@ -1,0 +1,1 @@
+Allow configuration of default IMAP folder names


### PR DESCRIPTION
## What type of PR?

Enhancement

## What does this PR do?

Allows the default IMAP folder names to be configured for users who prefer different names, or who are using software which has fixed ideas about what those names should be.

As most people will be able to go with the defaults, there doesn't seem to be much need to complicate the setup generator, so this PR just adds four unset variables to `mailu.env`. Setting one of them will override the values placed in the generated `dovecot.conf`, both when assigning the special folder names and, when the Junk folder is overridden, in the monitoring rules generated.

I'm not 100% happy about the `user.spam_folder` as it's really a server setting — if anybody can suggest a better place to put that, I can move it.

### Related issue(s)
closes #1552 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
