### PR TITLE
Add support for SSHA256, SSHA512 password hashing

### DIFF
--- a/core/admin/requirements-prod.txt
+++ b/core/admin/requirements-prod.txt
@@ -29,7 +29,7 @@ limits==1.3
 Mako==1.0.9
 MarkupSafe==1.1.1
 mysqlclient==1.4.2.post1
-passlib==1.7.1
+passlib==1.7.4
 psycopg2==2.8.2
 pycparser==2.19
 pyOpenSSL==19.0.0

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -145,7 +145,7 @@ LOG_DRIVER=json-file
 COMPOSE_PROJECT_NAME=mailu
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, SSHA256, SSHA512, CRYPT)
 PASSWORD_SCHEME=PBKDF2
 
 # Header to take the real ip from

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -146,7 +146,7 @@ DOMAIN_REGISTRATION=true
 COMPOSE_PROJECT_NAME={{ compose_project_name or 'mailu' }}
 
 # Default password scheme used for newly created accounts and changed passwords
-# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT)
+# (value: PBKDF2, BLF-CRYPT, SHA512-CRYPT, SHA256-CRYPT, MD5-CRYPT, SSHA256, SSHA512, CRYPT)
 PASSWORD_SCHEME={{ password_scheme or 'PBKDF2' }}
 
 # Header to take the real ip from


### PR DESCRIPTION
## What type of PR?
Enhancement

## What does this PR do?
Adds support for SSHA256, SSHA512 password hashing

The SSHA256 and SSHA512 schemes are "pre tagged", i.e. they have
`{SSHA256}` or `{SSHA512}` already prepended out of hashlib, so the
check_password and set_password logic is modified to support this.

passlib was updated to 1.7.4 to add support for `ldap_salted_sha256` and
`ldap_salted_sha512`.

This addition is particuilarly useful for users coming from other mail
systems (for example, iRedMail).

### Related issue(s)
Closes #1662

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
