### PR TITLE
Fix missing bullet points and styling in documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@
 
 import os
 
-extensions = ['sphinx.ext.imgmath', 'sphinx.ext.viewcode']
+extensions = ['sphinx.ext.imgmath', 'sphinx.ext.viewcode', 'sphinx_rtd_theme']
 templates_path = ['_templates']
 source_suffix = '.rst'
 master_doc = 'index'

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,4 @@ recommonmark
 Sphinx
 sphinx-autobuild
 sphinx-rtd-theme
+docutils==0.16


### PR DESCRIPTION
## What type of PR?
Bug-fix

## What does this PR do?
It brings back the bullet points and correct styling to the documentation.
Conf.py was missing an extension declaration.
The requirement docutils was missing. Currently Sphinx only supports docutils 0.16. 

To see the issue yourself compare
Ok: https://mailu.io/1.7/
Not Ok: https://mailu.io/1.8.

### Related issue(s)
- None

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
