### PR TITLE
Change unbound logfile to the empty string

### DIFF
--- a/optional/unbound/unbound.conf
+++ b/optional/unbound/unbound.conf
@@ -2,7 +2,7 @@ server:
   verbosity: 1
   interface: 0.0.0.0
   interface: ::0
-  logfile: /dev/stdout
+  logfile: ""
   do-ip4: yes
   do-ip6: yes
   do-udp: yes


### PR DESCRIPTION
This is defined to send log messages to stderr, which is
what we want - fixes #1536 ("Could not open logfile /dev/stdout:
Permission denied")

## What type of PR?

Fix for https://github.com/Mailu/Mailu/issues/1536

## What does this PR do?

As defined in https://nlnetlabs.nl/documentation/unbound/unbound.conf/, log messages will go to /dev/stderr if logfile is set to "" in the config file.

### Related issue(s)

closes #1536 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [N/A ] In case of feature or enhancement: documentation updated accordingly
- [N/A ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
