### PR TITLE
Prevent all form of authentication on port 25

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -82,7 +82,8 @@ def handle_authentication(headers):
         password = raw_password.encode("iso8859-1").decode("utf8")
         ip = urllib.parse.unquote(headers["Client-Ip"])
         user = models.User.query.get(user_email)
-        if check_credentials(user, password, ip, protocol):
+        port = int(urllib.parse.unquote(headers["Auth-Port"]))
+        if port != 25 or check_credentials(user, password, ip, protocol):
             return {
                 "Auth-Status": "OK",
                 "Auth-Server": server,

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -250,6 +250,7 @@ mail {
       listen 10025;
       protocol smtp;
       smtp_auth plain;
+      auth_http_header Auth-Port 10025;
     }
 
     # Default IMAP server for the webmail (no encryption, but authentication)
@@ -271,6 +272,7 @@ mail {
       {% endif %}
       protocol smtp;
       smtp_auth none;
+      auth_http_header Auth-Port 25;
     }
 
     # All other protocols are disabled if TLS is failing
@@ -283,6 +285,7 @@ mail {
       {% endif %}
       protocol imap;
       imap_auth plain;
+      auth_http_header Auth-Port 143;
     }
 
     server {
@@ -293,6 +296,7 @@ mail {
       {% endif %}
       protocol pop3;
       pop3_auth plain;
+      auth_http_header Auth-Port 110;
     }
 
     server {
@@ -303,6 +307,7 @@ mail {
       {% endif %}
       protocol smtp;
       smtp_auth plain login;
+      auth_http_header Auth-Port 587;
     }
 
     {% if TLS %}
@@ -311,6 +316,7 @@ mail {
       listen [::]:465 ssl;
       protocol smtp;
       smtp_auth plain login;
+      auth_http_header Auth-Port 465;
     }
 
     server {
@@ -318,6 +324,7 @@ mail {
       listen [::]:993 ssl;
       protocol imap;
       imap_auth plain;
+      auth_http_header Auth-Port 993;
     }
 
     server {
@@ -325,6 +332,7 @@ mail {
       listen [::]:995 ssl;
       protocol pop3;
       pop3_auth plain;
+      auth_http_header Auth-Port 995;
     }
     {% endif %}
     {% endif %}

--- a/towncrier/newsfragments/116.feature
+++ b/towncrier/newsfragments/116.feature
@@ -1,0 +1,1 @@
+Prevent all form of authentication on port 25 (well-behaved clients shouldn't attempt it anyway as AUTH isn't advertised there)


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

It prevents all form of authentication on port 25. Well-behaved clients shouldn't attempt it anyway as AUTH isn't advertised there...

### Related issue(s)
- #116

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
