### PR TITLE
Ensure that we don't do multiple DNS lookups in the sieve script

### DIFF
--- a/core/dovecot/conf/ham.script
+++ b/core/dovecot/conf/ham.script
@@ -1,5 +1,12 @@
 #!/bin/bash
 
-tee >(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu learn_ham /dev/stdin) \
-	>(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 11 fuzzy_del /dev/stdin) \
-	| rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 13 fuzzy_add /dev/stdin
+RSPAMD_HOST="$(getent hosts {{ ANTISPAM_WEBUI_ADDRESS }})"
+if [[ $? -ne 0 ]]
+then
+	echo "Failed to lookup {{ ANTISPAM_WEBUI_ADDRESS }}" >&2
+	exit 1
+fi
+
+tee >(rspamc -h $RSPAMD_HOST -P mailu learn_ham /dev/stdin) \
+	>(rspamc -h $RSPAMD_HOST -P mailu -f 11 fuzzy_del /dev/stdin) \
+	| rspamc -h $RSPAMD_HOST -P mailu -f 13 fuzzy_add /dev/stdin

--- a/core/dovecot/conf/ham.script
+++ b/core/dovecot/conf/ham.script
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RSPAMD_HOST="$(getent hosts {{ ANTISPAM_WEBUI_ADDRESS }})"
+RSPAMD_HOST="$(getent hosts {{ ANTISPAM_WEBUI_ADDRESS }}|cut -d\  -f1)"
 if [[ $? -ne 0 ]]
 then
 	echo "Failed to lookup {{ ANTISPAM_WEBUI_ADDRESS }}" >&2

--- a/core/dovecot/conf/spam.script
+++ b/core/dovecot/conf/spam.script
@@ -1,5 +1,13 @@
 #!/bin/bash
 
-tee >(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu learn_spam /dev/stdin) \
-    >(rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 13 fuzzy_del /dev/stdin) \
-    | rspamc -h {{ ANTISPAM_WEBUI_ADDRESS }} -P mailu -f 11 fuzzy_add /dev/stdin
+RSPAMD_HOST="$(getent hosts {{ ANTISPAM_WEBUI_ADDRESS }})"
+if [[ $? -ne 0 ]]
+then
+	echo "Failed to lookup {{ ANTISPAM_WEBUI_ADDRESS }}" >&2
+	exit 1
+fi
+
+
+tee >(rspamc -h $RSPAMD_HOST -P mailu learn_spam /dev/stdin) \
+    >(rspamc -h $RSPAMD_HOST -P mailu -f 13 fuzzy_del /dev/stdin) \
+    | rspamc -h $RSPAMD_HOST -P mailu -f 11 fuzzy_add /dev/stdin

--- a/core/dovecot/conf/spam.script
+++ b/core/dovecot/conf/spam.script
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RSPAMD_HOST="$(getent hosts {{ ANTISPAM_WEBUI_ADDRESS }})"
+RSPAMD_HOST="$(getent hosts {{ ANTISPAM_WEBUI_ADDRESS }}|cut -d\  -f1)"
 if [[ $? -ne 0 ]]
 then
 	echo "Failed to lookup {{ ANTISPAM_WEBUI_ADDRESS }}" >&2


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

It ensures that DNS lookups don't introduce inconsistent state. We may want to go further and actually check the return codes of rspamc too.

I haven't tested it but it should work.

### Related issue(s)
- #1938

