### PR TITLE
Security BugFix, relay networks

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -100,7 +100,6 @@ smtpd_sender_login_maps = ${podop}senderlogin
 smtpd_helo_required = yes
 
 smtpd_client_restrictions =
-  permit_mynetworks,
   check_sender_access ${podop}senderaccess,
   reject_non_fqdn_sender,
   reject_unknown_sender_domain,
@@ -108,7 +107,6 @@ smtpd_client_restrictions =
   permit
 
 smtpd_relay_restrictions =
-  permit_mynetworks,
   permit_sasl_authenticated,
   reject_unauth_destination
 


### PR DESCRIPTION
## BugFix

This is a security bug!
When you are using the docker network, every outstanding IP will come to you as GATEWAY IP, and the attacker can send an email via a relayed network!

here is the proof python code, you can setup a sample mailu and try to send without login:


```python
import smtplib, ssl

smtp_server = "mail.example.com"
port = 587  # For starttls
sender_email = "no-reply@example.com"
password = "" # NOT IMPORTANT!!!!
receiver_email = "fill@your.address"
message = "HelloWorld"

# Create a secure SSL context
context = ssl.create_default_context()

# Try to log in to the server and send an email
try:
    server = smtplib.SMTP(smtp_server, port)

    # Uncomment 3 following lines in case of secure smtp
    #server.ehlo()  
    #server.starttls(context=context)  # Secure the connection
    #server.ehlo()  

    # HERE IS THE BUG
    # YOU SHOULD NOT ABLE TO COMMUNICATE FURTHERMORE WITHOUT AUTHENTICATION
    # EXPECTED MESSAGE IS: 
    # {'fill@you.address': (554, b'5.7.1 <no-reply@example.com>: Sender address rejected: Access denied')}
    # But without my commit it says nothing!!!!
    # Process finished with exit code 0
    #server.login(sender_email, password)
    server.sendmail(sender_email, receiver_email, message)
except Exception as e:
    # Print any error messages to stdout
    print(e)
finally:
    server.quit()
```


On the antispam page, I have this result for this email:
![Screenshot from 2021-01-16 03-49-09](https://user-images.githubusercontent.com/7057611/104790927-01241500-57ae-11eb-8da9-be1b4060a210.png)
![Screenshot from 2021-01-16 03-49-20](https://user-images.githubusercontent.com/7057611/104790938-04b79c00-57ae-11eb-85b7-501680f1564a.png)


P.S: I didn't provide a full vector attack.
GitHub is not a good place to put exploits and I don't want to face the chaotic result.