### PR TITLE
fix 1789: ensure that nginx resolves ipv4 addresses

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -18,7 +18,7 @@ http {
     keepalive_timeout  65;
     server_tokens off;
     absolute_redirect off;
-    resolver {{ RESOLVER }} valid=30s;
+    resolver {{ RESOLVER }} ipv6=off valid=30s;
 
     {% if REAL_IP_HEADER %}
     real_ip_header {{ REAL_IP_HEADER }};
@@ -233,7 +233,7 @@ mail {
     server_name {{ HOSTNAMES.split(",")[0] }};
     auth_http http://127.0.0.1:8000/auth/email;
     proxy_pass_error_message on;
-    resolver {{ RESOLVER }} valid=30s;
+    resolver {{ RESOLVER }} ipv6=off valid=30s;
 
     {% if TLS and not TLS_ERROR %}
     include /etc/nginx/tls.conf;


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

This fixes ipv6 enabled setup by disabling it. If you were using SUBNET6 in your configuration, odds are it's broken since gunicorn isn't bound on an on an ipv6 enabled socket.

Should we backport this?

### Related issue(s)
- close #1789
- close #1802
