### PR TITLE
BugFix 1952 - use punycode encoding in HTTP headers for webmail/radicale

### DIFF
--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -67,7 +67,7 @@ def basic_authentication():
         user = models.User.query.get(user_email.decode("utf8"))
         if nginx.check_credentials(user, password.decode('utf-8'), flask.request.remote_addr, "web"):
             response = flask.Response()
-            response.headers["X-User"] = user.email
+            response.headers["X-User"] = models.IdnaEmail.process_bind_param(flask_login, user.email, "")
             return response
     response = flask.Response(status=401)
     response.headers["WWW-Authenticate"] = 'Basic realm="Login Required"'

--- a/towncrier/newsfragments/1952.bugfix
+++ b/towncrier/newsfragments/1952.bugfix
@@ -1,0 +1,3 @@
+Webmail and Radicale (webdav) were not useable with domains with special characters such as umlauts.
+Webmail and radicale now use punycode for logging in.
+Punycode was not used in the HTTP headers. This resulted in illegal non-ASCII HTTP headers.


### PR DESCRIPTION
## What type of PR?

Bug fix

## What does this PR do?

Fixes a bug introduced by the SSO implementation and an already existing bug for radicale.
In auth.py we did not use punycode (ACE) encoding for the domain part of an email. 
Since we pass the user name in the HTTP header to webmail/radicale, we would sometime pass non-ascii. E.g. user@exämple.io.
This is illegal. HTTP headers may only contain ASCII. The domain part of the user name therefore now uses punycode encoding.

I tested that I can log in with the form user@exämple.io and user@xn--exmple-cua.io for
- admin
- roundcube (also tested sending emails of course)
- rainloop (also tested sending emails of course)
- radicale (webdav)
- thunderbird - sending/receiving emails and accessing/modifying the webdav calendar added in radicale.
  - for the calendar you can use the normal and punnycode notation
  - for email you can only use punnycode. This is a limitation of thunderbird. It does not accept email addresses with non-ascii in the domain part of an email address.

### Related issue(s)
- closes  #1952 

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [n/a] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
