### PR TITLE
Format python, rst and yml source with pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/psf/black
+    rev: 21.6b0
+    hooks:
+    -   id: black
+        args: [--config=./pyproject.toml]
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: 'v5.9.2'  # Use the revision sha / tag you want to point at
+    hooks:
+    -   id: isort

--- a/docs/contributors/environment.rst
+++ b/docs/contributors/environment.rst
@@ -1,6 +1,21 @@
 Development environment
 =======================
 
+Development Station
+---
+
+Get the minimal tooling for development. This will setup a pre-commit
+hook to format the newly added sources. This will also install
+towncrier, in order to produce the changelog files.
+
+.. code-block:: bash
+
+  python3 -m venv <path-to-the-virtualenv>
+  source <path-to-the-virtualenv>/bin/activate
+  pip3 install -r requirements-dev.txt
+  pre-commit install
+
+
 Git
 ---
 
@@ -277,7 +292,7 @@ Merge conflicts
 Before proceeding, check the PR page in the bottom. It should not indicate a merge conflict.
 If there are merge conflicts, you have 2 options:
 
-#. Do a review "request changes" and ask the author to resolve the merge conflict. 
+#. Do a review "request changes" and ask the author to resolve the merge conflict.
 #. Solve the merge conflict yourself on Github, using the web editor.
 
 If it can't be done in the web editor, go for option 1. Unless you want to go through the trouble of

--- a/docs/contributors/guidelines.rst
+++ b/docs/contributors/guidelines.rst
@@ -188,7 +188,7 @@ Coding standards
 ````````````````
 
 All Python code should comply with PEP-8. We should review our code using
-pylint.
+pylint. We should format the code with black and isort.
 
 We should comply with architectural recommendations from the Flask
 documentation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,14 @@
     title_format = "v{version} - {project_date}"
     issue_format = "[#{issue}](https://github.com/Mailu/Mailu/issues/{issue})"
     start_string = "<!-- TOWNCRIER -->"
+
+[tool.black]
+line-length = 90
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 90

--- a/requirements-dev.py
+++ b/requirements-dev.py
@@ -1,4 +1,0 @@
-towncrier
-pre - commit
-black
-isort

--- a/requirements-dev.py
+++ b/requirements-dev.py
@@ -1,0 +1,4 @@
+towncrier
+pre - commit
+black
+isort

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+towncrier==21.3.0
+pre-commit==2.13.0
+black==21.6b0
+isort==5.9.2

--- a/towncrier/newsfragments/1839.feature
+++ b/towncrier/newsfragments/1839.feature
@@ -1,0 +1,1 @@
+Reformat python, yml and rst code with pre-commit


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

This provide a pre-commit hook to format every source the same way for each commit. The existing source have been reformated. Note that this will affect `git blame` and this commit should be hidden accordingly in a other PR.

This PR does not deal with lint which need many modification in the source, and will be addressed later

### Related issue(s)

- closes #1839

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
