### PR TITLE
Fix extract_host_port port separation

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -84,7 +84,7 @@ def get_status(protocol, status):
     return status, codes[protocol]
 
 def extract_host_port(host_and_port, default_port):
-    host, _, port = re.match('^(.*)(:([0-9]*))?$', host_and_port).groups()
+    host, _, port = re.match('^(.*?)(:([0-9]*))?$', host_and_port).groups()
     return host, int(port) if port else default_port
 
 def get_server(protocol, authenticated=False):

--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -28,7 +28,7 @@ poll "{host}" proto {protocol}  port {port}
 
 
 def extract_host_port(host_and_port, default_port):
-    host, _, port = re.match('^(.*)(:([0-9]*))?$', host_and_port).groups()
+    host, _, port = re.match('^(.*?)(:([0-9]*))?$', host_and_port).groups()
     return host, int(port) if port else default_port
 
 

--- a/towncrier/newsfragments/1669.bugfix
+++ b/towncrier/newsfragments/1669.bugfix
@@ -1,0 +1,1 @@
+Fix "extract_host_port" function to support containers with custom / dynamic ports


### PR DESCRIPTION
Regex quantifier should be lazy to make port separation work.

## What type of PR?
bug-fix

## What does this PR do?
The "extract_host_port" function in admin/mailu/internal/nginx.py and optional/fetchmail/fetchmail.py is not actually separating host and port due to the `(.*)` part of the regex being too generous. Lazy quantifier `(.*?)` allows the other capturing groups to match.

### Related issue(s)
- No issue raised for this

## Prerequistes
- [x] Documentation updated accordingly: N/A, bug-fix
- [x] Add [changelog] entry file: Added towncrier newsfragment with second commit