### PR TITLE
Fix bug #1660 (don't replace nested headers)

### DIFF
--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -12,6 +12,7 @@ smtp      inet  n       -       n       -       -       smtpd
   -o cleanup_service_name=outclean
 outclean  unix n       -       n       -       0       cleanup
   -o header_checks=pcre:/etc/postfix/outclean_header_filter.cf
+  -o nested_header_checks=
 
 # Internal postfix services
 pickup    unix  n       -       n       60      1       pickup

--- a/towncrier/newsfragments/1660.bugfix
+++ b/towncrier/newsfragments/1660.bugfix
@@ -1,0 +1,1 @@
+Don't replace nested headers (typically in attached emails)


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Don't replace nested headers (typically in forwarded/attached emails). This will ensure we don't break cryptographic signatures.

### Related issue(s)
- close #1660

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
