### PR TITLE
Modified trusted authors mergify config as disccused in #1932

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,7 +27,7 @@ pull_request_rules:
 
   - name: Trusted author and 1 approved review; trigger bors r+
     conditions:
-      - author~=^(mergify|kaiyou|muhlemmer|mildred|HorayNarea|hoellen|ofthesun9|Nebukadneza|micw|lub|Diman0|3-w-c|decentral1se|ghostwheel42|nextgens|parisni)$
+      - author~=^(mergify|kaiyou|muhlemmer|mildred|HorayNarea|hoellen|ofthesun9|Nebukadneza|micw|lub|Diman0|ghostwheel42|nextgens)$
       - -title~=(WIP|wip)
       - -label~=^(status/wip|status/blocked|review/need2)$
       - "#approved-reviews-by>=1"


### PR DESCRIPTION
## What type of PR?

organisational clean-up

## What does this PR do?
As discussed in #1932, we have to do some tidying up. People who have not contributed a lot yet, should not be made a trusted author. After multiple OK PR's we can still add these people again to the trusted author's list. This change only means that PR's submitted by these persons need 2 reviews instead of 1.

### Related issue(s)
- #1932
