### PR TITLE
Fix bug #1934: logs flooded with "unbound udp connect failed: Address not available for"

### DIFF
--- a/optional/unbound/Dockerfile
+++ b/optional/unbound/Dockerfile
@@ -1,4 +1,4 @@
-ARG DISTRO=alpine:3.14
+ARG DISTRO=alpine:3.12
 FROM $DISTRO
 # python3 shared with most images
 RUN apk add --no-cache \


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Revert back to alpine 1.12 for the resolver/unbound container. The official fix is at:
https://github.com/NLnetLabs/unbound/commit/08968baec1122a58bb90d8f97ad948a75f8a5d69
but alpine doesn't ship it yet:
https://pkgs.alpinelinux.org/packages?name=unbound&branch=v3.14

### Related issue(s)
- closes #1934 
