### PR TITLE
Adds own server on port 80 for letsencrypt and redirect

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -34,6 +34,25 @@ http {
       ''      $scheme;
     }
 
+    {% if KUBERNETES_INGRESS != 'true' and TLS_FLAVOR in [ 'letsencrypt', 'cert' ] and not TLS_ERROR %}
+    # Enable the proxy for certbot if the flavor is letsencrypt and not on kubernetes
+    # 
+    server {
+      # Listen over HTTP
+      listen 80;
+      listen [::]:80;
+      {% if TLS_FLAVOR == 'letsencrypt' %}      
+      location ^~ /.well-known/acme-challenge/ {
+          proxy_pass http://127.0.0.1:8008;
+      }
+      {% endif %}
+      # redirect to https
+      location / {
+        return 301 https://$host$request_uri;
+      }
+    }
+    {% endif %}
+
     # Main HTTP server
     server {
       # Favicon stuff
@@ -48,9 +67,11 @@ http {
       set $webdav {{ WEBDAV_ADDRESS }};
       {% endif %}
 
-      # Always listen over HTTP
+      # Listen on HTTP only in kubernetes or behind reverse proxy
+      {% if KUBERNETES_INGRESS == 'true' or TLS_FLAVOR in [ 'mail-letsencrypt', 'notls',  'mail' ] or TLS_ERROR %}
       listen 80;
       listen [::]:80;
+      {% endif %}
 
       # Only enable HTTPS if TLS is enabled with no error and not on kubernetes
       {% if KUBERNETES_INGRESS != 'true' and TLS and not TLS_ERROR %}
@@ -78,8 +99,7 @@ http {
       add_header X-XSS-Protection '1; mode=block';
       add_header Referrer-Policy 'same-origin';
 
-      # In any case, enable the proxy for certbot if the flavor is letsencrypt and not on kubernetes
-      {% if KUBERNETES_INGRESS != 'true' and TLS_FLAVOR in [ 'letsencrypt', 'mail-letsencrypt' ] %}
+      {% if TLS_FLAVOR == 'mail-letsencrypt' %}      
       location ^~ /.well-known/acme-challenge/ {
           proxy_pass http://127.0.0.1:8008;
       }

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -34,7 +34,7 @@ http {
       ''      $scheme;
     }
 
-    {% if KUBERNETES_INGRESS != 'true' and TLS_FLAVOR in [ 'letsencrypt', 'cert' ] and not TLS_ERROR %}
+    {% if KUBERNETES_INGRESS != 'true' and TLS_FLAVOR in [ 'letsencrypt', 'cert' ] %}
     # Enable the proxy for certbot if the flavor is letsencrypt and not on kubernetes
     # 
     server {
@@ -68,7 +68,7 @@ http {
       {% endif %}
 
       # Listen on HTTP only in kubernetes or behind reverse proxy
-      {% if KUBERNETES_INGRESS == 'true' or TLS_FLAVOR in [ 'mail-letsencrypt', 'notls',  'mail' ] or TLS_ERROR %}
+      {% if KUBERNETES_INGRESS == 'true' or TLS_FLAVOR in [ 'mail-letsencrypt', 'notls',  'mail' ] %}
       listen 80;
       listen [::]:80;
       {% endif %}

--- a/towncrier/newsfragments/1564.bugfix
+++ b/towncrier/newsfragments/1564.bugfix
@@ -1,0 +1,1 @@
+Fixes certbot renewal


### PR DESCRIPTION
## What type of PR?

Bugfix

## What does this PR do?

Handle letsencrypt route to `.well-known` by own server configuration within nginx.

### Related issue(s)
closes #1564

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
