### PR TITLE
Fix roundcube database env configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -195,4 +195,24 @@ resolved. This can be used to rely on DNS based service discovery with changing 
 When using ``*_ADDRESS``, the hostnames must be full-qualified hostnames. Otherwise nginx will not be able to
 resolve the hostnames.
 
+Database settings
+-----------------
 
+
+The admin service stores configurations in a database.
+
+- ``DB_FLAVOR``: the database type for mailu admin service. (``sqlite``, ``postgresql``, ``mysql``)
+- ``DB_HOST``: the database host for mailu admin service. (when not ``sqlite``)
+- ``DB_PORT``: the database port for mailu admin service. (when not ``sqlite``)
+- ``DB_PW``: the database password for mailu admin service. (when not ``sqlite``)
+- ``DB_USER``: the database user for mailu admin service. (when not ``sqlite``)
+- ``DB_NAME``: the database name for mailu admin service. (when not ``sqlite``)
+
+The roundcube service stores configurations in a database.
+
+- ``ROUNDCUBE_DB_FLAVOR``: the database type for roundcube service. (``sqlite``, ``postgresql``, ``mysql``)
+- ``ROUNDCUBE_DB_HOST``: the database host for roundcube service. (when not ``sqlite``)
+- ``ROUNDCUBE_DB_PORT``: the database port for roundcube service. (when not ``sqlite``)
+- ``ROUNDCUBE_DB_PW``: the database password for roundcube service. (when not ``sqlite``)
+- ``ROUNDCUBE_DB_USER``: the database user for roundcube service. (when not ``sqlite``)
+- ``ROUNDCUBE_DB_NAME``: the database name for roundcube service. (when not ``sqlite``)

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -8,8 +8,8 @@ This functionality should still be considered experimental!
 Mailu Postgresql
 ----------------
 
-Mailu optionally comes with a pre-configured Postgresql image, wich as of 1.8 is deprecated
-will be removed in 1.9
+Mailu optionally comes with a pre-configured Postgresql image, which as of 1.8, is deprecated
+and will be removed in 1.9.
 This images has the following features:
 
 - Automatic creation of users, db, extensions and password;

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -8,7 +8,8 @@ This functionality should still be considered experimental!
 Mailu Postgresql
 ----------------
 
-Mailu optionally comes with a pre-configured Postgresql image.
+Mailu optionally comes with a pre-configured Postgresql image, wich as of 1.8 is deprecated
+will be removed in 1.9
 This images has the following features:
 
 - Automatic creation of users, db, extensions and password;

--- a/optional/postgresql/start.py
+++ b/optional/postgresql/start.py
@@ -2,7 +2,6 @@
 
 import anosql
 import psycopg2
-import jinja2
 import glob
 import os
 import subprocess

--- a/optional/postgresql/start.py
+++ b/optional/postgresql/start.py
@@ -37,7 +37,6 @@ if not os.listdir("/data"):
                 rec.write("restore_command = 'gunzip < /backup/wal_archive/%f > %p'\n")
                 rec.write("standby_mode = off\n")
             os.system("chown postgres:postgres /data/recovery.conf")
-            #os.system("sudo -u postgres pg_ctl start -D /data -o '-h \"''\" '")
     else:
         # Bootstrap the database
         os.system("sudo -u postgres initdb -D /data")

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -175,3 +175,9 @@ DB_HOST={{ db_url }}
 DB_NAME={{ db_name }}
 {% endif %}
 
+{% if (postgresql == 'external' or db_flavor == 'mysql') and webmail_type == 'roundcube' %}
+ROUNDCUBE_DB_USER={{ roundcube_db_user }}
+ROUNDCUBE_DB_PW={{ roundcube_db_pw }}
+ROUNDCUBE_DB_HOST={{ roundcube_db_url }}
+ROUNDCUBE_DB_NAME={{ roundcube_db_name }}
+{% endif %}

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -176,6 +176,7 @@ DB_NAME={{ db_name }}
 {% endif %}
 
 {% if (postgresql == 'external' or db_flavor == 'mysql') and webmail_type == 'roundcube' %}
+ROUNDCUBE_DB_FLAVOR={{ db_flavor }}
 ROUNDCUBE_DB_USER={{ roundcube_db_user }}
 ROUNDCUBE_DB_PW={{ roundcube_db_pw }}
 ROUNDCUBE_DB_HOST={{ roundcube_db_url }}

