### PR TITLE
_FILE variables for Docker swarm secrets

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -100,6 +100,15 @@ class ConfigManager(dict):
         if self.config["WEBMAIL"] != "none":
             self.config["WEBMAIL_ADDRESS"] = self.get_host_address("WEBMAIL")
 
+    def __get_env(self, key, value):
+        key_file = key + "_FILE"
+        if key_file in os.environ:
+            with open(os.environ.get(key_file)) as file:
+                value_from_file = file.read()
+            return value_from_file.strip()
+        else:
+            return os.environ.get(key, value)
+
     def __coerce_value(self, value):
         if isinstance(value, str) and value.lower() in ('true','yes'):
             return True
@@ -111,7 +120,7 @@ class ConfigManager(dict):
         self.config.update(app.config)
         # get environment variables
         self.config.update({
-            key: self.__coerce_value(os.environ.get(key, value))
+            key: self.__coerce_value(self.__get_env(key, value))
             for key, value in DEFAULT_CONFIG.items()
         })
         self.resolve_hosts()

--- a/docs/swarm/master/README.md
+++ b/docs/swarm/master/README.md
@@ -106,6 +106,9 @@ As a side effect of this ingress mode "feature", make sure that the ingress subn
 - front and webmail are scalable (pending POD_ADDRESS_RANGE is used), although the let's encrypt magic might not like it (race condidtion ? or risk to be banned by let's encrypt server if too many front containers attemps to renew the certs at the same time) 
 - redis, antispam, antivirus, fetchmail, admin, webdav have not been tested (hence replicas=1 in the following docker-compose.yml file)
 
+## Docker secrets
+There are DB_PW_FILE and SECRET_KEY_FILE environment variables available to specify files for these variables. These can be used to configure Docker secrets instead of writing the values directly into the `docker-compose.yml` or `mailu.env`.
+
 ## Variable substitution and docker-compose.yml
 The docker stack deploy command doesn't support variable substitution in the .yml file itself. 
 As a consequence, we cannot simply use ``` docker stack deploy -c docker.compose.yml mailu ```

--- a/towncrier/newsfragments/1607.feature
+++ b/towncrier/newsfragments/1607.feature
@@ -1,0 +1,1 @@
+Implement SECRET_KEY_FILE and DB_PW_FILE variables for usage with Docker secrets.

--- a/webmails/roundcube/config.inc.php
+++ b/webmails/roundcube/config.inc.php
@@ -5,7 +5,7 @@ $config = array();
 // Generals
 $config['db_dsnw'] = getenv('DB_DSNW');;
 $config['temp_dir'] = '/tmp/';
-$config['des_key'] = getenv('SECRET_KEY');
+$config['des_key'] = getenv('SECRET_KEY') ? getenv('SECRET_KEY') : trim(file_get_contents(getenv('SECRET_KEY_FILE')));
 $config['cipher_method'] = 'AES-256-CBC';
 $config['identities_level'] = 0;
 $config['reply_all_mode'] = 1;


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

This PR enables usage of DB_PW_FILE and SECRET_KEY_FILE instead of DB_PW and SECRET_KEY to load these values from files instead of supplying them directly. That way it's possible to use Docker secrets.

### Related issue(s)


## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
