### PR TITLE
Replace traceback with error message when creating initial admin user

### DIFF
--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -48,44 +48,45 @@ def advertise():
 @click.argument('localpart')
 @click.argument('domain_name')
 @click.argument('password')
-@click.option('-m', '--mode')
+@click.option('-m', '--mode', default='create')
 @with_appcontext
-def admin(localpart, domain_name, password, mode='create'):
+def admin(localpart, domain_name, password, mode):
     """ Create an admin user
         'mode' can be:
-            - 'create' (default) Will try to create user and will raise an exception if present
+            - 'create': (default) create user. it's an error if user already exists
             - 'ifmissing': if user exists, nothing happens, else it will be created
             - 'update': user is created or, if it exists, its password gets updated
     """
+
+    if not mode in ('create', 'update', 'ifmissing'):
+        raise click.ClickException(f'invalid mode: {mode!r}')
+
     domain = models.Domain.query.get(domain_name)
     if not domain:
         domain = models.Domain(name=domain_name)
         db.session.add(domain)
 
-    user = None
-    if mode == 'ifmissing' or mode == 'update':
-        email = f'{localpart}@{domain_name}'
-        user = models.User.query.get(email)
-
-        if user and mode == 'ifmissing':
-            print('user %s exists, not updating' % email)
+    email = f'{localpart}@{domain_name}'
+    if user := models.User.query.get(email):
+        if mode == 'ifmissing':
+            print(f'user {email!r} exists, not updating')
             return
-
-    if not user:
+        elif mode == 'update':
+            user.set_password(password)
+            db.session.commit()
+            print("updated admin password")
+        else:
+            raise click.ClickException(f'user {email!r} exists, not created')
+    else:
         user = models.User(
             localpart=localpart,
             domain=domain,
             global_admin=True
         )
-        user.set_password(password)
         db.session.add(user)
+        user.set_password(password)
         db.session.commit()
         print("created admin user")
-    elif mode == 'update':
-        user.set_password(password)
-        db.session.commit()
-        print("updated admin password")
-
 
 
 @mailu.command()

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -48,14 +48,13 @@ def advertise():
 @click.argument('localpart')
 @click.argument('domain_name')
 @click.argument('password')
-@click.option('-m', '--mode', default='create')
+@click.option('-m', '--mode', default='create', metavar='MODE', help='''\b'create' (default): create user. it's an error if user already exists
+'ifmissing': only update password if user is missing
+'update': create user or update password if user exists
+''')
 @with_appcontext
 def admin(localpart, domain_name, password, mode):
     """ Create an admin user
-        'mode' can be:
-            - 'create': (default) create user. it's an error if user already exists
-            - 'ifmissing': if user exists, nothing happens, else it will be created
-            - 'update': user is created or, if it exists, its password gets updated
     """
 
     if not mode in ('create', 'update', 'ifmissing'):


### PR DESCRIPTION
## What type of PR?

small enhancement

## What does this PR do?

when creating the admin user via cli a traceback is shown when this user is already present in the database.
This is confusing users. I've replaced the traceback with an error message.

### Related issue(s)

#1921

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
