### PR TITLE
save dkim key after creation

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -272,7 +272,7 @@ class Domain(Base):
             return dkim.strip_key(dkim_key).decode('utf8')
 
     def generate_dkim_key(self):
-        """ generate and activate new DKIM key """
+        """ generate new DKIM key """
         self.dkim_key = dkim.gen_key()
 
     def has_email(self, localpart):

--- a/core/admin/mailu/ui/views/domains.py
+++ b/core/admin/mailu/ui/views/domains.py
@@ -74,6 +74,8 @@ def domain_details(domain_name):
 def domain_genkeys(domain_name):
     domain = models.Domain.query.get(domain_name) or flask.abort(404)
     domain.generate_dkim_key()
+    models.db.session.add(domain)
+    models.db.session.commit()
     return flask.redirect(
         flask.url_for(".domain_details", domain_name=domain_name))
 


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

saves generated dkim key after creation vi web ui.
after the model change the domain object needs to be added and flushed via sqlalchemy.

### Related issue(s)

closes #1892
