### PR TITLE
add option to enforce inbound starttls

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -221,7 +221,7 @@ mail {
       ssl_protocols TLSv1.2 TLSv1.3;
       ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
       ssl_prefer_server_ciphers off;
-      starttls on;
+      starttls {{ INBOUND_TLS_LEVEL or 'on' }};
       {% endif %}
       protocol smtp;
       smtp_auth none;

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -73,6 +73,13 @@ By default postfix uses "opportunistic TLS" for outbound mail. This can be chang
 by setting ``OUTBOUND_TLS_LEVEL`` to ``encrypt``. This setting is highly recommended
 if you are a relayhost that supports TLS.
 
+Similarily by default nginx uses "opportunistic TLS" for inbound mail. This can be
+changed by setting ``INBOUND_TLS_LEVEL`` to ``only``. Please note that this is forbidden
+for internet facing hosts according to e.g. `RFC 3207`_ , because this prevents MTAs
+without STARTTLS support or e.g. mismatching TLS versions to deliver emails to Mailu.
+
+.. _`RFC 3207`: https://tools.ietf.org/html/rfc3207
+
 The ``FETCHMAIL_DELAY`` is a delay (in seconds) for the fetchmail service to
 go and fetch new email if available. Do not use too short delays if you do not
 want to be blacklisted by external services, but not too long delays if you

--- a/towncrier/newsfragments/1609.feature
+++ b/towncrier/newsfragments/1609.feature
@@ -1,0 +1,1 @@
+Add possibility to enforce inbound STARTTLS via INBOUND_TLS_LEVEL=only


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?
It exposes the starttls parameter in nginx.conf via INBOUND_TLS_LEVEL. The default is still 'on', so existing setups are unaffected by this.

### Related issue(s)

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
