### PR TITLE
re-enable mod_rewrite in roundcube

### DIFF
--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -33,13 +33,17 @@ RUN apt-get update && apt-get install -y \
  && mv roundcubemail-* html \
  && mv carddav html/plugins/ \
  && cd html \
- && rm -rf CHANGELOG INSTALL LICENSE README.md UPGRADING composer.json-dist installer \
+ && rm -rf CHANGELOG INSTALL LICENSE README.md UPGRADING composer.json-dist installer composer.* \
  && sed -i 's,mod_php5.c,mod_php7.c,g' .htaccess \
  && sed -i 's,^php_value.*post_max_size,#&,g' .htaccess \
  && sed -i 's,^php_value.*upload_max_filesize,#&,g' .htaccess \
- && chown -R www-data: logs temp \
+ && ln -sf index.php /var/www/html/sso.php \
+ && chown -R root:root . \
+ && touch logs/errors.log \
+ && chown -R www-data:www-data logs temp \
+ && chmod -R a+rX . \
  && rm -rf /var/lib/apt/lists \
- && a2enmod deflate expires headers
+ && a2enmod rewrite deflate expires headers
 
 COPY php.ini /php.ini
 COPY config.inc.php /var/www/html/config/

--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -34,11 +34,7 @@ else:
 conf.jinja("/php.ini", os.environ, "/usr/local/etc/php/conf.d/roundcube.ini")
 
 # Create dirs, setup permissions
-os.system("mkdir -p /data/gpg /var/www/html/logs")
-os.system("touch /var/www/html/logs/errors.log")
-os.system("chown -R www-data:www-data /var/www/html/logs")
-os.system("chmod -R a+rX /var/www/html/")
-os.system("ln -sf /var/www/html/index.php /var/www/html/sso.php")
+os.system("mkdir -p /data/gpg")
 
 try:
     print("Initializing database")


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

re-enabled mod_rewrite to make use of safeguards in .htaccess
fixed permissions of /var/www/html to make sso.php symlink work with htaccess safeguards enabled
moved chown/mkdir/symlink from start.py to Dockerfile

### Related issue(s)

undo of #1990

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
