### PR TITLE
The Rate-limiter should run after the deny

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -78,12 +78,6 @@ def handle_authentication(headers):
     # Authenticated user
     elif method == "plain":
         is_valid_user = False
-        if headers["Auth-Port"] == '25':
-            return {
-                "Auth-Status": "AUTH not supported",
-                "Auth-Error-Code": "502 5.5.1",
-                "Auth-Wait": 0
-            }
         # According to RFC2616 section 3.7.1 and PEP 3333, HTTP headers should
         # be ASCII and are generally considered ISO8859-1. However when passing
         # the password, nginx does not transcode the input UTF string, thus

--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -11,6 +11,13 @@ def nginx_authentication():
     """ Main authentication endpoint for Nginx email server
     """
     client_ip = flask.request.headers["Client-Ip"]
+    headers = flask.request.headers
+    if headers["Auth-Port"] == '25' and headers['Auth-Method'] == 'plain':
+        response = flask.Response()
+        response.headers['Auth-Status'] = 'AUTH not supported'
+        response.headers['Auth-Error-Code'] = '502 5.5.1'
+        utils.limiter.rate_limit_ip(client_ip)
+        return response
     if utils.limiter.should_rate_limit_ip(client_ip):
         status, code = nginx.get_status(flask.request.headers['Auth-Protocol'], 'ratelimit')
         response = flask.Response()


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

It ensures that we *always* prevent login attempts on port 25; without it clients eventually get a temporary error instead of a permanent one.