### PR TITLE
Smarter default settings for rate limiting

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -34,8 +34,8 @@ DEFAULT_CONFIG = {
     'POSTMASTER': 'postmaster',
     'TLS_FLAVOR': 'cert',
     'INBOUND_TLS_ENFORCE': False,
-    'AUTH_RATELIMIT': '10/minute;1000/hour',
-    'AUTH_RATELIMIT_SUBNET': True,
+    'AUTH_RATELIMIT': '1000/minute;10000/hour',
+    'AUTH_RATELIMIT_SUBNET': False,
     'DISABLE_STATISTICS': False,
     # Mail settings
     'DMARC_RUA': None,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -41,7 +41,7 @@ The ``AUTH_RATELIMIT`` holds a security setting for fighting attackers that
 try to guess user passwords. The value is the limit of failed authentication attempts
 that a single IP address can perform against IMAP, POP and SMTP authentication endpoints.
 
-If ``AUTH_RATELIMIT_SUBNET`` is ``True`` (which is the default), the ``AUTH_RATELIMIT``
+If ``AUTH_RATELIMIT_SUBNET`` is ``True`` (default: False), the ``AUTH_RATELIMIT``
 rules does also apply to auth requests coming from ``SUBNET``, especially for the webmail.
 If you disable this, ensure that the rate limit on the webmail is enforced in a different
 way (e.g. roundcube plug-in), otherwise an attacker can simply bypass the limit using webmail.

--- a/setup/templates/steps/config.html
+++ b/setup/templates/steps/config.html
@@ -50,7 +50,7 @@ Or in plain english: if receivers start to classify your mail as spam, this post
 <div class="form-group">
   <label>Authentication rate limit (per source IP address)</label>
   <!--   Validates number input only -->
-  <p><input class="form-control" style="width: 7%; display: inline;" type="number" name="auth_ratelimit_pm"
+  <p><input class="form-control" style="width: 9%; display: inline;" type="number" name="auth_ratelimit_pm"
   		value="10000" required > / minute
   </p>
 </div>

--- a/setup/templates/steps/config.html
+++ b/setup/templates/steps/config.html
@@ -51,7 +51,7 @@ Or in plain english: if receivers start to classify your mail as spam, this post
   <label>Authentication rate limit (per source IP address)</label>
   <!--   Validates number input only -->
   <p><input class="form-control" style="width: 7%; display: inline;" type="number" name="auth_ratelimit_pm"
-  		value="10" required > / minute
+  		value="10000" required > / minute
   </p>
 </div>
 

--- a/towncrier/newsfragments/1867.feature
+++ b/towncrier/newsfragments/1867.feature
@@ -1,0 +1,1 @@
+Changed default value of AUTH_RATELIMIT_SUBNET to false. Increased default value of the rate limit in setup utility (AUTH_RATELIMIT) to a higher value.


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?
As discussed during the last meeting (#1582) people have issues with a too low default value for rate limiting. By default rate limiting was also enabled for the internal subnet which caused normal users to block webmail for all users after a couple of failed login attempts on webmail.

As discussed in #1867 we will make the following changes for now.
The default value for AUTH_RATELIMIT_SUBNET is set to False again. 
The default value for AUTH_RATELIMIT is increased to a higher value to prevent issues.

### Related issue(s)
- #1582
- closes #1867

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
