### PR TITLE
make admin app listen on ipv4 and ipv6

### DIFF
--- a/core/admin/start.py
+++ b/core/admin/start.py
@@ -19,7 +19,7 @@ if account is not None and domain is not None and password is not None:
     os.system("flask mailu admin %s %s '%s' --mode %s" % (account, domain, password, mode))
 
 start_command="".join([
-    "gunicorn -w 4 -b :80 ",
+    "gunicorn -w 4 -b [::]:80 ",
     "--access-logfile - " if (log.root.level<=log.INFO) else "",
     "--error-logfile - ",
     "--preload ",

--- a/towncrier/newsfragments/1802.bugfix
+++ b/towncrier/newsfragments/1802.bugfix
@@ -1,0 +1,1 @@
+Make gunicorn in admin container listen on ipv4 and ipv6.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Make gunicorn in admin container listen on ipv4 and ipv6.

### Related issue(s)
Fixes #1789 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
