### PR TITLE
Make logs more quiet

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -13,7 +13,6 @@ http {
     # Standard HTTP configuration with slight hardening
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
-    access_log /dev/stdout;
     sendfile on;
     keepalive_timeout 65;
     server_tokens off;
@@ -37,6 +36,13 @@ http {
       default off;
       ~*\.(ico|css|js|gif|jpeg|jpg|png|woff2?|ttf|otf|svg|tiff|eot|webp)$ 97d;
     }
+
+    map $request_uri $loggable {
+      /health 0;
+      /auth/email 0;
+      default 1;
+    }
+    access_log /dev/stdout combined if=$loggable;
 
     # compression
     gzip on;

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -1,7 +1,7 @@
 # Basic configuration
 user nginx;
 worker_processes auto;
-error_log /dev/stderr info;
+error_log /dev/stderr notice;
 pid /var/run/nginx.pid;
 load_module "modules/ngx_mail_module.so";
 
@@ -252,6 +252,7 @@ mail {
     auth_http http://127.0.0.1:8000/auth/email;
     proxy_pass_error_message on;
     resolver {{ RESOLVER }} ipv6=off valid=30s;
+    error_log /dev/stderr info;
 
     {% if TLS and not TLS_ERROR %}
     include /etc/nginx/tls.conf;


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

It silences various useless log messages in front, specifically:
```
Oct 30 03:11:04 instance-20210109-1612 docker-front[1963]: 127.0.0.1 - - [30/Oct/2021:03:11:04 +0000] "GET /health HTTP/1.1" 301 162 "-" "curl/7.78.0"
Oct 30 03:11:04 instance-20210109-1612 docker-front[1963]: 127.0.0.1 - - [30/Oct/2021:03:11:04 +0000] "GET /health HTTP/2.0" 204 0 "-" "curl/7.78.0"
Oct 30 03:11:04 instance-20210109-1612 docker-front[1963]: 2021/10/30 03:11:04 [info] 476302#476302: *2622679 client 127.0.0.1 closed keepalive connection
Oct 30 03:13:02 instance-20210109-1612 docker-front[1963]: 127.0.0.1 - - [30/Oct/2021:03:13:02 +0000] "GET /auth/email HTTP/1.0" 200 0 "-" "-"
```

@micw has requested it for k8s