### PR TITLE
fix 1884: always lookup a FQDN

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -38,7 +38,11 @@ os.environ["ANTISPAM_MILTER_ADDRESS"] = system.get_host_address_from_environment
 os.environ["LMTP_ADDRESS"] = system.get_host_address_from_environment("LMTP", "imap:2525")
 os.environ["OUTCLEAN"] = os.environ["HOSTNAMES"].split(",")[0]
 try:
-    os.environ["OUTCLEAN_ADDRESS"] = system.resolve_hostname(os.environ["OUTCLEAN"])
+    _to_lookup = os.environ["OUTCLEAN"]
+    # Ensure we lookup a FQDN: @see #1884
+    if not _to_lookup.endswith('.'):
+        _to_lookup += '.'
+    os.environ["OUTCLEAN_ADDRESS"] = system.resolve_hostname(_to_lookup)
 except:
     os.environ["OUTCLEAN_ADDRESS"] = "10.10.10.10"
 


### PR DESCRIPTION
## What type of PR?

bugfix

## What does this PR do?

Fix bug #1884. Ensure that we avoid the musl resolver bug by always looking up a FQDN

### Related issue(s)
- closes #1884