### PR TITLE
Add new security-release of roundcube 1.4.10 and an update to carddav-plugin

### DIFF
--- a/towncrier/1739.feature
+++ b/towncrier/1739.feature
@@ -1,0 +1,1 @@
+Add new version of roundcube webmailer and its plugin carddav. This is a security update.

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -16,9 +16,11 @@ RUN apt-get update && apt-get install -y \
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube
 RUN pip3 install socrate
 
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.4.6/roundcubemail-1.4.6-complete.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.4.10/roundcubemail-1.4.10-complete.tar.gz
 
-ENV CARDDAV_URL https://github.com/blind-coder/rcmcarddav/releases/download/v3.0.3/carddav-3.0.3.tar.bz2
+ENV CARDDAV_URL https://github.com/blind-coder/rcmcarddav/releases/download/v4.0.4/carddav-v4.0.4.tgz
+
+ENV PHAR_URL https://getcomposer.org/download/2.0.7/composer.phar
 
 RUN apt-get update && apt-get install -y \
       zlib1g-dev libzip4 libzip-dev libpq-dev \
@@ -31,9 +33,9 @@ RUN apt-get update && apt-get install -y \
  && curl -L -O ${ROUNDCUBE_URL} \
  && curl -L -O ${CARDDAV_URL} \
  && tar -xf *.tar.gz \
- && tar -xf *.tar.bz2 \
+ && tar -xf *.tgz\
  && rm -f *.tar.gz \
- && rm -f *.tar.bz2 \
+ && rm -f *.tgz \
  && mv roundcubemail-* html \
  && mv carddav html/plugins/ \
  && cd html \
@@ -42,6 +44,11 @@ RUN apt-get update && apt-get install -y \
  && sed -i 's,^php_value.*post_max_size,#&,g' .htaccess \
  && sed -i 's,^php_value.*upload_max_filesize,#&,g' .htaccess \
  && chown -R www-data: logs temp \
+ && cd plugins/carddav \
+ && curl -L -O ${PHAR_URL} \
+ && php composer.phar install --no-dev \
+ && php composer.phar update --no-dev \
+ && rm -rf composer.phar \
  && rm -rf /var/lib/apt/lists
 
 COPY php.ini /php.ini


### PR DESCRIPTION
## What type of PR?

Security-update for roundcube-webmailer.

## What does this PR do?

This PR updates the Roundcube webmail to the latest version, also updates the roundcube carddav-plugin to a new version.

### Related issue(s)

This PR superseeds PR #1699 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
