### PR TITLE
Set sensible cookie flags on the admin app

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -54,6 +54,7 @@ DEFAULT_CONFIG = {
     # Advanced settings
     'PASSWORD_SCHEME': 'PBKDF2',
     'LOG_LEVEL': 'WARNING',
+    'SESSION_COOKIE_SECURE': True,
     # Host settings
     'HOST_IMAP': 'imap',
     'HOST_LMTP': 'imap:2525',
@@ -125,7 +126,6 @@ class ConfigManager(dict):
         self.config['QUOTA_STORAGE_URL'] = 'redis://{0}/1'.format(self.config['REDIS_ADDRESS'])
         self.config['SESSION_COOKIE_SAMESITE'] = 'Strict'
         self.config['SESSION_COOKIE_HTTPONLY'] = True
-        self.config['SESSION_COOKIE_SECURE'] = self.config['TLS_FLAVOR'] != 'notls'
         # update the app config itself
         app.config = self
 

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -123,6 +123,9 @@ class ConfigManager(dict):
 
         self.config['RATELIMIT_STORAGE_URL'] = 'redis://{0}/2'.format(self.config['REDIS_ADDRESS'])
         self.config['QUOTA_STORAGE_URL'] = 'redis://{0}/1'.format(self.config['REDIS_ADDRESS'])
+        self.config['SESSION_COOKIE_SAMESITE'] = 'Strict'
+        self.config['SESSION_COOKIE_HTTPONLY'] = True
+        self.config['SESSION_COOKIE_SECURE'] = self.config['TLS_FLAVOR'] != 'notls'
         # update the app config itself
         app.config = self
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -142,6 +142,8 @@ The ``PASSWORD_SCHEME`` is the password encryption scheme. You should use the
 default value, unless you are importing password from a separate system and
 want to keep using the old password encryption scheme.
 
+The ``SESSION_COOKIE_SECURE`` (default: True) setting controls the secure flag on the cookies of the administrative interface. It should only be turned off if you intend to access it over plain HTTP.
+
 The ``LOG_LEVEL`` setting is used by the python start-up scripts as a logging threshold.
 Log messages equal or higher than this priority will be printed.
 Can be one of: CRITICAL, ERROR, WARNING, INFO, DEBUG or NOTSET.


### PR DESCRIPTION
## What type of PR?

Bugfix

## What does this PR do?

It sets the right flags on the session cookie issued by the admin app.
This should probably be backported as the lack of secure flag on TLS-enabled setup is a high risk vulnerability.

SameSite is hardening / helps against CSRF on modern browsers
HTTPOnly is hardening / helps reduce the impact of XSS