### PR TITLE
Vault/rspamd: don't return any key for relayed domains

### DIFF
--- a/core/admin/mailu/internal/views/rspamd.py
+++ b/core/admin/mailu/internal/views/rspamd.py
@@ -14,22 +14,14 @@ def vault_error(*messages, status=404):
 
 @internal.route("/rspamd/vault/v1/dkim/<domain_name>", methods=['GET'])
 def rspamd_dkim_key(domain_name):
-    models.Relay.query.get(domain_name) and return flask.jsonify({
-        'data': {
-            'selectors': []
-        }
-    })
-    domain = models.Domain.query.get(domain_name) or flask.abort(vault_error('unknown domain'))
-    key = domain.dkim_key or flask.abort(vault_error('no dkim key', status=400))
-    return flask.jsonify({
-        'data': {
-            'selectors': [
+    selectors = []
+    if domain := models.Domain.query.get(domain_name):
+        if key := domain.dkim_key:
+            selectors.append(
                 {
                     'domain'  : domain.name,
                     'key'     : key.decode('utf8'),
                     'selector': flask.current_app.config.get('DKIM_SELECTOR', 'dkim'),
                 }
-            ]
-        }
-    })
-
+            )
+    return flask.jsonify({'data': {'selectors': selectors}})

--- a/core/admin/mailu/internal/views/rspamd.py
+++ b/core/admin/mailu/internal/views/rspamd.py
@@ -14,6 +14,11 @@ def vault_error(*messages, status=404):
 
 @internal.route("/rspamd/vault/v1/dkim/<domain_name>", methods=['GET'])
 def rspamd_dkim_key(domain_name):
+    models.Relay.query.get(domain_name) and return flask.jsonify({
+        'data': {
+            'selectors': []
+        }
+    })
     domain = models.Domain.query.get(domain_name) or flask.abort(vault_error('unknown domain'))
     key = domain.dkim_key or flask.abort(vault_error('no dkim key', status=400))
     return flask.jsonify({

--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -38,7 +38,7 @@ def login():
             flask.session.regenerate()
             flask_login.login_user(user)
             response = flask.redirect(destination)
-            response.set_cookie('rate_limit', utils.limiter.device_cookie(username), max_age=31536000, path=flask.url_for('sso.login'), secure=True, httponly=True)
+            response.set_cookie('rate_limit', utils.limiter.device_cookie(username), max_age=31536000, path=flask.url_for('sso.login'), secure=app.config['SESSION_COOKIE_SECURE'], httponly=True)
             flask.current_app.logger.info(f'Login succeeded for {username} from {client_ip}.')
             return response
         else:

--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -38,7 +38,7 @@ def login():
             flask.session.regenerate()
             flask_login.login_user(user)
             response = flask.redirect(destination)
-            response.set_cookie('rate_limit', utils.limiter.device_cookie(username), max_age=31536000, path=flask.url_for('sso.login'))
+            response.set_cookie('rate_limit', utils.limiter.device_cookie(username), max_age=31536000, path=flask.url_for('sso.login'), secure=True, httponly=True)
             flask.current_app.logger.info(f'Login succeeded for {username} from {client_ip}.')
             return response
         else:


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR 

Don't return any key for relayed domains. We may want to revisit this (ARC signing)... but in the meantime it saves from a scary message in rspamd.
    
```signing failure: cannot request data from the vault url: /internal/rspamd/vault/v1/dkim/ ...```
