### PR TITLE
Remove dot in blueprint name to prevent critical flask error

### DIFF
--- a/setup/server.py
+++ b/setup/server.py
@@ -54,11 +54,11 @@ def build_app(path):
     @app.context_processor
     def app_context():
         return dict(
-            versions=os.getenv("VERSIONS","master").split(','), 
+            versions=os.getenv("VERSIONS","master").split(','),
             stable_version = os.getenv("stable_version", "master")
         )
 
-    prefix_bp = flask.Blueprint(version, __name__)
+    prefix_bp = flask.Blueprint(version.replace(".", "_"), __name__)
     prefix_bp.jinja_loader = jinja2.ChoiceLoader([
         jinja2.FileSystemLoader(os.path.join(path, "templates")),
         jinja2.FileSystemLoader(os.path.join(path, "flavors"))

--- a/towncrier/newsfragments/1874.bugfix
+++ b/towncrier/newsfragments/1874.bugfix
@@ -1,0 +1,1 @@
+Remove dot in blueprint name to prevent critical flask startup error in setup.


### PR DESCRIPTION
## What type of PR?

Bug-fix 

## What does this PR do?
Currently setup uses the version (1.7, 1.8, master) as the blueprint name for the setup flask instance. Flask introduced a breaking change that does not allow a dot in the blueprint name anymore. As a result the setup container does not start. This PR contains the bug fix for this issue.


```
stable_1       |   File "/app/server.py", line 58, in build_app
stable_1       |     prefix_bp = flask.Blueprint(version, __name__)
stable_1       |   File "/usr/local/lib/python3.9/site-packages/flask/blueprints.py", line 195, in __init__
stable_1       |     raise ValueError("'name' may not contain a dot '.' character.")
stable_1       | ValueError: 'name' may not contain a dot '.' character.
stable_1       | Traceback (most recent call last):
```

 See https://flask.palletsprojects.com/en/2.0.x/changes/
```
Show an error when a blueprint name contains a dot. The . has special meaning, it is used to separate (nested) blueprint names and the endpoint name. #4041
```

### Related issue(s)
- #1814
- Closes #1818
- Closes #1869

I will close the linked issues personally once I have made the necessary changes on the infra machine after the backported PR has been merged. 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
