### PR TITLE
Postfix main.cf needs a EOL on last line

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -126,3 +126,4 @@ milter_default_action = tempfail
 ###############
 # Extra Settings
 ###############
+


### PR DESCRIPTION
When using a override file, a EOL is needed for the main.cf on the last line, or else the first line of the overrides file ends up after the #### a quick workaround is to place a dummy option on the first line of your override file.

```
###############
# Extra Settings
###############dummy = monkey
postscreen_upstream_proxy_protocol = haproxy
```

## What type of PR?

bug-fix

## What does this PR do?

Fixes the override option in postfix main.cf

### Related issue(s)

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
