### PR TITLE
Do not call .split() on RELAYNETS if not specified

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -17,7 +17,7 @@ queue_directory = /queue
 message_size_limit = {{ MESSAGE_SIZE_LIMIT }}
 
 # Relayed networks
-mynetworks = 127.0.0.1/32 [::1]/128 {{ SUBNET }} {{ RELAYNETS.split(",") | join(' ') }}
+mynetworks = 127.0.0.1/32 [::1]/128 {{ SUBNET }}  {% if RELAYNETS %}{{ RELAYNETS.split(",") | join(' ') }}{% endif %}
 
 # Empty alias list to override the configuration variable and disable NIS
 alias_maps =


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

The call to {{ RELAYNETS.split(",") | join(' ') }} when starting postfix breaks if RELAYNETS has not been specified using the environmental variables.

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.
