### PR TITLE
Improve ci

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
         env:
           MAILU_BRANCH: ${{ env.BRANCH }}
         run: |
-          echo "MAILU_VERSION=${{ MAILU_BRANCH }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -295,6 +295,21 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        #For branch TESTING, we set the image tag to PR-xxxx
+      - name: Derive MAILU_VERSION for branch testing
+        if: ${{ env.BRANCH == 'testing' }}
+        shell: bash
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+      - name: Derive MAILU_VERSION for other branches than testing
+        if: ${{ env.BRANCH != 'testing' }}
+        shell: bash
+        env:
+          MAILU_BRANCH: ${{ env.BRANCH }}
+        run: |
+          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ on:
       - '[1-9].[0-9].[0-9]'
       # pre-releases, e.g. 1.8-pre1
       - 1.8-pre[0-9]
-    # test branches, e.g. test-debian
+      # test branches, e.g. test-debian
       - test-*
 
 ###############################################
@@ -39,6 +39,21 @@ jobs:
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+        #For branch TESTING, we set the image tag to PR-xxxx
+      - name: Derive MAILU_VERSION for branch testing
+        if: ${{ env.BRANCH == 'testing' }}
+        shell: bash
+        env:
+          COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
+          echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+      - name: Derive MAILU_VERSION for other branches than testing
+        if: ${{ env.BRANCH != 'testing' }}
+        shell: bash
+        env:
+          MAILU_BRANCH: ${{ env.BRANCH }}
+        run: |
+          echo "MAILU_VERSION=${{ MAILU_BRANCH }}" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -58,7 +73,7 @@ jobs:
         run: echo "$DOCKER_PW" | docker login --username $DOCKER_UN --password-stdin
       - name: Build all docker images
         env:
-          MAILU_VERSION: ${{ env.BRANCH }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: docker-compose -f tests/build.yml build
@@ -94,7 +109,7 @@ jobs:
       - name: Test core suite
         run: python tests/compose/test.py core 1
         env:
-          MAILU_VERSION: ${{ env.BRANCH }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}
           TRAVIS_BRANCH: ${{ env.BRANCH }} 
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 
@@ -127,7 +142,7 @@ jobs:
       - name: Test fetch
         run: python tests/compose/test.py fetchmail 1
         env:
-          MAILU_VERSION: ${{ env.BRANCH }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 
@@ -160,7 +175,7 @@ jobs:
       - name: Test clamvav
         run: python tests/compose/test.py filters 2
         env:
-          MAILU_VERSION: ${{ env.BRANCH }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 
@@ -193,7 +208,7 @@ jobs:
       - name: Test rainloop
         run: python tests/compose/test.py rainloop 1
         env:
-          MAILU_VERSION: ${{ env.BRANCH }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}
           TRAVIS_BRANCH: ${{ env.BRANCH }} 
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 
@@ -226,7 +241,7 @@ jobs:
       - name: Test roundcube
         run: python tests/compose/test.py roundcube 1
         env:
-          MAILU_VERSION: ${{ env.BRANCH }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}
           TRAVIS_BRANCH: ${{ env.BRANCH }} 
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 
@@ -259,7 +274,7 @@ jobs:
       - name: Test webdav
         run: python tests/compose/test.py webdav 1
         env:
-          MAILU_VERSION: ${{ env.BRANCH }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
 
@@ -300,9 +315,8 @@ jobs:
           DOCKER_PW: ${{ secrets.Docker_Password }}
           DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
           DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
-          MAILU_VERSION: ${{ env.BRANCH }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}
           TRAVIS_BRANCH: ${{ env.BRANCH }}
-          TRAVIS_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
         run: bash tests/deploy.sh
 
  # This job is watched by bors. It only complets if building,testing and deploy worked.

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -3,14 +3,5 @@
 # Skip deploy for staging branch
 [ "$TRAVIS_BRANCH" = "staging" ] && exit 0
 
-# Retag in case of `bors try`
-if [ "$TRAVIS_BRANCH" = "testing" ]; then
-    export DOCKER_ORG=$DOCKER_ORG_TESTS
-    # Commit message is like "Try #99".
-    # This sets the version tag to "pr-99"
-    export MAILU_VERSION="pr-${TRAVIS_COMMIT_MESSAGE//[!0-9]/}"
-    docker-compose -f tests/build.yml build
-fi
-
 docker login -u $DOCKER_UN -p $DOCKER_PW
 docker-compose -f tests/build.yml push


### PR DESCRIPTION
## What type of PR?

Enhancement for CI. 

## What does this PR do?

Moved logic for configuring the tag for images for testing branch (bors try) and building the images, from deploy.sh (deploy job) to the Build job. Now the images are only built once during the build job. This saves about ~10 minutes for the CI workflow for bors try. Now for all situations (bors try, bors r+ and merge with master) should take around 20 minutes.

I did not create yet another newsfragment since it is an internal enhancement.
### Related issue(s)

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
