### PR TITLE
Use alpine 3.13 to fix CVE-2020-25275 and CVE-2020-24386

### DIFF
--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+FROM alpine:3.13
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip git bash py3-multidict py3-yarl \

--- a/towncrier/newsfragments/1720.bugfix
+++ b/towncrier/newsfragments/1720.bugfix
@@ -1,0 +1,2 @@
+Fix CVE-2020-25275 and CVE-2020-24386 by using alpine 3.13 for
+dovecot which contains a fixed dovecot version.


### PR DESCRIPTION
## What type of PR?

bug-fix for 1.7 branch

## What does this PR do?

Upgrade dovecot alpine to 3.13 to fix CVEs in dovecot

### Related issue(s)

- #1720

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
