### PR TITLE
Update stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -17,6 +17,8 @@ exemptLabels:
   - priority/p2
   - backlog
   - status/wip
+  - type/bug
+  - type/discussion
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
As discussed in the chat. 
if something is classified as a bug by a member of the Mailu team, then it should not be closed automatically by stalebot but explicitly with wontfix. 
If something is classified as discussion by a member of the Mailu team, it should only be closed explicitly. It is normal that it takes a long time for someone to respond in a discussion.  A discussion can be kept open for a long time, to continue later on.
