### PR TITLE
check for `ipv6_enabled` in the compose template

### DIFF
--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     {% if bind4 %}
       - "{{ bind4 }}:{{ port }}:{{ port }}"
     {% endif %}
-    {% if bind6 %}
+    {% if ipv6_enabled and bind6 %}
       - "{{ bind6 }}:{{ port }}:{{ port }}"
     {% endif %}
     {% endfor %}


### PR DESCRIPTION
Checking only `ipv6` isn't sufficient, because it has a default value.

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
-

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [it's a minor change] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
