### PR TITLE
Alpine has removed support for btree and hash from postfix

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -32,7 +32,7 @@ mydestination =
 relayhost = {{ RELAYHOST }}
 {% if RELAYUSER %}
 smtp_sasl_auth_enable = yes
-smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
+smtp_sasl_password_maps = lmdb:/etc/postfix/sasl_passwd
 smtp_sasl_security_options = noanonymous
 {% endif %}
 
@@ -58,7 +58,7 @@ tls_ssl_options = NO_COMPRESSION
 smtp_tls_security_level = {{ OUTBOUND_TLS_LEVEL|default('may') }}
 smtp_tls_mandatory_protocols = !SSLv2, !SSLv3
 smtp_tls_protocols =!SSLv2,!SSLv3
-smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+smtp_tls_session_cache_database = lmdb:${data_directory}/smtp_scache
 
 ###############
 # Virtual

--- a/core/postfix/conf/sasl_passwd
+++ b/core/postfix/conf/sasl_passwd
@@ -1,1 +1,2 @@
 {{ RELAYHOST }} {{ RELAYUSER }}:{{ RELAYPASSWORD }}
+

--- a/towncrier/newsfragments/1917.bugfix
+++ b/towncrier/newsfragments/1917.bugfix
@@ -1,0 +1,1 @@
+Alpine has removed support for btree and hash in postfix... please use lmdb instead


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

fix the following errors:
Aug 08 16:52:03 ocloud postfix/smtp[376]: error: unsupported dictionary type: hash
Aug 08 16:52:03 ocloud postfix/tlsmgr[377]: error: unsupported dictionary type: btree
Aug 08 16:52:03 ocloud postfix/tlsmgr[377]: warning: btree:/var/lib/postfix/smtp_scache is unavailable. unsupported dictionary type: btree

Without it Mailu is unusable with a relay.