### PR TITLE
Security updates to postgresql

### DIFF
--- a/optional/postgresql/Dockerfile
+++ b/optional/postgresql/Dockerfile
@@ -3,6 +3,7 @@ FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \
     python3 py3-pip bash py3-multidict \
+  && apk add --upgrade sudo \
   && pip3 install --upgrade pip
 
 # Shared layer between nginx, dovecot, postfix, postgresql, rspamd, unbound, rainloop, roundcube

--- a/towncrier/newsfragments/1760.bugfix
+++ b/towncrier/newsfragments/1760.bugfix
@@ -1,0 +1,2 @@
+Fix CVE-2021-23240, CVE-2021-3156 and CVE-2021-23239 for postgresql
+by force-upgrading sudo.


### PR DESCRIPTION
## What type of PR?

Security update

## What does this PR do?

It fixes vulnerabilities in the sudo package in the postgresql optional container documented in
CVE-2021-23240, CVE-2021-3156 and CVE-2021-23239

### Related issue(s)

None

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
