### PR TITLE
add OCSP stapling to nginx.conf

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -58,6 +58,8 @@ http {
       listen [::]:443 ssl http2;
 
       include /etc/nginx/tls.conf;
+      ssl_stapling on;
+      ssl_stapling_verify on;
       ssl_session_cache shared:SSLHTTP:50m;
       add_header Strict-Transport-Security 'max-age=31536000';
 

--- a/towncrier/newsfragments/1618.feature
+++ b/towncrier/newsfragments/1618.feature
@@ -1,0 +1,1 @@
+Enable OCSP stapling for the http server within nginx.


### PR DESCRIPTION
It's not added in tls.conf, because apparently the mail ssl module
doesnt' support OCSP stapling.

https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_stapling
^ exists

https://nginx.org/en/docs/mail/ngx_mail_ssl_module.html#ssl_stapling
^ missing

When the configured certificate doesn't have OCSP information, it'll
just log a warning during startup.

## What type of PR?

enhancement

## What does this PR do?

It enables OCSP stapling for the http server. OCSP stapling reduces roundtrips for the client and reduces load on OCSP responders.

### Related issue(s)
- fixes  #1616

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
