### PR TITLE
Add mergify team-members

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,7 +27,7 @@ pull_request_rules:
 
   - name: Trusted author and 1 approved review; trigger bors r+
     conditions:
-      - author~=^(kaiyou|muhlemmer|mildred|HorayNarea|adi90x|hoellen|ofthesun9|Nebukadneza|micw)$
+      - author~=^(kaiyou|muhlemmer|mildred|HorayNarea|adi90x|hoellen|ofthesun9|Nebukadneza|micw|lub|Diman0)$
       - -title~=(WIP|wip)
       - -label~=^(status/wip|status/blocked|review/need2)$
       - "#approved-reviews-by>=1"

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,9 +11,9 @@ pull_request_rules:
         message: |
           Thanks for submitting this pull request.
           Bors-ng will now build test images. When it succeeds, we will continue to review and test your PR.
-
+          
           bors try
-
+          
           Note: if this build fails, [read this](http://mailu.io/master/contributors/environment.html#when-bors-try-fails).
 
   - name: 2 approved reviews; trigger bors r+

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,9 +11,9 @@ pull_request_rules:
         message: |
           Thanks for submitting this pull request.
           Bors-ng will now build test images. When it succeeds, we will continue to review and test your PR.
-          
+
           bors try
-          
+
           Note: if this build fails, [read this](http://mailu.io/master/contributors/environment.html#when-bors-try-fails).
 
   - name: 2 approved reviews; trigger bors r+


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Sync the newly added team-members to the mergify team-regex so that they will benefit from the "team needs only one approve" rule


### Related issue(s)

## Prerequistes
- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
