### PR TITLE
Fix link to installation guide for Cert Manager

### DIFF
--- a/docs/kubernetes/mailu/index.rst
+++ b/docs/kubernetes/mailu/index.rst
@@ -192,7 +192,7 @@ Happy mailing!
 
 .. _here: https://github.com/hacor/Mailu/blob/master/core/postfix/conf/main.cf#L35
 .. _cert-manager: https://github.com/jetstack/cert-manager
-.. _docs: https://cert-manager.readthedocs.io/en/latest/getting-started/2-installing.html
+.. _docs: https://cert-manager.io/docs/installation/kubernetes/
 
 Imap login fix
 ~~~~~~~~~~~~~~


### PR DESCRIPTION
## What type of PR?
Bugfix in Documentation

(Feature, enhancement, bug-fix, documentation)

## What does this PR do?
Fixes link to Cert Manager installation in documentation. Previous link was returning 404.