### PR TITLE
Ensure that we don't trust client headers

### DIFF
--- a/core/nginx/conf/proxy.conf
+++ b/core/nginx/conf/proxy.conf
@@ -1,7 +1,12 @@
 # Default proxy setup
 proxy_set_header Host $http_host;
 proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header True-Client-IP $remote_addr;
 proxy_set_header Forwarded "";
-proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
+{% if REAL_IP_HEADER and REAL_IP_FROM %}
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+{% else %}
+proxy_set_header X-Forwarded-For $remote_addr;
+{% endif %}
 proxy_http_version 1.1;

--- a/core/nginx/conf/proxy.conf
+++ b/core/nginx/conf/proxy.conf
@@ -1,6 +1,7 @@
 # Default proxy setup
 proxy_set_header Host $http_host;
 proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header Forwarded "";
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
 proxy_http_version 1.1;

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -169,6 +169,7 @@ The ``LETSENCRYPT_SHORTCHAIN`` (default: False) setting controls whether we send
 
 .. _`android handsets older than 7.1.1`: https://community.letsencrypt.org/t/production-chain-changes/150739
 
+The ``REAL_IP_HEADER`` (default: unset) and ``REAL_IP_FROM`` (default: unset) settings controls whether HTTP headers such as ``X-Forwarded-For`` or ``X-Real-IP`` should be trusted. The former should be the name of the HTTP header to extract the client IP address from and the later a comma separated list of IP addresses designing which proxies to trust. If you are using Mailu behind a reverse proxy, you should set both. Setting the former without the later introduces a security vulnerability allowing a potential attacker to spoof his source address.
 
 Antivirus settings
 ------------------

--- a/towncrier/newsfragments/1960.bugfix
+++ b/towncrier/newsfragments/1960.bugfix
@@ -1,0 +1,1 @@
+Ensure that we do not trust the source-ip address set in headers if REAL_IP_HEADER isn't set. If you are using Mailu behind a reverse proxy, please ensure that you do read the documentation.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Document how REAL_IP_FROM and REAL_IP_HEADER should be used. Ensure that we strip True-Client-IP and X-Forwarded-For if neither are set.

We should also update the documentation on reverse-proxies... but that's #1958

### Related issue(s)
- #1958

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
