### PR TITLE
Add mergify to the list of trusted authors

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,7 +27,7 @@ pull_request_rules:
 
   - name: Trusted author and 1 approved review; trigger bors r+
     conditions:
-      - author~=^(kaiyou|muhlemmer|mildred|HorayNarea|adi90x|hoellen|ofthesun9|Nebukadneza|micw|lub|Diman0)$
+      - author~=^(mergify|kaiyou|muhlemmer|mildred|HorayNarea|adi90x|hoellen|ofthesun9|Nebukadneza|micw|lub|Diman0)$
       - -title~=(WIP|wip)
       - -label~=^(status/wip|status/blocked|review/need2)$
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
The idea is to prevent backports from being stuck pending review for too long.

#1767 was created by a trusted author (p0) ... reviewed and merged to master relatively quickly... but it's backport got stuck for a week (#1768) as it required double the number of reviews.

This probably needs to be backported to be effective