### PR TITLE
Update docs/reverse.rst with Traefik v2+ info

### DIFF
--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -154,7 +154,40 @@ Add the respective Traefik labels for your domain/configuration, like
 If your Traefik is configured to automatically request certificates from *letsencrypt*, then you’ll have a certificate for ``mail.your.doma.in`` now. However,
 ``mail.your.doma.in`` might only be the location where you want the Mailu web-interfaces to live — your mail should be sent/received from ``your.doma.in``,
 and this is the ``DOMAIN`` in your ``.env``?
-To support that use-case, Traefik can request ``SANs`` for your domain. Lets add something like
+To support that use-case, Traefik can request ``SANs`` for your domain. The configuration for this will depend on your Traefik version.
+
+----
+
+Traefik 2.x using labels configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Add the appropriate labels for your domain(s) to the ``front`` container in ``docker-compose.yml``.
+
+.. code-block:: yaml
+
+  services:
+    front:
+      labels:
+        # Enable TLS
+        - "traefik.http.routers.mailu-secure.tls"
+        # Your main domain
+        - "traefik.http.routers.mailu-secure.tls.domains[0].main=your.doma.in"
+        # Optional SANs for your main domain
+        - "traefik.http.routers.mailu-secure.tls.domains[0].sans=mail.your.doma.in,webmail.your.doma.in,smtp.your.doma.in"
+        # Optionally add other domains
+        - "traefik.http.routers.mailu-secure.tls.domains[1].main=mail.other.doma.in"
+        - "traefik.http.routers.mailu-secure.tls.domains[1].sans=mail2.other.doma.in,mail3.other.doma.in"
+        # Your ACME certificate resolver
+        - "traefik.http.routers.mailu-secure.tls.certResolver=foo"
+
+Of course, be sure to define the Certificate Resolver ``foo`` in the static configuration as well.
+
+Alternatively, you can define SANs in the Traefik static configuration using routers, or in the static configuration using entrypoints. Refer to the Traefik documentation for more details.
+
+Traefik 1.x with TOML configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Lets add something like
 
 .. code-block:: yaml
 
@@ -163,7 +196,11 @@ To support that use-case, Traefik can request ``SANs`` for your domain. Lets add
       main = "your.doma.in" # this is the same as $TRAEFIK_DOMAIN!
       sans = ["mail.your.doma.in", "webmail.your.doma.in", "smtp.your.doma.in"]
 
-to your ``traefik.toml``. You might need to clear your ``acme.json``, if a certificate for one of these domains already exists.
+to your ``traefik.toml``.
+
+----
+
+You might need to clear your ``acme.json``, if a certificate for one of these domains already exists.
 
 You will need some solution which dumps the certificates in ``acme.json``, so you can include them in the ``mailu/front`` container.
 One such example is ``mailu/traefik-certdumper``, which has been adapted for use in Mailu. You can add it to your ``docker-compose.yml`` like:

--- a/towncrier/newsfragments/1503.doc
+++ b/towncrier/newsfragments/1503.doc
@@ -1,0 +1,1 @@
+Add documentation for Traefik 2 in Reverse Proxy


### PR DESCRIPTION
## What type of PR?

Documentation

## What does this PR do?

Adds information about using Traefik v2+ as a reverse proxy.

### Related issue(s)
Closes #1503 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
