### PR TITLE
Ensure that flashed messages are displayed

### DIFF
--- a/core/admin/mailu/ui/templates/base.html
+++ b/core/admin/mailu/ui/templates/base.html
@@ -38,6 +38,15 @@
 
         <section class="content">
           {% block content %}{% endblock %}
+	  {% with messages = get_flashed_messages(with_categories=true) %}
+	  {% if messages %}
+	  <ul class=flashes>
+	    {% for category, message in messages %}
+            <li class="{{ category }}">{{ message }}</li>
+	    {% endfor %}
+	  </ul>
+	  {% endif %}
+	  {% endwith %}
         </section>
       </div>
       <footer class="main-footer">


### PR DESCRIPTION
## What type of PR?

Bugfix: display flashed messages

## What does this PR do?

It ensure that we display the flashed messages somewhere. Without it basic things like authentication failures give no feedback!
