### PR TITLE
Add ability to set no WEBROOT_REDIRECT to Nginx

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -115,7 +115,7 @@ http {
       include /overrides/*.conf;
 
       # Actual logic
-      {% if WEB_WEBMAIL != '/' %}
+      {% if WEB_WEBMAIL != '/' and WEBROOT_REDIRECT != 'none' %}
       location / {
       {% if WEBROOT_REDIRECT %}
         try_files $uri {{ WEBROOT_REDIRECT }};

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -92,14 +92,19 @@ the localpart for DMARC rua and ruf email addresses.
 Full-text search is enabled for IMAP is enabled by default. This feature can be disabled
 (e.g. for performance reasons) by setting the optional variable ``FULL_TEXT_SEARCH`` to ``off``.
 
+.. _web_settings:
+
 Web settings
 ------------
 
-The ``WEB_ADMIN`` contains the path to the main admin interface, while
-``WEB_WEBMAIL`` contains the path to the Web email client.
-The ``WEBROOT_REDIRECT`` redirects all non-found queries to the set path.
-An empty ``WEBROOT_REDIRECT`` value disables redirecting and enables classic
-behavior of a 404 result when not found.
+- ``WEB_ADMIN`` contains the path to the main admin interface 
+
+- ``WEB_WEBMAIL`` contains the path to the Web email client.
+
+- ``WEBROOT_REDIRECT`` redirects all non-found queries to the set path.
+  An empty ``WEBROOT_REDIRECT`` value disables redirecting and enables classic behavior of a 404 result when not found. 
+  Alternatively, ``WEBROOT_REDIRECT`` can be set to ``none`` if you are using an Nginx override for ``location /``.
+
 All three options need a leading slash (``/``) to work.
 
   .. note:: ``WEBROOT_REDIRECT`` has to point to a valid path on the webserver.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -262,6 +262,8 @@ correct syntax. The following file names will be taken as override configuration
 - `Nginx`_ - All ``*.conf`` files in the ``nginx`` sub-directory;
 - `Rspamd`_ - All files in the ``rspamd`` sub-directory.
 
+To override the root location (``/``) in Nginx ``WEBROOT_REDIRECT`` needs to be set to ``none`` in the env file (see :ref:`web settings <web_settings>`).
+
 *Issue reference:* `206`_, `1368`_.
 
 I want to integrate Nextcloud 15 (and newer) with Mailu


### PR DESCRIPTION
## What type of PR?

Enhancement / Documentation

## What does this PR do?

From commit:

---

Adds a 'none' env option to WEBROOT_REDIRECT so that no `location /`
configuration is written to nginx.conf.

This is useful for setting up Mailu and Mailman where we override the
root to proxy to the mailing list server instead. Without this change
the nginx container will not start, or for 1.7 users can set their
WEBMAIL_PATH to / with no webmail to get the same results.

This fix means that future users don't have to choose between webmail
and a root override and makes the configuration intention clear.

---

I've also added bullet points to break up a long flowing sentence in `configuration.rst` - it should be a bit easier to read now

### Related issue(s)
No Related Issue - I just jumped to a PR

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly

@ Maintainers - Is this worthy of the changelog, it's useful to know about but I imagine the number of people it affects is equally minimal?
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
