### PR TITLE
Fix hardcoded reference to admin container.

### DIFF
--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -47,7 +47,7 @@ def fetchmail(fetchmailrc):
 
 def run(debug):
     try:
-        fetches = requests.get("http://admin/internal/fetch").json()
+        fetches = requests.get("http://" + os.environ.get("HOST_ADMIN", "admin") + "/internal/fetch").json()
         smtphost, smtpport = extract_host_port(os.environ.get("HOST_SMTP", "smtp"), None)
         if smtpport is None:
             smtphostport = smtphost
@@ -85,7 +85,7 @@ def run(debug):
                         user_info in error_message):
                     print(error_message)
             finally:
-                requests.post("http://admin/internal/fetch/{}".format(fetch["id"]),
+                requests.post("http://" + os.environ.get("HOST_ADMIN", "admin") + "/internal/fetch/{}".format(fetch["id"]),
                     json=error_message.split("\n")[0]
                 )
     except Exception:


### PR DESCRIPTION
Superseding #1330 

## What type of PR?

big-fix

## What does this PR do?

Fixes a hardcoded reference to ``admin`` container which may or may not be called ``admin`` in reality, since the user may eventually to name the container otherwise.

### Related issue(s)
- closes #1323
- subsumes #1324 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- Minor bug-fix, no additional documentation needed.
