### PR TITLE
Misc

### DIFF
--- a/core/rspamd/conf/settings.conf
+++ b/core/rspamd/conf/settings.conf
@@ -1,0 +1,4 @@
+apply {
+	# see https://github.com/Mailu/Mailu/issues/1705
+	RCVD_NO_TLS_LAST = 0;
+}

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -90,7 +90,6 @@ services:
     env_file: {{ env }}
     volumes:
       - "{{ root }}/filter:/var/lib/rspamd"
-      - "{{ root }}/dkim:/dkim:ro"
       - "{{ root }}/overrides/rspamd:/etc/rspamd/override.d:ro"
     depends_on:
       - front

--- a/setup/flavors/stack/docker-compose.yml
+++ b/setup/flavors/stack/docker-compose.yml
@@ -74,7 +74,6 @@ services:
     env_file: {{ env }}
     volumes:
       - "{{ root }}/filter:/var/lib/rspamd"
-      - "{{ root }}/dkim:/dkim:ro"
       - "{{ root }}/overrides/rspamd:/etc/rspamd/override.d:ro"
     deploy:
       replicas: 1

--- a/towncrier/newsfragments/1705.enhancement
+++ b/towncrier/newsfragments/1705.enhancement
@@ -1,0 +1,1 @@
+Ensure that RCVD_NO_TLS_LAST doesn't add to the spam score (as TLS usage can't be determined)


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

- Remove /dkim from the rspamd container in setup as that's not necessary anymore;
@micw helms-chart should probably be updated too. There is an open question on whether we want to keep it on admin. We can either have DKIM keys auto-imported to the DB on upgrade (if they exist) or provide a facility to manually import them (so that the directory can be removed altogether). Having the former doesn't allow for removing /dkim from admin. @Diman0 any opinion on what we want for 1.9?

- Remove spam points from RCVD_NO_TLS_LAST as we don't detect whether TLS was used or not.

### Related issue(s)
- close #1705

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
