### PR TITLE
Fix 1294: ensure podop's socket is owned by postfix

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -8,12 +8,13 @@ import logging as log
 import sys
 
 from podop   import run_server
+from pwd import getpwnam
 from socrate import system, conf
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
 def start_podop():
-    os.setuid(100)
+    os.setuid(getpwnam('postfix').pw_uid)
     url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/postfix/"
     # TODO: Remove verbosity setting from Podop?
     run_server(0, "postfix", "/tmp/podop.socket", [

--- a/towncrier/newsfragments/1294.bugfix
+++ b/towncrier/newsfragments/1294.bugfix
@@ -1,0 +1,1 @@
+Ensure that the podop socket is always owned by the postfix user (wasn't the case when build using non-standard base images... typically for arm64)


### PR DESCRIPTION
## What type of PR?

bugfix

## What does this PR do?

Ensure that the podop socket is always owned by the postfix user (wasn't the case when build using non-standard base images... typically for arm64)

### Related issue(s)
- closes #1294