### PR TITLE
Fix ANTIVIRUS line in mailu.env file

### DIFF
--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -51,7 +51,7 @@ WEBMAIL={{ webmail_type }}
 WEBDAV={{ webdav_enabled or 'none' }}
 
 # Antivirus solution (value: clamav, none)
-#ANTIVIRUS={{ antivirus_enabled or 'none' }}
+ANTIVIRUS={{ antivirus_enabled or 'none' }}
 
 ###################################
 # Mail settings


### PR DESCRIPTION
The ANTIVIRUS line is commented in mailu.env file. Each mailu.env file generated by setup.mailu.io will have the antivirus line commented. Removed the # so that antivirus works again for new deployments.

## What type of PR?

bug fix

## What does this PR do?

### Related issue(s)
- #1595 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [N/A ] In case of feature or enhancement: documentation updated accordingly
- [ N/A minor change] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
