### PR TITLE
Implement a credential cache (alternative to #1758)

### DIFF
--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -1,5 +1,6 @@
 import flask
 import flask_bootstrap
+from flask_caching import Cache
 
 from mailu import utils, debug, models, manage, configuration
 
@@ -23,6 +24,14 @@ def create_app_from_config(config):
     utils.login.user_loader(models.User.get)
     utils.proxy.init_app(app)
     utils.migrate.init_app(app, models.db)
+
+    app.cache = Cache(config={
+        'CACHE_TYPE': 'simple',
+        'CACHE_IGNORE_ERRORS': True,
+        'CACHE_DEFAULT_TIMEOUT': app.config['CREDENTIAL_CACHE_TTL'],
+        'CACHE_THRESHOLD': app.config['CREDENTIAL_CACHE_SIZE'],
+        })
+    app.cache.init_app(app)
 
     # Initialize debugging tools
     if app.config.get("DEBUG"):

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -33,6 +33,8 @@ DEFAULT_CONFIG = {
     'TLS_FLAVOR': 'cert',
     'AUTH_RATELIMIT': '10/minute;1000/hour',
     'AUTH_RATELIMIT_SUBNET': True,
+    'CREDENTIAL_CACHE_TTL': 3600,
+    'CREDENTIAL_CACHE_SIZE': 1000,
     'DISABLE_STATISTICS': False,
     # Mail settings
     'DMARC_RUA': None,

--- a/core/admin/requirements-prod.txt
+++ b/core/admin/requirements-prod.txt
@@ -12,6 +12,7 @@ dominate==2.3.5
 Flask==1.0.2
 Flask-Babel==0.12.2
 Flask-Bootstrap==3.3.7.1
+Flask-Caching==1.9.0
 Flask-DebugToolbar==0.10.1
 Flask-Limiter==1.0.1
 Flask-Login==0.4.1

--- a/core/admin/requirements.txt
+++ b/core/admin/requirements.txt
@@ -23,3 +23,4 @@ mysqlclient
 psycopg2
 idna
 srslib
+Flask-Caching

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -138,9 +138,15 @@ Depending on your particular deployment you most probably will want to change th
 Advanced settings
 -----------------
 
-The ``PASSWORD_SCHEME`` is the password encryption scheme. You should use the
+The ``PASSWORD_SCHEME`` is the password hashing scheme. You should use the
 default value, unless you are importing password from a separate system and
-want to keep using the old password encryption scheme.
+want to keep using the old password hashing scheme.
+
+The ``CREDENTIAL_CACHE_SIZE`` (default: 1000) and ``CREDENTIAL_CACHE_TTL``
+(in seconds: default: 3600) allow for customization of the credential cache.
+The credential cache speeds up the login process by using a representation
+of the passwords that is faster (a non-iterated salted hash), regardless of
+what is in cold-storage (see ``PASSWORD_SCHEME`` above).
 
 The ``LOG_LEVEL`` setting is used by the python start-up scripts as a logging threshold.
 Log messages equal or higher than this priority will be printed.

--- a/towncrier/newsfragments/1194.feature
+++ b/towncrier/newsfragments/1194.feature
@@ -1,0 +1,1 @@
+Add a credential cache and optimize the logic to speedup authentication requests.


### PR DESCRIPTION
## What type of PR?

Feature: it implements a credential cache to speedup authentication requests.

## What does this PR do?

Credentials are stored in cold-storage using a slow, salted/iterated hash function to prevent offline bruteforce attacks. This creates a performance bottleneck for no valid reason (see the
rationale/long version on https://github.com/Mailu/Mailu/issues/1194#issuecomment-762115549).

The new credential cache makes things fast again.

Keep in mind that the cache is local to each gunicorn.

There is an argument to be said about making it less configurable (remove the new knobs, no new dependency) ... that is at #1758

### Related issue(s)
- close #1411
- close #1194 
- close #1758

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
