### PR TITLE
fix #1861: allow colons in passwords: fix the parsing of http-basic auth headers

### DIFF
--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -63,7 +63,7 @@ def basic_authentication():
     authorization = flask.request.headers.get("Authorization")
     if authorization and authorization.startswith("Basic "):
         encoded = authorization.replace("Basic ", "")
-        user_email, password = base64.b64decode(encoded).split(b":")
+        user_email, password = base64.b64decode(encoded).split(b":", 1)
         user = models.User.query.get(user_email.decode("utf8"))
         if nginx.check_credentials(user, password.decode('utf-8'), flask.request.remote_addr, "web"):
             response = flask.Response()

--- a/towncrier/newsfragments/1861.bugfix
+++ b/towncrier/newsfragments/1861.bugfix
@@ -1,0 +1,1 @@
+Fix a bug preventing colons from being used in passwords when using radicale/webdav.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix a bug preventing colons from being used in passwords when using radicale/webdav.
Thank you to @parisni for reporting it and @ghostwheel42 for spotting it.

### Related issue(s)
- close #1861

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/guide.html#changelog) entry file.
