### PR TITLE
Remove rspamd unused env var from start script

### DIFF
--- a/core/rspamd/start.py
+++ b/core/rspamd/start.py
@@ -10,7 +10,6 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
 # Actual startup script
 
-os.environ["FRONT_ADDRESS"] = system.get_host_address_from_environment("FRONT", "front")
 os.environ["REDIS_ADDRESS"] = system.get_host_address_from_environment("REDIS", "redis")
 
 if os.environ.get("ANTIVIRUS") == 'clamav':


### PR DESCRIPTION
## What type of PR?
Cleanup

## What does this PR do?
Remove unused environment variable FRONT_ADDRESS in rspamd. FRONT_ADDRESS references were removed with commit 8172f3e in PR #727 like mentioned in chat https://matrix.to/#/!MINuyJjJSrfowljYCK:tedomum.net/$160401946364NGNmI:imninja.net?via=huisman.xyz&via=matrix.org&via=imninja.net
```
Mailu$ grep -r "FRONT_ADDRESS" core/rspamd/
core/rspamd/start.py:os.environ["FRONT_ADDRESS"] = system.get_host_address_from_environment("FRONT", "front")
```

### Related issue(s)
N/A

## Prerequistes
- [x] Documentation updated accordingly: No documentation to update
- [x] Add to changelog: Minor change