### PR TITLE
Test ci parallel

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -292,6 +292,7 @@ jobs:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
       - name: Load docker images
+        if: ${{ env.BRANCH != 'staging' }}
         run: docker load -i /images/images.tar.gz
       - name: Deploy built docker images
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,6 +85,8 @@ jobs:
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: Load docker images
+        run: docker load -i /images/images.tar.gz
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
       - name: Copy all certs
@@ -116,6 +118,8 @@ jobs:
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: Load docker images
+        run: docker load -i /images/images.tar.gz
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
       - name: Copy all certs
@@ -147,6 +151,8 @@ jobs:
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: Load docker images
+        run: docker load -i /images/images.tar.gz
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
       - name: Copy all certs
@@ -178,6 +184,8 @@ jobs:
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: Load docker images
+        run: docker load -i /images/images.tar.gz
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
       - name: Copy all certs
@@ -209,6 +217,8 @@ jobs:
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: Load docker images
+        run: docker load -i /images/images.tar.gz
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
       - name: Copy all certs
@@ -240,6 +250,8 @@ jobs:
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: Load docker images
+        run: docker load -i /images/images.tar.gz
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
       - name: Copy all certs

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,7 +77,9 @@ jobs:
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Create folder for storing images
-        run: sudo mkdir -p /images
+        run: |
+          sudo mkdir -p /images
+          sudo chmod 777 /images
       - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
@@ -106,7 +108,9 @@ jobs:
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Create folder for storing images
-        run: sudo mkdir -p /images
+        run: |
+          sudo mkdir -p /images
+          sudo chmod 777 /images
       - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
@@ -135,7 +139,9 @@ jobs:
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Create folder for storing images
-        run: sudo mkdir -p /images
+        run: |
+          sudo mkdir -p /images
+          sudo chmod 777 /images
       - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
@@ -164,7 +170,9 @@ jobs:
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Create folder for storing images
-        run: sudo mkdir -p /images
+        run: |
+          sudo mkdir -p /images
+          sudo chmod 777 /images
       - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
@@ -193,7 +201,9 @@ jobs:
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Create folder for storing images
-        run: sudo mkdir -p /images
+        run: |
+          sudo mkdir -p /images
+          sudo chmod 777 /images
       - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
@@ -222,7 +232,9 @@ jobs:
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
       - name: Create folder for storing images
-        run: sudo mkdir -p /images
+        run: |
+          sudo mkdir -p /images
+          sudo chmod 777 /images
       - name: Configure images folder for caching
         uses: actions/cache@v2
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ on:
 
 jobs:
   build:
-    name: build images
+    name: Build images
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -39,28 +39,30 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: create folder for storing images
-        run: sudo mkdir -p /images
-      - name: configure images folder for caching
+      - name: Create folder for storing images
+        run: |
+          sudo mkdir -p /images
+          chmod sudo chmod 777 /images
+      - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
-      - name: check docker-compose version
+      - name: Check docker-compose version
         run: docker-compose -v
