### PR TITLE
For travis Ci: Need to docker login before pulling images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 
 before_script:
   - docker-compose -v
-  - docker login -u $DOCKER_UN -p $DOCKER_PW
+  - echo "$DOCKER_PW" | docker login --username $DOCKER_UN --password-stdin 
   - docker-compose -f tests/build.yml build
   - sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ install:
 
 before_script:
   - docker-compose -v
+  - docker login -u $DOCKER_UN -p $DOCKER_PW
   - docker-compose -f tests/build.yml build
   - sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
 


### PR DESCRIPTION
To avoid triggering the Download rate limit from Docker Hub

## What type of PR?
enhancement

## What does this PR do?
This PR add a docker login cmd before launching the build script