### PR TITLE
Fix letsencrypt access to certbot for the mail-letsencrypt flavour

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -106,7 +106,7 @@ http {
       {% endif %}
 
       # If TLS is failing, prevent access to anything except certbot
-      {% if KUBERNETES_INGRESS != 'true' and TLS_ERROR and not TLS_FLAVOR == "mail" %}
+      {% if KUBERNETES_INGRESS != 'true' and TLS_ERROR and not (TLS_FLAVOR in [ 'mail-letsencrypt', 'mail' ]) %}
       location / {
         return 403;
       }

--- a/towncrier/newsfragments/1686.bugfix
+++ b/towncrier/newsfragments/1686.bugfix
@@ -1,0 +1,1 @@
+Fix letsencrypt access to certbot for the mail-letsencrypt flavour


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
This PR changes nginx.conf file to ensure that the flavor mail-letsencrypt is also having the redirection for .well-known/acme-challenge

### Related issue(s)
closes #1686

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