-      - name: login docker
+      - name: Login docker
         env:
           DOCKER_UN: ${{ secrets.Docker_Login }}
           DOCKER_PW: ${{ secrets.Docker_Password }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: echo "$DOCKER_PW" | docker login --username $DOCKER_UN --password-stdin
-      - name: build all docker images
+      - name: Build all docker images
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: docker-compose -f tests/build.yml build
-      - name: save all docker images
+      - name: Save all docker images
         run: docker save ${{ secrets.DOCKER_ORG }}/admin ${{ secrets.DOCKER_ORG }}/clamav ${{ secrets.DOCKER_ORG }}/docs ${{ secrets.DOCKER_ORG }}/dovecot ${{ secrets.DOCKER_ORG }}/fetchmail ${{ secrets.DOCKER_ORG }}/nginx ${{ secrets.DOCKER_ORG }}/none ${{ secrets.DOCKER_ORG }}/postfix ${{ secrets.DOCKER_ORG }}/postgresql ${{ secrets.DOCKER_ORG }}/radicale ${{ secrets.DOCKER_ORG }}/rainloop ${{ secrets.DOCKER_ORG }}/roundcube ${{ secrets.DOCKER_ORG }}/rspamd ${{ secrets.DOCKER_ORG }}/setup ${{ secrets.DOCKER_ORG }}/traefik-certdumper ${{ secrets.DOCKER_ORG }}/unbound -o /images/images.tar.gz
 
   test-core:
@@ -74,18 +76,18 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: create folder for storing images
+      - name: Create folder for storing images
         run: sudo mkdir -p /images
-      - name: configure images folder for caching
+      - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
-      - name: install python packages
+      - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
-      - name: copy all certs
+      - name: Copy all certs
         run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
-      - name: test core suite
+      - name: Test core suite
         run: python tests/compose/test.py core 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
@@ -103,18 +105,18 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: create folder for storing images
+      - name: Create folder for storing images
         run: sudo mkdir -p /images
-      - name: configure images folder for caching
+      - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
-      - name: install python packages
+      - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
-      - name: copy all certs
+      - name: Copy all certs
         run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
-      - name: test fetch
+      - name: Test fetch
         run: python tests/compose/test.py fetchmail 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
@@ -132,18 +134,18 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: create folder for storing images
+      - name: Create folder for storing images
         run: sudo mkdir -p /images
-      - name: configure images folder for caching
+      - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
-      - name: install python packages
+      - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
-      - name: copy all certs
+      - name: Copy all certs
         run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
-      - name: 'test clamvav'
+      - name: Test clamvav
         run: python tests/compose/test.py filters 2
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
@@ -161,18 +163,18 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: create folder for storing images
+      - name: Create folder for storing images
         run: sudo mkdir -p /images
-      - name: configure images folder for caching
+      - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
-      - name: install python packages
+      - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
-      - name: copy all certs
+      - name: Copy all certs
         run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
-      - name: test rainloop
+      - name: Test rainloop
         run: python tests/compose/test.py rainloop 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
@@ -190,18 +192,18 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: create folder for storing images
+      - name: Create folder for storing images
         run: sudo mkdir -p /images
-      - name: configure images folder for caching
+      - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
-      - name: install python packages
+      - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
-      - name: copy all certs
+      - name: Copy all certs
         run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
-      - name: test roundcube
+      - name: Test roundcube
         run: python tests/compose/test.py roundcube 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
@@ -219,18 +221,18 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: create folder for storing images
+      - name: Create folder for storing images
         run: sudo mkdir -p /images
-      - name: configure images folder for caching
+      - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
-      - name: install python packages
+      - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
-      - name: copy all certs
+      - name: Copy all certs
         run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
-      - name: test webdav
+      - name: Test webdav
         run: python tests/compose/test.py webdav 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
@@ -254,9 +256,11 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: create folder for storing images
-        run: sudo mkdir -p /images        
-      - name: configure images folder for caching
+      - name: Create folder for storing images
+        run: |
+          sudo mkdir -p /images
+          chmod sudo chmod 777 /images     
+      - name: Configure images folder for caching
         # For staging we do not deploy images. So we do not have to load them from cache.
         if: ${{ env.BRANCH != 'staging' }}
         uses: actions/cache@v2
@@ -265,7 +269,7 @@ jobs:
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
       - name: Load docker images
         run: docker load -i /images/images.tar.gz
-      - name: deploy built docker images
+      - name: Deploy built docker images
         env:
           DOCKER_UN: ${{ secrets.Docker_Login }}
           DOCKER_PW: ${{ secrets.Docker_Password }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,10 +1,5 @@
 name: CI
 on:
-#NOTE: The workflow will ONLY trigger when the branch actually contains the CI.yml workflow file.
-#So if a PR is tested on STAGING/TESTING branch by BORS without this file present, then the workflow
-#will NOT trigger. For these situations, manually start the workflow. This should be resolved once all
-#old PRs without the CI.yml workflow file have been merged.
-  workflow_dispatch:
   push:
     branches:
       - staging

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
       - name: create folder for storing images
         run: sudo mkdir -p /images
       - name: configure images folder for caching
-        using: actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
@@ -77,7 +77,7 @@ jobs:
       - name: create folder for storing images
         run: sudo mkdir -p /images
       - name: configure images folder for caching
-        using: actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
@@ -106,7 +106,7 @@ jobs:
       - name: create folder for storing images
         run: sudo mkdir -p /images
       - name: configure images folder for caching
-        using: actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
@@ -135,7 +135,7 @@ jobs:
       - name: create folder for storing images
         run: sudo mkdir -p /images
       - name: configure images folder for caching
-        using: actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
@@ -164,7 +164,7 @@ jobs:
       - name: create folder for storing images
         run: sudo mkdir -p /images
       - name: configure images folder for caching
-        using: actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
@@ -193,7 +193,7 @@ jobs:
       - name: create folder for storing images
         run: sudo mkdir -p /images
       - name: configure images folder for caching
-        using: actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
@@ -222,7 +222,7 @@ jobs:
       - name: create folder for storing images
         run: sudo mkdir -p /images
       - name: configure images folder for caching
-        using: actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
@@ -259,7 +259,7 @@ jobs:
       - name: configure images folder for caching
         # For staging we do not deploy images. So we do not have to load them from cache.
         if: ${{ env.BRANCH != 'staging' }}
-        using: actions/cache@v2
+        uses: actions/cache@v2
         with:
           path: /images
           key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
-          chmod sudo chmod 777 /images
+          sudo chmod 777 /images
       - name: Configure images folder for caching
         uses: actions/cache@v2
         with:
@@ -259,7 +259,7 @@ jobs:
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
-          chmod sudo chmod 777 /images     
+          sudo chmod 777 /images     
       - name: Configure images folder for caching
         # For staging we do not deploy images. So we do not have to load them from cache.
         if: ${{ env.BRANCH != 'staging' }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,7 +63,6 @@ jobs:
       - name: save all docker images
         run: docker save ${{ secrets.DOCKER_ORG }}/admin ${{ secrets.DOCKER_ORG }}/clamav ${{ secrets.DOCKER_ORG }}/docs ${{ secrets.DOCKER_ORG }}/dovecot ${{ secrets.DOCKER_ORG }}/fetchmail ${{ secrets.DOCKER_ORG }}/nginx ${{ secrets.DOCKER_ORG }}/none ${{ secrets.DOCKER_ORG }}/postfix ${{ secrets.DOCKER_ORG }}/postgresql ${{ secrets.DOCKER_ORG }}/radicale ${{ secrets.DOCKER_ORG }}/rainloop ${{ secrets.DOCKER_ORG }}/roundcube ${{ secrets.DOCKER_ORG }}/rspamd ${{ secrets.DOCKER_ORG }}/setup ${{ secrets.DOCKER_ORG }}/traefik-certdumper ${{ secrets.DOCKER_ORG }}/unbound -o /images/images.tar.gz
 
-
   test-core:
     name: Perform core tests
     runs-on: ubuntu-latest
@@ -93,7 +92,7 @@ jobs:
           TRAVIS_BRANCH: ${{ env.BRANCH }} 
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 
- test-fetchmail:
+  test-fetchmail:
     name: Perform fetchmail tests
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,23 +25,27 @@ on:
 # DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 #    The docker repository where the images are pushed to.
 # DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
-#    The docker repository for test images. Only used for the branch TESTING (BORS try). 
+#    The docker repository for test images. Only used for the branch TESTING (BORS try).
 # Add the above secrets to your github repo to determine where the images will be pushed.
 ################################################
 
 jobs:
-  build-test-deploy:
-    name: build and test
+  build:
+    name: build images
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: install python packages
-        run: python3 -m pip install -r tests/requirements.txt
+      - name: create folder for storing images
+        run: sudo mkdir -p /images
+      - name: configure images folder for caching
+        using: actions/cache@v2
+        with:
+          path: /images
+          key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
       - name: check docker-compose version
         run: docker-compose -v
       - name: login docker
@@ -49,22 +53,39 @@ jobs:
           DOCKER_UN: ${{ secrets.Docker_Login }}
           DOCKER_PW: ${{ secrets.Docker_Password }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
-        run: echo "$DOCKER_PW" | docker login --username $DOCKER_UN --password-stdin      
-      # In this step, this action saves a list of existing images,
-      # the cache is created without them in the post run.
-      # It also restores the cache if it exists.
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-       # Ignore the failure of a step and avoid terminating the job.
-        continue-on-error: true
+        run: echo "$DOCKER_PW" | docker login --username $DOCKER_UN --password-stdin
       - name: build all docker images
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: docker-compose -f tests/build.yml build
+      - name: save all docker images
+        run: docker save ${{ secrets.DOCKER_ORG }}/admin ${{ secrets.DOCKER_ORG }}/clamav ${{ secrets.DOCKER_ORG }}/docs ${{ secrets.DOCKER_ORG }}/dovecot ${{ secrets.DOCKER_ORG }}/fetchmail ${{ secrets.DOCKER_ORG }}/nginx ${{ secrets.DOCKER_ORG }}/none ${{ secrets.DOCKER_ORG }}/postfix ${{ secrets.DOCKER_ORG }}/postgresql ${{ secrets.DOCKER_ORG }}/radicale ${{ secrets.DOCKER_ORG }}/rainloop ${{ secrets.DOCKER_ORG }}/roundcube ${{ secrets.DOCKER_ORG }}/rspamd ${{ secrets.DOCKER_ORG }}/setup ${{ secrets.DOCKER_ORG }}/traefik-certdumper ${{ secrets.DOCKER_ORG }}/unbound -o /images/images.tar.gz
 
+
+  test-core:
+    name: Perform core tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: create folder for storing images
+        run: sudo mkdir -p /images
+      - name: configure images folder for caching
+        using: actions/cache@v2
+        with:
+          path: /images
+          key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: install python packages
+        run: python3 -m pip install -r tests/requirements.txt
       - name: copy all certs
-        run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'      
+        run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
       - name: test core suite
         run: python tests/compose/test.py core 1
         env:
@@ -72,41 +93,179 @@ jobs:
           TRAVIS_BRANCH: ${{ env.BRANCH }} 
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 
-      - name: 'test clamvav'
-        run: python tests/compose/test.py filters 2
-        env:
-          MAILU_VERSION: ${{ env.BRANCH }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
-          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
-                  
+ test-fetchmail:
+    name: Perform fetchmail tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: create folder for storing images
+        run: sudo mkdir -p /images
+      - name: configure images folder for caching
+        using: actions/cache@v2
+        with:
+          path: /images
+          key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: install python packages
+        run: python3 -m pip install -r tests/requirements.txt
+      - name: copy all certs
+        run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
       - name: test fetch
         run: python tests/compose/test.py fetchmail 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
-                
+
+  test-filters:
+    name: Perform filter tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: create folder for storing images
+        run: sudo mkdir -p /images
+      - name: configure images folder for caching
+        using: actions/cache@v2
+        with:
+          path: /images
+          key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: install python packages
+        run: python3 -m pip install -r tests/requirements.txt
+      - name: copy all certs
+        run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
+      - name: 'test clamvav'
+        run: python tests/compose/test.py filters 2
+        env:
+          MAILU_VERSION: ${{ env.BRANCH }}
+          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
+
+  test-rainloop:
+    name: Perform rainloop tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: create folder for storing images
+        run: sudo mkdir -p /images
+      - name: configure images folder for caching
+        using: actions/cache@v2
+        with:
+          path: /images
+          key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: install python packages
+        run: python3 -m pip install -r tests/requirements.txt
+      - name: copy all certs
+        run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
       - name: test rainloop
         run: python tests/compose/test.py rainloop 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
           TRAVIS_BRANCH: ${{ env.BRANCH }} 
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
-  
+
+  test-roundcube:
+    name: Perform roundcube tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: create folder for storing images
+        run: sudo mkdir -p /images
+      - name: configure images folder for caching
+        using: actions/cache@v2
+        with:
+          path: /images
+          key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: install python packages
+        run: python3 -m pip install -r tests/requirements.txt
+      - name: copy all certs
+        run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
       - name: test roundcube
         run: python tests/compose/test.py roundcube 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
           TRAVIS_BRANCH: ${{ env.BRANCH }} 
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
-                  
+
+  test-webdav:
+    name: Perform webdav tests
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: create folder for storing images
+        run: sudo mkdir -p /images
+      - name: configure images folder for caching
+        using: actions/cache@v2
+        with:
+          path: /images
+          key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: install python packages
+        run: python3 -m pip install -r tests/requirements.txt
+      - name: copy all certs
+        run: sudo -- sh -c 'mkdir -p /mailu && cp -r tests/certs /mailu && chmod 600 /mailu/certs/*'
       - name: test webdav
         run: python tests/compose/test.py webdav 1
         env:
           MAILU_VERSION: ${{ env.BRANCH }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
-         
+
+  deploy:
+    name: Deploy images
+    runs-on: ubuntu-latest
+    needs:
+      - build
+      - test-core
+      - test-fetchmail
+      - test-filters
+      - test-rainloop
+      - test-roundcube
+      - test-webdav
+    steps:
+      - uses: actions/checkout@v2
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: create folder for storing images
+        run: sudo mkdir -p /images        
+      - name: configure images folder for caching
+        # For staging we do not deploy images. So we do not have to load them from cache.
+        if: ${{ env.BRANCH != 'staging' }}
+        using: actions/cache@v2
+        with:
+          path: /images
+          key: ${{ env.BRANCH }}-${{ github.run_id }}-${{ github.run_number }}
+      - name: Load docker images
+        run: docker load -i /images/images.tar.gz
       - name: deploy built docker images
         env:
           DOCKER_UN: ${{ secrets.Docker_Login }}
@@ -124,10 +283,8 @@ jobs:
     #Returns true when none of the **previous** steps have failed or been canceled.
     if: ${{ success() }}
     needs: 
-      - build-test-deploy
+      - deploy
     runs-on: ubuntu-latest
     steps:
       - name: CI/CD succeeded.
         run: exit 0
-
-

--- a/tests/compose/filters/00_create_users.sh
+++ b/tests/compose/filters/00_create_users.sh
@@ -1,0 +1,5 @@
+echo "Creating user required for next test ..."
+# Should not fail and update the password; update mode
+docker-compose -f tests/compose/filters/docker-compose.yml exec -T admin flask mailu admin admin mailu.io 'password' --mode=update || exit 1
+docker-compose -f tests/compose/filters/docker-compose.yml exec -T admin flask mailu user user mailu.io 'password' || exit 1
+echo "User created successfully"

--- a/towncrier/newsfragments/1830.misc
+++ b/towncrier/newsfragments/1830.misc
@@ -1,0 +1,1 @@
+Make CI tests run in parallel.


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Changes CI workflow to run all tests in parellel.  After performing some tests (see #1830  ), I determined that using actions/cache to only cache a tar.gz. file with all build images and use this for all parallel tests is the fasted solution.

With Travis builds took ~30 minutes. Now each build runs for a maximum of 20 minutes (bors test and merge on master).
Bors r+ runs take about ~16/17 minutes.

### Related issue(s)
- Auto close an issue like: closes #1830

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
