### PR TITLE
Docs: Limit fail2ban matches to front container

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -497,6 +497,8 @@ follow these steps:
 
   logging:
     driver: journald
+    options:
+      tag: mailu-front
 
 2. Add the /etc/fail2ban/filter.d/bad-auth.conf
 
@@ -506,6 +508,7 @@ follow these steps:
   [Definition]
   failregex = .* client login failed: .+ client:\ <HOST>
   ignoreregex =
+  journalmatch = CONTAINER_TAG=mailu-front
 
 3. Add the /etc/fail2ban/jail.d/bad-auth.conf
 


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?

Previously fail2ban matched against all journal entries. This pull request adds a tag to the logdriver and fail2ban filter documentation that limits the matches to entries from the front container

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
