### PR TITLE
DNS records for client autoconfiguration (RFC6186)

### DIFF
--- a/core/admin/mailu/ui/templates/domain/details.html
+++ b/core/admin/mailu/ui/templates/domain/details.html
@@ -50,5 +50,17 @@
   <td><pre>_dmarc.{{ domain.name }}. 600 IN TXT "v=DMARC1; p=reject;{% if config["DMARC_RUA"] %} rua=mailto:{{ config["DMARC_RUA"] }}@{{ config["DOMAIN"] }};{% endif %}{% if config["DMARC_RUF"] %} ruf=mailto:{{ config["DMARC_RUF"] }}@{{ config["DOMAIN"] }};{% endif %} adkim=s; aspf=s"</pre></td>
 </tr>
 {% endif %}
+<tr>
+  <th>{% trans %}DNS client auto-configuration (RFC6186) entries{% endtrans %}</th>
+  <td>
+    <pre style="white-space: pre-wrap; word-wrap: break-word;">_submission._tcp.{{ domain.name }}. 600 IN SRV 1 1 587 {{ config["HOSTNAMES"].split(',')[0] }}.</pre>
+    <pre style="white-space: pre-wrap; word-wrap: break-word;">_imap._tcp.{{ domain.name }}. 600 IN SRV 100 1 143 {{ config["HOSTNAMES"].split(',')[0] }}.</pre>
+    <pre style="white-space: pre-wrap; word-wrap: break-word;">_pop3._tcp.{{ domain.name }}. 600 IN SRV 100 1 110 {{ config["HOSTNAMES"].split(',')[0] }}.</pre>
+{% if config["TLS_FLAVOR"] != "notls" %}
+    <pre style="white-space: pre-wrap; word-wrap: break-word;">_submissions._tcp.{{ domain.name }}. 600 IN SRV 10 1 465 {{ config["HOSTNAMES"].split(',')[0] }}.</pre>
+    <pre style="white-space: pre-wrap; word-wrap: break-word;">_imaps._tcp.{{ domain.name }}. 600 IN SRV 10 1 993 {{ config["HOSTNAMES"].split(',')[0] }}.</pre>
+    <pre style="white-space: pre-wrap; word-wrap: break-word;">_pop3s._tcp.{{ domain.name }}. 600 IN SRV 10 1 995 {{ config["HOSTNAMES"].split(',')[0] }}.</pre>
+{% endif %}</td>
+</tr>
 {% endcall %}
 {% endblock %}

--- a/towncrier/newsfragments/224.feature
+++ b/towncrier/newsfragments/224.feature
@@ -1,0 +1,1 @@
+Add instructions on how to create DNS records for email client auto-configuration (RFC6186 style)


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

Add instructions on how to configure rfc6186 DNS records for client autoconfiguration

### Related issue(s)
- #224
- #498

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
