### PR TITLE
Update stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -15,6 +15,7 @@ exemptLabels:
   - priority/p0
   - priority/p1
   - priority/p2
+  - backlog
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
Add label backlog to exempt labels in stale.yml. We will use label backlog to collect bugs/features that we want to consider for a future release. Thus we do not want to auto-close those issues.
