### PR TITLE
Fix a bug whereby adding new HOSTNAMEs won't necessarily lead to certificates being renewed.

### DIFF
--- a/core/nginx/letsencrypt.py
+++ b/core/nginx/letsencrypt.py
@@ -13,6 +13,7 @@ command = [
     "--cert-name", "mailu",
     "--preferred-challenges", "http", "--http-01-port", "8008",
     "--keep-until-expiring",
+    "--renew-with-new-domains",
     "--config-dir", "/certs/letsencrypt",
     "--post-hook", "/config.py"
 ]
@@ -26,6 +27,7 @@ command2 = [
     "--preferred-challenges", "http", "--http-01-port", "8008",
     "--keep-until-expiring",
     "--key-type", "ecdsa",
+    "--renew-with-new-domains",
     "--config-dir", "/certs/letsencrypt",
     "--post-hook", "/config.py"
 ]


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix a bug whereby adding new HOSTNAMEs won't necessarily lead to certificates being renewed.

certbot's defaut behaviour has changed when --renew-with-new-domains was introduced

### Related issue(s)
- close #1270