### PR TITLE
Remove "CHUNKING" capability from nginx-smtp

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -215,7 +215,7 @@ mail {
     {% endif %}
 
     # Advertise real capabilites of backends (postfix/dovecot)
-    smtp_capabilities PIPELINING SIZE {{ MESSAGE_SIZE_LIMIT }} ETRN ENHANCEDSTATUSCODES 8BITMIME DSN CHUNKING;
+    smtp_capabilities PIPELINING SIZE {{ MESSAGE_SIZE_LIMIT }} ETRN ENHANCEDSTATUSCODES 8BITMIME DSN;
     pop3_capabilities TOP UIDL RESP-CODES PIPELINING AUTH-RESP-CODE USER;
     imap_capabilities IMAP4 IMAP4rev1 UIDPLUS SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+;
 


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
With `CHUNKING`set as a capability, nginx advertises this capability to
clients at a stage where the SMTP dialog does not seem to be forwarded
to the proxy-target (postfix) yet. Nginx' SMTP parser itself does not
support the `BDAT` command issued as part of a chunke-d dialog. This makes
Nginx respond with a `250 2.0.0 OK` and close the connection, after the
mail-data got sent by the client — without forwarding this to the
proxy-target.

With this, users mail can be lost.

Furthermore, when a user uses a sieve filter to forward mail, dovecot
sometimes chunks the forwarded mail when sending it through `front`.
These forwards then fail.

Removing `CHUNKING` from the capabilities fixes this behavior.

### Related issue(s)
closes #1766 