### PR TITLE
Update fail2ban documentation

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -540,24 +540,24 @@ The above will block flagged IPs for a week, you can of course change it to you 
   
   actionunban = iptables -D f2b-bad-auth -s <ip> -j DROP
 
-Using DOCKER-USER chain ensures that blocked IPs are processed in correct order with Docker. See more in: https://docs.docker.com/network/iptables/
+Using DOCKER-USER chain ensures that the blocked IPs are processed in the correct order with Docker. See more in: https://docs.docker.com/network/iptables/
 
-5. Configure and restart Fail2Ban service
+5. Configure and restart the Fail2Ban service
 
-Make sure Fail2Ban is started after Docker service by adding partial override which appends this to existing configuration..
+Make sure Fail2Ban is started after the Docker service by adding a partial override which appends this to the existing configuration.
 
 .. code-block:: bash
 
   sudo systemctl edit fail2ban
 
-Add override and save file.
+Add the override and save the file.
 
 .. code-block:: bash
 
   [Unit]
   After=docker.service
 
-Restart service.
+Restart the Fail2Ban service.
 
 .. code-block:: bash
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -528,25 +528,42 @@ The above will block flagged IPs for a week, you can of course change it to you 
   
   actionstart = iptables -N f2b-bad-auth
                 iptables -A f2b-bad-auth -j RETURN
-                iptables -I FORWARD -p tcp -m multiport --dports 1:1024 -j f2b-bad-auth
+                iptables -I DOCKER-USER -p tcp -m multiport --dports 1:1024 -j f2b-bad-auth
   
-  actionstop = iptables -D FORWARD -p tcp -m multiport --dports 1:1024 -j f2b-bad-auth
+  actionstop = iptables -D DOCKER-USER -p tcp -m multiport --dports 1:1024 -j f2b-bad-auth
                iptables -F f2b-bad-auth
                iptables -X f2b-bad-auth
   
-  actioncheck = iptables -n -L FORWARD | grep -q 'f2b-bad-auth[ \t]'
+  actioncheck = iptables -n -L DOCKER-USER | grep -q 'f2b-bad-auth[ \t]'
   
   actionban = iptables -I f2b-bad-auth 1 -s <ip> -j DROP
   
   actionunban = iptables -D f2b-bad-auth -s <ip> -j DROP
 
-5. Restart Fail2Ban
+Using DOCKER-USER chain ensures that blocked IPs are processed in correct order with Docker. See more in: https://docs.docker.com/network/iptables/
+
+5. Configure and restart Fail2Ban service
+
+Make sure Fail2Ban is started after Docker service by adding partial override which appends this to existing configuration..
+
+.. code-block:: bash
+
+  sudo systemctl edit fail2ban
+
+Add override and save file.
+
+.. code-block:: bash
+
+  [Unit]
+  After=docker.service
+
+Restart service.
 
 .. code-block:: bash
 
   sudo systemctl restart fail2ban
 
-*Issue reference:* `85`_, `116`_, `171`_, `584`_, `592`_.
+*Issue reference:* `85`_, `116`_, `171`_, `584`_, `592`_, `1727`_.
 
 Users can't change their password from webmail
 ``````````````````````````````````````````````
@@ -670,7 +687,7 @@ iptables -t nat -A POSTROUTING -o eth0 -p tcp --dport 25 -j SNAT --to <your mx i
 .. _`1090`: https://github.com/Mailu/Mailu/issues/1090
 .. _`unbound`: https://nlnetlabs.nl/projects/unbound/about/
 .. _`1438`: https://github.com/Mailu/Mailu/issues/1438
-
+.. _`1727`: https://github.com/Mailu/Mailu/issues/1727
 
 A user gets ``Sender address rejected: Access denied. Please check the`` ``message recipient […] and try again`` even though the sender is legitimate?
 ``````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````````


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?

Update fail2ban documentation. Use DOCKER-USER chain instead of FORWARD chain for fail2ban rules so that they are always processed before any other rules added by docker itself. Also add instructions how to make fail2ban start after docker to prevent fail2ban from failing because of missing DOCKER-USER chain in iptables.

### Related issue(s)
closes #1727 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.


