### PR TITLE
Update stale.yml

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -5,7 +5,7 @@ daysUntilStale: 21
 
 # Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
 # Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
+daysUntilClose: 14
 
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []
@@ -17,6 +17,11 @@ exemptLabels:
   - priority/p2
   - backlog
   - status/wip
+  - type/bug
+  - type/discussion
+  - type/enhancement
+  - type/feature
+  - type/security
 
 # Set to true to ignore issues in a project (defaults to false)
 exemptProjects: false


### PR DESCRIPTION
as discussed in chat https://matrix.to/#/!RJFCFtixHgPhzacdhW:tedomum.net/$160120578037UHNkM:huisman.xyz?via=ghostdub.de&via=matrix.org&via=tedomum.net
stalebot should only touch
- user support (issue with no label or issue with label type/question).
- issues we explicitly mark with a response_needed label (whatever the name will be of this label).
To give more time to respond when we mark issue with more info needed, we increase the daysUntilClose to 14
