### PR TITLE
Fix RELAYNETS

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -17,7 +17,7 @@ queue_directory = /queue
 message_size_limit = {{ MESSAGE_SIZE_LIMIT }}
 
 # Relayed networks
-mynetworks = 127.0.0.1/32 [::1]/128 {{ SUBNET }} {{ RELAYNETS }}
+mynetworks = 127.0.0.1/32 [::1]/128 {{ SUBNET }} {{ RELAYNETS.split(",") }}
 
 # Empty alias list to override the configuration variable and disable NIS
 alias_maps =

--- a/core/rspamd/conf/options.inc
+++ b/core/rspamd/conf/options.inc
@@ -1,0 +1,3 @@
+{% if RELAYNETS %}
+local_networks = [{{ RELAYNETS }}];
+{% endif %}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -74,12 +74,13 @@ meant to fight outbound spam in case of compromised or malicious account on the
 server.
 
 The ``RELAYNETS`` (default: unset) is a comma delimited list of network addresses
-for which mail is relayed for, with no authentication required. This should be
-used with great care.
+for which mail is relayed for with no authentication required. This should be
+used with great care as misconfigurations may turn your Mailu instance into an
+open-relay!
 
-The ``RELAYHOST`` is an optional address of a mail server to use as a smarthost for
-all outgoing mail in following format: ``[HOST]:PORT``.
-``RELAYUSER`` and ``RELAYPASSWORD`` can be used when authentication is required.
+The ``RELAYHOST`` is an optional address to use as a smarthost for all outgoing
+mail in following format: ``[HOST]:PORT``. ``RELAYUSER`` and ``RELAYPASSWORD``
+can be used when authentication is required.
 
 By default postfix uses "opportunistic TLS" for outbound mail. This can be changed
 by setting ``OUTBOUND_TLS_LEVEL`` to ``encrypt`` or ``secure``. This setting is

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -73,14 +73,13 @@ The ``MESSAGE_RATELIMIT`` is the limit of messages a single user can send. This 
 meant to fight outbound spam in case of compromised or malicious account on the
 server.
 
-The ``RELAYNETS`` are network addresses for which mail is relayed for free with
-no authentication required. This should be used with great care. If you want other
-Docker services' outbound mail to be relayed, you can set this to ``172.16.0.0/12``
-to include **all** Docker networks. The default is to leave this empty.
+The ``RELAYNETS`` (default: unset) is a comma delimited list of network addresses
+for which mail is relayed for, with no authentication required. This should be
+used with great care.
 
-The ``RELAYHOST`` is an optional address of a mail server relaying all outgoing
-mail in following format: ``[HOST]:PORT``.
-``RELAYUSER`` and ``RELAYPASSWORD`` can be used when authentication is needed.
+The ``RELAYHOST`` is an optional address of a mail server to use as a smarthost for
+all outgoing mail in following format: ``[HOST]:PORT``.
+``RELAYUSER`` and ``RELAYPASSWORD`` can be used when authentication is required.
 
 By default postfix uses "opportunistic TLS" for outbound mail. This can be changed
 by setting ``OUTBOUND_TLS_LEVEL`` to ``encrypt`` or ``secure``. This setting is

--- a/towncrier/newsfragments/360.bugfix
+++ b/towncrier/newsfragments/360.bugfix
@@ -1,0 +1,1 @@
+RELAYNETS should be a comma separated list of networks


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

RELAYNETS should be comma separated like everything else; rspamd should also be aware of what is considered "trusted".

I am not sure whether ```local_networks``` is the right configuration option for it though

- close #360