### PR TITLE
handle DEFER_ON_TLS_ERROR as bool

### DIFF
--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -20,7 +20,6 @@ RUN apk add --no-cache postfix postfix-pcre cyrus-sasl-login
 
 COPY conf /conf
 COPY start.py /start.py
-COPY mta-sts-daemon.yml /etc/
 
 EXPOSE 25/tcp 10025/tcp
 VOLUME ["/queue"]

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -59,7 +59,7 @@ tls_ssl_options = NO_COMPRESSION, NO_TICKET
 smtp_tls_mandatory_protocols = !SSLv2, !SSLv3
 smtp_tls_protocols =!SSLv2,!SSLv3
 smtp_tls_security_level = {{ OUTBOUND_TLS_LEVEL|default('dane') }}
-smtp_tls_dane_insecure_mx_policy = {% if DEFER_ON_TLS_ERROR == 'false' %}may{% else %}dane{% endif %}
+smtp_tls_dane_insecure_mx_policy = {{ 'dane' if DEFER_ON_TLS_ERROR else 'may' }}
 smtp_tls_policy_maps=lmdb:/etc/postfix/tls_policy.map, ${podop}dane, socketmap:unix:/tmp/mta-sts.socket:postfix
 smtp_tls_CApath = /etc/ssl/certs
 smtp_tls_session_cache_database = lmdb:/dev/shm/postfix/smtp_scache

--- a/core/postfix/conf/mta-sts-daemon.yml
+++ b/core/postfix/conf/mta-sts-daemon.yml
@@ -6,5 +6,5 @@ cache:
   options:
     cache_size: 10000
 default_zone:
-  strict_testing: {{ DEFER_ON_TLS_ERROR |default('true') }}
+  strict_testing: {{ 'true' if DEFER_ON_TLS_ERROR else 'false' }}
   timeout: 4

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -76,9 +76,9 @@ for map_file in glob.glob("/overrides/*.map"):
     os.remove(destination)
 
 if os.path.exists("/overrides/mta-sts-daemon.yml"):
-	conf.jinja("/overrides/mta-sts-daemon.yml", os.environ, "/etc/mta-sts-daemon.yml")
+    shutil.copyfile("/overrides/mta-sts-daemon.yml", "/etc/mta-sts-daemon.yml")
 else:
-	conf.jinja("/conf/mta-sts-daemon.yml", os.environ, "/etc/mta-sts-daemon.yml")
+    conf.jinja("/conf/mta-sts-daemon.yml", os.environ, "/etc/mta-sts-daemon.yml")
 
 if not os.path.exists("/etc/postfix/tls_policy.map.lmdb"):
     open("/etc/postfix/tls_policy.map", "a").close()

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -76,8 +76,9 @@ for map_file in glob.glob("/overrides/*.map"):
     os.remove(destination)
 
 if os.path.exists("/overrides/mta-sts-daemon.yml"):
-    shutil.copyfile("/overrides/mta-sts-daemon.yml", "/etc/mta-sts-daemon.yml")
-conf.jinja("/etc/mta-sts-daemon.yml", os.environ, "/etc/mta-sts-daemon.yml")
+	conf.jinja("/overrides/mta-sts-daemon.yml", os.environ, "/etc/mta-sts-daemon.yml")
+else:
+	conf.jinja("/conf/mta-sts-daemon.yml", os.environ, "/etc/mta-sts-daemon.yml")
 
 if not os.path.exists("/etc/postfix/tls_policy.map.lmdb"):
     open("/etc/postfix/tls_policy.map", "a").close()


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

DEFER_ON_TLS_ERROR is a bool and not a string: fixed jinja2 templates
move mta-sts-daemon.yml to core/postfix/conf

### Related issue(s)

closes #1973

## Prerequistes
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
