### PR TITLE
Set static hostname for antispam to preserve history. 

### DIFF
--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -85,6 +85,7 @@ services:
 
   antispam:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}rspamd:${MAILU_VERSION:-{{ version }}}
+    hostname: antispam
     restart: always
     env_file: {{ env }}
     volumes:

--- a/setup/flavors/stack/docker-compose.yml
+++ b/setup/flavors/stack/docker-compose.yml
@@ -70,6 +70,7 @@ services:
 
   antispam:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}rspamd:${MAILU_VERSION:-{{ version }}}
+    hostname: antispam
     env_file: {{ env }}
     volumes:
       - "{{ root }}/filter:/var/lib/rspamd"

--- a/towncrier/newsfragments/1837.bugfix
+++ b/towncrier/newsfragments/1837.bugfix
@@ -1,0 +1,1 @@
+Antispam service now uses a static hostname. Rspamd history is only retained when the service has a fixed hostname.


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
It addresses bug #561. Rspamd stores the history in redis. The key for storing the history contains the hostname. On recreation of the docker container, the hostname changes and for this reason the rspamd history is lost. Setting a fixed hostname resolves this. Upon recreating the antispam container the history is retained. 

### Related issue(s)
- Closes #561

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