--- a/setup/static/render.js
+++ b/setup/static/render.js
@@ -57,6 +57,13 @@ $(document).ready(function() {
 			$("#db_pw").prop('required',true);
 			$("#db_url").prop('required',true);
 			$("#db_name").prop('required',true);
+			if ($("#webmail").val() == 'roundcube') {
+				$("#roundcube_external_db").show();
+				$("#roundcube_db_user").prop('required',true);
+				$("#roundcube_db_pw").prop('required',true);
+				$("#roundcube_db_url").prop('required',true);
+				$("#roundcube_db_name").prop('required',true);
+			}
 		} else if (this.value == 'mysql') {
 			$("#postgres_db").hide();
 			$("#external_db").show();
@@ -64,6 +71,13 @@ $(document).ready(function() {
 			$("#db_pw").prop('required',true);
 			$("#db_url").prop('required',true);
 			$("#db_name").prop('required',true);
+			if ($("#webmail").val() == 'roundcube') {
+				$("#roundcube_external_db").show();
+				$("#roundcube_db_user").prop('required',true);
+				$("#roundcube_db_pw").prop('required',true);
+				$("#roundcube_db_url").prop('required',true);
+				$("#roundcube_db_name").prop('required',true);
+			}
 		}
 	});
 	$("#external_psql").change(function() {
@@ -73,6 +87,13 @@ $(document).ready(function() {
 			$("#db_pw").prop('required',true);
 			$("#db_url").prop('required',true);
 			$("#db_name").prop('required',true);
+			if ($("#webmail").val() == 'roundcube') {
+				$("#roundcube_external_db").show();
+				$("#roundcube_db_user").prop('required',true);
+				$("#roundcube_db_pw").prop('required',true);
+				$("#roundcube_db_url").prop('required',true);
+				$("#roundcube_db_name").prop('required',true);
+			}
 		} else {
 			$("#external_db").hide();
 		}

--- a/setup/templates/steps/database.html
+++ b/setup/templates/steps/database.html
@@ -28,7 +28,7 @@
 		<br/>
 	</div>
 	<div class="form-group" id="external_db" style="display: none">
-		<p>Set external database parameters for <b>ADMIN UI</b></p>
+		<p>Set external database parameters for <b>Admin UI</b></p>
 		<label>DB User</label>
 		<input class="form-control" type="text" name="db_user" placeholder="Username" id="db_user">
 		<label>Db Password</label>

--- a/setup/templates/steps/database.html
+++ b/setup/templates/steps/database.html
@@ -42,7 +42,7 @@
 			<p>Set external database parameters for <b>Roundcube</b></p>
 			<label>DB User</label>
 			<input class="form-control" type="text" name="roundcube_db_user" placeholder="Username" id="roundcube_db_user">
-			<label>Db Password</label>
+			<label>DB Password</label>
 			<input class="form-control" type="password" name="roundcube_db_pw" placeholder="Password" id="roundcube_db_pw">
 			<label>DB URL</label>
 			<input class="form-control" type="text" name="roundcube_db_url" placeholder="URL" id="roundcube_db_url">

--- a/setup/templates/steps/database.html
+++ b/setup/templates/steps/database.html
@@ -28,7 +28,7 @@
 		<br/>
 	</div>
 	<div class="form-group" id="external_db" style="display: none">
-		<p>Set external database parameters</p>
+		<p>Set external database parameters for <b>ADMIN UI</b></p>
 		<label>DB User</label>
 		<input class="form-control" type="text" name="db_user" placeholder="Username" id="db_user">
 		<label>Db Password</label>
@@ -37,6 +37,18 @@
 		<input class="form-control" type="text" name="db_url" placeholder="URL" id="db_url">
 		<label>Db Name</label>
 		<input class="form-control" type="text" name="db_name" placeholder="Database Name" id="db_name">
+		<br/>
+		<div class="form-group" id="roundcube_external_db" style="display: none">
+			<p>Set external database parameters for <b>Roundcube</b></p>
+			<label>DB User</label>
+			<input class="form-control" type="text" name="roundcube_db_user" placeholder="Username" id="roundcube_db_user">
+			<label>Db Password</label>
+			<input class="form-control" type="password" name="roundcube_db_pw" placeholder="Password" id="roundcube_db_pw">
+			<label>Db URL</label>
+			<input class="form-control" type="text" name="roundcube_db_url" placeholder="URL" id="roundcube_db_url">
+			<label>Db Name</label>
+			<input class="form-control" type="text" name="roundcube_db_name" placeholder="Database Name" id="roundcube_db_name">
+		</div>
 	</div>
 </div>
 

--- a/setup/templates/steps/database.html
+++ b/setup/templates/steps/database.html
@@ -46,7 +46,7 @@
 			<input class="form-control" type="password" name="roundcube_db_pw" placeholder="Password" id="roundcube_db_pw">
 			<label>Db URL</label>
 			<input class="form-control" type="text" name="roundcube_db_url" placeholder="URL" id="roundcube_db_url">
-			<label>Db Name</label>
+			<label>DB Name</label>
 			<input class="form-control" type="text" name="roundcube_db_name" placeholder="Database Name" id="roundcube_db_name">
 		</div>
 	</div>

--- a/setup/templates/steps/database.html
+++ b/setup/templates/steps/database.html
@@ -44,7 +44,7 @@
 			<input class="form-control" type="text" name="roundcube_db_user" placeholder="Username" id="roundcube_db_user">
 			<label>Db Password</label>
 			<input class="form-control" type="password" name="roundcube_db_pw" placeholder="Password" id="roundcube_db_pw">
-			<label>Db URL</label>
+			<label>DB URL</label>
 			<input class="form-control" type="text" name="roundcube_db_url" placeholder="URL" id="roundcube_db_url">
 			<label>DB Name</label>
 			<input class="form-control" type="text" name="roundcube_db_name" placeholder="Database Name" id="roundcube_db_name">

--- a/towncrier/newsfragments/1831.bugfix
+++ b/towncrier/newsfragments/1831.bugfix
@@ -1,0 +1,1 @@
+Fix roundcube environment configuration for databases

--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -17,14 +17,14 @@ elif db_flavor == "mysql":
     os.environ["DB_DSNW"] = "mysql://%s:%s@%s/%s" % (
         os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
         os.environ.get("ROUNDCUBE_DB_PW"),
-        os.environ.get("ROUNDCUBE_DB_HOST", os.environ.get("DB_HOST", "database")),
+        os.environ.get("ROUNDCUBE_DB_HOST", "database"),
         os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
     )
 elif db_flavor == "postgresql":
     os.environ["DB_DSNW"] = "pgsql://%s:%s@%s/%s" % (
         os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
         os.environ.get("ROUNDCUBE_DB_PW"),
-        os.environ.get("ROUNDCUBE_DB_HOST", os.environ.get("DB_HOST", "database")),
+        os.environ.get("ROUNDCUBE_DB_HOST", "database"),
         os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
     )
 else:

--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -10,7 +10,7 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
 os.environ["MAX_FILESIZE"] = str(int(int(os.environ.get("MESSAGE_SIZE_LIMIT"))*0.66/1048576))
 
-db_flavor=os.environ.get("ROUNDCUBE_DB_FLAVOR",os.environ.get("DB_FLAVOR","sqlite"))
+db_flavor=os.environ.get("ROUNDCUBE_DB_FLAVOR","sqlite")
 if db_flavor=="sqlite":
     os.environ["DB_DSNW"]="sqlite:////data/roundcube.db"
 elif db_flavor=="mysql":

--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -8,30 +8,28 @@ import subprocess
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
-os.environ["MAX_FILESIZE"] = str(int(int(os.environ.get("MESSAGE_SIZE_LIMIT"))*0.66/1048576))
+os.environ["MAX_FILESIZE"] = str(int(int(os.environ.get("MESSAGE_SIZE_LIMIT")) * 0.66 / 1048576))
 
-db_flavor=os.environ.get("ROUNDCUBE_DB_FLAVOR","sqlite")
-if db_flavor=="sqlite":
-    os.environ["DB_DSNW"]="sqlite:////data/roundcube.db"
-elif db_flavor=="mysql":
-    os.environ["DB_DSNW"]="mysql://%s:%s@%s/%s" % (
-        os.environ.get("ROUNDCUBE_DB_USER","roundcube"),
+db_flavor = os.environ.get("ROUNDCUBE_DB_FLAVOR", "sqlite")
+if db_flavor == "sqlite":
+    os.environ["DB_DSNW"] = "sqlite:////data/roundcube.db"
+elif db_flavor == "mysql":
+    os.environ["DB_DSNW"] = "mysql://%s:%s@%s/%s" % (
+        os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
         os.environ.get("ROUNDCUBE_DB_PW"),
-        os.environ.get("ROUNDCUBE_DB_HOST",os.environ.get("DB_HOST","database")),
-        os.environ.get("ROUNDCUBE_DB_NAME","roundcube")
-        )
-elif db_flavor=="postgresql":
-    os.environ["DB_DSNW"]="pgsql://%s:%s@%s/%s" % (
-        os.environ.get("ROUNDCUBE_DB_USER","roundcube"),
+        os.environ.get("ROUNDCUBE_DB_HOST", os.environ.get("DB_HOST", "database")),
+        os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
+    )
+elif db_flavor == "postgresql":
+    os.environ["DB_DSNW"] = "pgsql://%s:%s@%s/%s" % (
+        os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
         os.environ.get("ROUNDCUBE_DB_PW"),
-        os.environ.get("ROUNDCUBE_DB_HOST",os.environ.get("DB_HOST","database")),
-        os.environ.get("ROUNDCUBE_DB_NAME","roundcube")
-        )
+        os.environ.get("ROUNDCUBE_DB_HOST", os.environ.get("DB_HOST", "database")),
+        os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
+    )
 else:
-    print("Unknown ROUNDCUBE_DB_FLAVOR: %s",db_flavor)
+    print("Unknown ROUNDCUBE_DB_FLAVOR: %s", db_flavor)
     exit(1)
-
-
 
 conf.jinja("/php.ini", os.environ, "/usr/local/etc/php/conf.d/roundcube.ini")
 
@@ -42,7 +40,8 @@ os.system("chown -R www-data:www-data /var/www/html/logs")
 
 try:
     print("Initializing database")
-    result=subprocess.check_output(["/var/www/html/bin/initdb.sh","--dir","/var/www/html/SQL"],stderr=subprocess.STDOUT)
+    result = subprocess.check_output(["/var/www/html/bin/initdb.sh", "--dir", "/var/www/html/SQL"],
+                                     stderr=subprocess.STDOUT)
     print(result.decode())
 except subprocess.CalledProcessError as e:
     if "already exists" in e.stdout.decode():
@@ -53,7 +52,7 @@ except subprocess.CalledProcessError as e:
 
 try:
     print("Upgrading database")
-    subprocess.check_call(["/var/www/html/bin/update.sh","--version=?","-y"],stderr=subprocess.STDOUT)
+    subprocess.check_call(["/var/www/html/bin/update.sh", "--version=?", "-y"], stderr=subprocess.STDOUT)
 except subprocess.CalledProcessError as e:
     quit(1)
 
@@ -61,7 +60,7 @@ except subprocess.CalledProcessError as e:
 os.system("chown -R www-data:www-data /data")
 
 # Tail roundcube logs
-subprocess.Popen(["tail","-f","-n","0","/var/www/html/logs/errors.log"])
+subprocess.Popen(["tail", "-f", "-n", "0", "/var/www/html/logs/errors.log"])
 
 # Run apache
 os.execv("/usr/local/bin/apache2-foreground", ["apache2-foreground"])


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Both roundcube and mailu admin website can be backed by postgres/mysql. Before this PR, the `DB_FLAVOR` is shared by both services. However, the other roundcube dedicated DB params are prefixed with `ROUNDCUBE_`. (eg: `ROUNDCUBE_DB_NAME`)
There is no reason to share the DB_FLAVOR for both: This PR makes them be considered independently to make things clear and avoid bugs.
Also, the roundcube_db_flavor and db_flavor are made separated in this PR. However for simplicity, the template generator bind them : roundcube_db_flavor = db_flavor. This makes the template generator UI more simple. I considered most of the time people want to have both roundcube and mailu share the same RDBMS.

Also, AFAIK the internal postgresql service is deprecated and will be removed in 1.9. This is why this PR does not integrate roundcube in postgres when the internal DB is choosen: in case of internal postgres, the roundcube is backed with sqlite.

Both documentation and setup website have been updated accordingly.

### Related issue(s)
- Auto close an issue like: closes #1648 #1471

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
