### PR TITLE
fix for issue 1223 (fetchmail persistence idfile)

### DIFF
--- a/optional/fetchmail/Dockerfile
+++ b/optional/fetchmail/Dockerfile
@@ -13,10 +13,7 @@ RUN apk add --no-cache fetchmail ca-certificates openssl \
  && pip3 install requests
 
 RUN mkdir -p /data
-RUN chown fetchmail:fetchmail /data
 
 COPY fetchmail.py /fetchmail.py
-
-USER fetchmail
 
 CMD ["/fetchmail.py"]

--- a/optional/fetchmail/Dockerfile
+++ b/optional/fetchmail/Dockerfile
@@ -12,6 +12,9 @@ RUN apk add --no-cache \
 RUN apk add --no-cache fetchmail ca-certificates openssl \
  && pip3 install requests
 
+RUN mkdir -p /data
+RUN chown fetchmail:fetchmail /data
+
 COPY fetchmail.py /fetchmail.py
 
 USER fetchmail

--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -13,6 +13,7 @@ import traceback
 
 FETCHMAIL = """
 fetchmail -N \
+    --idfile /data/.fetchids \
     --sslcertck --sslcertpath /etc/ssl/certs \
     -f {}
 """

--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -13,7 +13,7 @@ import traceback
 
 FETCHMAIL = """
 fetchmail -N \
-    --idfile /data/.fetchids \
+    --idfile /data/.fetchids --uidl \
     --sslcertck --sslcertpath /etc/ssl/certs \
     -f {}
 """

--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -13,7 +13,7 @@ import traceback
 
 FETCHMAIL = """
 fetchmail -N \
-    --idfile /data/.fetchids --uidl \
+    --idfile /data/fetchids --uidl \
     --sslcertck --sslcertpath /etc/ssl/certs \
     -f {}
 """

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -129,6 +129,8 @@ services:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}fetchmail:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
+    volumes:
+      - "{{ root }}/fetchmail:/data"
     {% if resolver_enabled %}
     depends_on:
       - resolver

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -130,7 +130,7 @@ services:
     restart: always
     env_file: {{ env }}
     volumes:
-      - "{{ root }}/fetchmail:/data"
+      - "{{ root }}/data/fetchmail:/data"
     {% if resolver_enabled %}
     depends_on:
       - resolver

--- a/setup/flavors/stack/docker-compose.yml
+++ b/setup/flavors/stack/docker-compose.yml
@@ -110,7 +110,7 @@ services:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}fetchmail:${MAILU_VERSION:-{{ version }}}
     env_file: {{ env }}
     volumes:
-      - "{{ root }}/fetchmail:/data"
+      - "{{ root }}/data/fetchmail:/data"
     deploy:
       replicas: 1
     healthcheck:

--- a/setup/flavors/stack/docker-compose.yml
+++ b/setup/flavors/stack/docker-compose.yml
@@ -110,7 +110,7 @@ services:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}fetchmail:${MAILU_VERSION:-{{ version }}}
     env_file: {{ env }}
     volumes:
-      - "{{ root }}/data:/data"
+      - "{{ root }}/fetchmail:/data"
     deploy:
       replicas: 1
     healthcheck:

--- a/towncrier/newsfragments/1223.bugfix
+++ b/towncrier/newsfragments/1223.bugfix
@@ -1,0 +1,4 @@
+Fixed fetchmail losing track of fetched emails upon container recreation. 
+The relevant fetchmail files are now retained in the /data folder (in the fetchmail image).
+See the docker-compose.yml file for the relevant volume mapping.
+If you already had your own mapping, you must double check the volume mapping and take action.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
It introduces a new data folder (/mailu/fetchmail) that will hold the idfile. The file that is used by fetchmail to keep track of what messages where retrieved. Recreating the fetchmail container does not result in all messages being retrieved again. It also configurs fetchmail to actually create this file (--uidl).

It changes fetchmail to run as root. For now this is required, because the mailu data folder (/mailu) is owned by root. In the future we must change all images at the same time, to run without root and use a mailu folder that is not owned by root. That is out of scope for this PR. 

### Related issue(s)
- closes #1223

## Prerequisites
- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
