### PR TITLE
Docs: Replace hardcoded journald logpath with systemd backend

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@ Before we can consider review and merge, please make sure the following list is 
 If an entry in not applicable, you can check it or remove it from the list.
 
 - [ ] In case of feature or enhancement: documentation updated accordingly
-- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
+- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -513,8 +513,8 @@ follow these steps:
 
   [bad-auth]
   enabled = true
+  backend = systemd
   filter = bad-auth
-  logpath = /var/log/messages
   bantime = 604800
   findtime = 300
   maxretry = 10
@@ -565,7 +565,7 @@ Restart the Fail2Ban service.
 
   sudo systemctl restart fail2ban
 
-*Issue reference:* `85`_, `116`_, `171`_, `584`_, `592`_, `1727`_.
+*Issue reference:* `85`_, `116`_, `171`_, `584`_, `592`_, `1727`_, `1857`_.
 
 Users can't change their password from webmail
 ``````````````````````````````````````````````

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -565,7 +565,7 @@ Restart the Fail2Ban service.
 
   sudo systemctl restart fail2ban
 
-*Issue reference:* `85`_, `116`_, `171`_, `584`_, `592`_, `1727`_, `1857`_.
+*Issue reference:* `85`_, `116`_, `171`_, `584`_, `592`_, `1727`_.
 
 Users can't change their password from webmail
 ``````````````````````````````````````````````

--- a/towncrier/newsfragments/1857.doc
+++ b/towncrier/newsfragments/1857.doc
@@ -1,0 +1,1 @@
+Update fail2ban documentation to use systemd backend instead of filepath for journald


### PR DESCRIPTION
The file at /var/log/messages is not universal for every
distribution. Fail2ban can access journald logs directly
by using the systemd backend.

## What type of PR?

documentation

## What does this PR do?

The path /var/log/messages does not apply for Ubuntu 20.04 for example, because of that I have looked
at alternative ways to access journald in fail2ban. The proper way seems to be to use the systemd
backend, this patch updates the documentation accordingly.

### Related issue(s)
*none*

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
