### PR TITLE
Remove the username from the milter_headers

### DIFF
--- a/core/rspamd/conf/milter_headers.conf
+++ b/core/rspamd/conf/milter_headers.conf
@@ -5,6 +5,9 @@ skip_authenticated = false;
 use = ["x-spamd-bar", "x-spam-level", "x-virus", "authentication-results"];
 
 routines {
+  authentication-results {
+    add_smtp_user = false;
+  }
   x-virus {
     symbols = ["CLAM_VIRUS", "FPROT_VIRUS", "JUST_EICAR"];
   }

--- a/towncrier/newsfragments/1638.fix
+++ b/towncrier/newsfragments/1638.fix
@@ -1,0 +1,1 @@
+Hide the login of the user in sent emails


### PR DESCRIPTION
Rspamd adds the name of the authenticated user by default. Setting add_smtp_user to false prevents the login to be leaked.

## What type of PR?
Enhancement

## What does this PR do?
This PR prevents the user login to be leaked in sent emails (for example using an alias)

### Related issue(s)
Closes https://github.com/Mailu/Mailu/issues/1465

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
