### PR TITLE
Implement a simpler credential cache (alternative to #1755)

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -305,6 +305,7 @@ class User(Base, Email):
     """
     __tablename__ = "user"
     _ctx = None
+    _credential_cache = {}
 
     domain = db.relationship(Domain,
         backref=db.backref('users', cascade='all, delete-orphan'))
@@ -382,6 +383,17 @@ class User(Base, Email):
         return User._ctx
 
     def check_password(self, password):
+        cache_result = self._credential_cache.get(self.get_id())
+        current_salt = self.password.split('$')[3] if len(self.password.split('$')) == 5 else None
+        if cache_result and current_salt:
+            cache_salt, cache_hash = cache_result
+            if cache_salt == current_salt:
+                return hash.pbkdf2_sha256.verify(password, cache_hash)
+            else:
+                # the cache is local per gunicorn; the password has changed
+                # so the local cache can be invalidated
+                del self._credential_cache[self.get_id()]
+
         reference = self.password
         # strip {scheme} if that's something mailu has added
         # passlib will identify *crypt based hashes just fine
@@ -396,6 +408,17 @@ class User(Base, Email):
             self.password = new_hash
             db.session.add(self)
             db.session.commit()
+
+        if result:
+            """The credential cache uses a low number of rounds to be fast.
+While it's not meant to be persisted to cold-storage, no additional measures
+are taken to ensure it isn't (mlock(), encrypted swap, ...) on the basis that
+we have little control over GC and string interning anyways.
+
+ An attacker that can dump the process' memory is likely to find credentials
+in clear-text regardless of the presence of the cache.
+            """
+            self._credential_cache[self.get_id()] = (self.password.split('$')[3], hash.pbkdf2_sha256.using(rounds=1).hash(password))
         return result
 
     def set_password(self, password, hash_scheme=None, raw=False):

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -17,7 +17,7 @@ import dns
 
 
 db = flask_sqlalchemy.SQLAlchemy()
-_credential_cache = {}
+
 
 class IdnaDomain(db.TypeDecorator):
     """ Stores a Unicode string in it's IDNA representation (ASCII only)
@@ -383,7 +383,7 @@ class User(Base, Email):
         return User._ctx
 
     def check_password(self, password):
-        cache_result = _credential_cache.get(self.get_id())
+        cache_result = self._credential_cache.get(self.get_id())
         current_salt = self.password.split('$')[3] if len(self.password.split('$')) == 5 else None
         if cache_result and current_salt:
             cache_salt, cache_hash = cache_result
@@ -392,7 +392,7 @@ class User(Base, Email):
             else:
                 # the cache is local per gunicorn; the password has changed
                 # so the local cache can be invalidated
-                del _credential_cache[self.get_id()]
+                del self._credential_cache[self.get_id()]
 
         reference = self.password
         # strip {scheme} if that's something mailu has added
@@ -418,7 +418,7 @@ we have little control over GC and string interning anyways.
  An attacker that can dump the process' memory is likely to find credentials
 in clear-text regardless of the presence of the cache.
             """
-            _credential_cache[self.get_id()] = (self.password.split('$')[3], hash.pbkdf2_sha256.using(rounds=1).hash(password))
+            self._credential_cache[self.get_id()] = (self.password.split('$')[3], hash.pbkdf2_sha256.using(rounds=1).hash(password))
         return result
 
     def set_password(self, password, hash_scheme=None, raw=False):

--- a/towncrier/newsfragments/1194.feature
+++ b/towncrier/newsfragments/1194.feature
@@ -1,0 +1,1 @@
+Add a credential cache to speedup authentication requests.


### PR DESCRIPTION
## What type of PR?

Feature: it implements a credential cache to speedup authentication requests.

## What does this PR do?

Credentials are stored in cold-storage using a slow, salted/iterated hash function to prevent offline bruteforce attacks. This creates a performance bottleneck for no valid reason (see the
rationale/long version on https://github.com/Mailu/Mailu/issues/1194#issuecomment-762115549).

The new credential cache makes things fast again.

This is the simpler version of #1755 (with no new dependencies)

### Related issue(s)
- close #1411
- close #1194 
- close #1755

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
