### PR TITLE
Implement versioning for CI/CD workflow.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,10 +9,6 @@ on:
       - '1.7'
       - '1.8'
       - master
-      # version tags, e.g. 1.7.1
-      - '[1-9].[0-9].[0-9]'
-      # pre-releases, e.g. 1.8-pre1
-      - 1.8-pre[0-9]
       # test branches, e.g. test-debian
       - test-*
 
@@ -28,6 +24,18 @@ on:
 #    The docker repository for test images. Only used for the branch TESTING (BORS try).
 # Add the above secrets to your github repo to determine where the images will be pushed.
 ################################################
+# Code block that is used as one liner.
+##!/bin/bash
+#version=$( git tag --list "{{ env.MAILU_VERSION }}.*" | tail -1  )
+#root_version=${version:0:3}
+#patch_version=${version:4:4}
+#if [ "$patch_version" == "" ]
+#then
+#  pinned_version={{ env.MAILU_VERSION }}.0
+#else
+#  pinned_version=$root_version.$(expr $patch_version + 1)
+#fi
+#echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
 
 jobs:
   build:
@@ -35,27 +43,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
         #For branch TESTING, we set the image tag to PR-xxxx
-      - name: Derive MAILU_VERSION for branch testing
+      - name: Derive MAILU_VERSION and PINNED_MAILU_VERSION for branch testing
         if: ${{ env.BRANCH == 'testing' }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG_TESTS }}" >> $GITHUB_ENV
+          echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG_TESTS" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION for other branches than testing
         if: ${{ env.BRANCH != 'testing' }}
         shell: bash
         env:
-          MAILU_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'staging' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for staging
+        if: ${{ env.BRANCH == 'staging' }}
+        shell: bash
+        run: |
+          echo "PINNED_MAILU_VERSION=staging" >> $GITHUB_ENV      
+      - name: Derive PINNED_MAILU_VERSION for master
+        if: ${{ env.BRANCH == 'master' }}
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        run: |
+          echo "PINNED_MAILU_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -76,7 +106,7 @@ jobs:
       - name: Build all docker images
         env:
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
           DOCKER_ORG: ${{ env.DOCKER_ORG }}
         run: docker-compose -f tests/build.yml build
       - name: Save all docker images
@@ -89,26 +119,49 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: Derive MAILU_VERSION for branch testing
+        #For branch TESTING, we set the image tag to PR-xxxx
+      - name: Derive MAILU_VERSION and PINNED_MAILU_VERSION for branch testing
         if: ${{ env.BRANCH == 'testing' }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG_TESTS }}" >> $GITHUB_ENV
+          echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG_TESTS" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION for other branches than testing
         if: ${{ env.BRANCH != 'testing' }}
         shell: bash
         env:
-          MAILU_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for staging
+        if: ${{ env.BRANCH == 'staging' }}
+        shell: bash
+        run: |
+          echo "PINNED_MAILU_VERSION=staging" >> $GITHUB_ENV          
+      - name: Derive PINNED_MAILU_VERSION for master
+        if: ${{ env.BRANCH == 'master' }}
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        run: |
+          echo "PINNED_MAILU_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -128,7 +181,7 @@ jobs:
         run: python tests/compose/test.py core 2
         env:
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
           DOCKER_ORG: ${{ env.DOCKER_ORG }}
 
   test-fetchmail:
@@ -138,26 +191,49 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: Derive MAILU_VERSION for branch testing
+        #For branch TESTING, we set the image tag to PR-xxxx
+      - name: Derive MAILU_VERSION and PINNED_MAILU_VERSION for branch testing
         if: ${{ env.BRANCH == 'testing' }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG_TESTS }}" >> $GITHUB_ENV
+          echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG_TESTS" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION for other branches than testing
         if: ${{ env.BRANCH != 'testing' }}
         shell: bash
         env:
-          MAILU_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for staging
+        if: ${{ env.BRANCH == 'staging' }}
+        shell: bash
+        run: |
+          echo "PINNED_MAILU_VERSION=staging" >> $GITHUB_ENV          
+      - name: Derive PINNED_MAILU_VERSION for master
+        if: ${{ env.BRANCH == 'master' }}
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        run: |
+          echo "PINNED_MAILU_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -177,7 +253,7 @@ jobs:
         run: python tests/compose/test.py fetchmail 2
         env:
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
           DOCKER_ORG: ${{ env.DOCKER_ORG }}
 
   test-filters:
@@ -187,26 +263,49 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: Derive MAILU_VERSION for branch testing
+        #For branch TESTING, we set the image tag to PR-xxxx
+      - name: Derive MAILU_VERSION and PINNED_MAILU_VERSION for branch testing
         if: ${{ env.BRANCH == 'testing' }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG_TESTS }}" >> $GITHUB_ENV
+          echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG_TESTS" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION for other branches than testing
         if: ${{ env.BRANCH != 'testing' }}
         shell: bash
         env:
-          MAILU_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for staging
+        if: ${{ env.BRANCH == 'staging' }}
+        shell: bash
+        run: |
+          echo "PINNED_MAILU_VERSION=staging" >> $GITHUB_ENV          
+      - name: Derive PINNED_MAILU_VERSION for master
+        if: ${{ env.BRANCH == 'master' }}
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        run: |
+          echo "PINNED_MAILU_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -226,7 +325,7 @@ jobs:
         run: python tests/compose/test.py filters 3
         env:
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
           DOCKER_ORG: ${{ env.DOCKER_ORG }}
 
   test-rainloop:
@@ -236,26 +335,49 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: Derive MAILU_VERSION for branch testing
+        #For branch TESTING, we set the image tag to PR-xxxx
+      - name: Derive MAILU_VERSION and PINNED_MAILU_VERSION for branch testing
         if: ${{ env.BRANCH == 'testing' }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG_TESTS }}" >> $GITHUB_ENV
+          echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG_TESTS" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION for other branches than testing
         if: ${{ env.BRANCH != 'testing' }}
         shell: bash
         env:
-          MAILU_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for staging
+        if: ${{ env.BRANCH == 'staging' }}
+        shell: bash
+        run: |
+          echo "PINNED_MAILU_VERSION=staging" >> $GITHUB_ENV          
+      - name: Derive PINNED_MAILU_VERSION for master
+        if: ${{ env.BRANCH == 'master' }}
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        run: |
+          echo "PINNED_MAILU_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -275,7 +397,7 @@ jobs:
         run: python tests/compose/test.py rainloop 2
         env:
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
           DOCKER_ORG: ${{ env.DOCKER_ORG }}
 
   test-roundcube:
@@ -285,26 +407,49 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: Derive MAILU_VERSION for branch testing
+        #For branch TESTING, we set the image tag to PR-xxxx
+      - name: Derive MAILU_VERSION and PINNED_MAILU_VERSION for branch testing
         if: ${{ env.BRANCH == 'testing' }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG_TESTS }}" >> $GITHUB_ENV
+          echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG_TESTS" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION for other branches than testing
         if: ${{ env.BRANCH != 'testing' }}
         shell: bash
         env:
-          MAILU_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for staging
+        if: ${{ env.BRANCH == 'staging' }}
+        shell: bash
+        run: |
+          echo "PINNED_MAILU_VERSION=staging" >> $GITHUB_ENV          
+      - name: Derive PINNED_MAILU_VERSION for master
+        if: ${{ env.BRANCH == 'master' }}
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        run: |
+          echo "PINNED_MAILU_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -324,7 +469,7 @@ jobs:
         run: python tests/compose/test.py roundcube 2
         env:
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
           DOCKER_ORG: ${{ env.DOCKER_ORG }}
 
   test-webdav:
@@ -334,26 +479,49 @@ jobs:
       - build
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
-      - name: Derive MAILU_VERSION for branch testing
+        #For branch TESTING, we set the image tag to PR-xxxx
+      - name: Derive MAILU_VERSION and PINNED_MAILU_VERSION for branch testing
         if: ${{ env.BRANCH == 'testing' }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG_TESTS }}" >> $GITHUB_ENV
+          echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG_TESTS" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION for other branches than testing
         if: ${{ env.BRANCH != 'testing' }}
         shell: bash
         env:
-          MAILU_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for staging
+        if: ${{ env.BRANCH == 'staging' }}
+        shell: bash
+        run: |
+          echo "PINNED_MAILU_VERSION=staging" >> $GITHUB_ENV          
+      - name: Derive PINNED_MAILU_VERSION for master
+        if: ${{ env.BRANCH == 'master' }}
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        run: |
+          echo "PINNED_MAILU_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -373,7 +541,7 @@ jobs:
         run: python tests/compose/test.py webdav 2
         env:
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
           DOCKER_ORG: ${{ env.DOCKER_ORG }}
 
   deploy:
@@ -389,27 +557,49 @@ jobs:
       - test-webdav
     steps:
       - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
       - name: Extract branch name
         shell: bash
         run: |
           echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
         #For branch TESTING, we set the image tag to PR-xxxx
-      - name: Derive MAILU_VERSION for branch testing
+      - name: Derive MAILU_VERSION and PINNED_MAILU_VERSION for branch testing
         if: ${{ env.BRANCH == 'testing' }}
         shell: bash
         env:
           COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+          DOCKER_ORG_TESTS: ${{ secrets.DOCKER_ORG_TESTS }}
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG_TESTS }}" >> $GITHUB_ENV
+          echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG_TESTS" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION for other branches than testing
         if: ${{ env.BRANCH != 'testing' }}
         shell: bash
         env:
-          MAILU_BRANCH: ${{ env.BRANCH }}
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
         run: |
-          echo "MAILU_VERSION=${{ env.MAILU_BRANCH }}" >> $GITHUB_ENV
-          echo "DOCKER_ORG=${{ secrets.DOCKER_ORG }}" >> $GITHUB_ENV
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for staging
+        if: ${{ env.BRANCH == 'staging' }}
+        shell: bash
+        run: |
+          echo "PINNED_MAILU_VERSION=staging" >> $GITHUB_ENV          
+      - name: Derive PINNED_MAILU_VERSION for master
+        if: ${{ env.BRANCH == 'master' }}
+        shell: bash
+        env:
+          GITHUB_SHA: ${{ env.GITHUB_SHA }}
+        run: |
+          echo "PINNED_MAILU_VERSION=$GITHUB_SHA" >> $GITHUB_ENV
       - name: Create folder for storing images
         run: |
           sudo mkdir -p /images
@@ -430,13 +620,49 @@ jobs:
           DOCKER_PW: ${{ secrets.Docker_Password }}
           DOCKER_ORG: ${{ env.DOCKER_ORG }}
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          TRAVIS_BRANCH: ${{ env.BRANCH }}
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
+          BRANCH: ${{ env.BRANCH }}
         run: bash tests/deploy.sh
+
+  tag-release:
+    runs-on: ubuntu-latest
+    needs:
+      - deploy
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # fetch-depth 0 is required to also retrieve all tags.
+          fetch-depth: 0
+      - name: Extract branch name
+        shell: bash
+        run: |
+          echo "BRANCH=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+      - name: Derive MAILU_VERSION amd DOCKER_ORG
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'staging' && env.BRANCH != 'master' }}
+        shell: bash
+        env:
+          DOCKER_ORG: ${{ secrets.DOCKER_ORG }}
+        run: |
+          echo "MAILU_VERSION=${{ env.BRANCH }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG=$DOCKER_ORG" >> $GITHUB_ENV
+      - name: Derive PINNED_MAILU_VERSION for normal release x.y
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'staging' && env.BRANCH != 'master' }}
+        shell: bash
+        run: |
+          version=$( git tag --list "${{ env.MAILU_VERSION }}.*" | tail -1  );root_version=${version:0:3};patch_version=${version:4:4};if [ "$patch_version" == "" ]; then pinned_version=${{ env.MAILU_VERSION }}.0; else pinned_version=$root_version.$(expr $patch_version + 1); fi;echo "PINNED_MAILU_VERSION=$pinned_version" >> $GITHUB_ENV
+      - name: Tag and create release
+        if: ${{ env.BRANCH != 'testing' && env.BRANCH != 'staging' && env.BRANCH != 'master' && env.PINNED_MAILU_VERSION != '' }}
+        uses: ncipollo/release-action@v1
+        with:
+          bodyFile: "RELEASE_TEMPLATE.md"
+          commit: ${{ env.GITHUB_SHA }}
+          tag: ${{ env.PINNED_MAILU_VERSION }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
  # This job is watched by bors. It only complets if building,testing and deploy worked.
   ci-success:
     name: CI-Done
-    #Returns true when none of the **previous** steps have failed or been canceled.
+    #Returns true when none of the **previous** steps have failed or have been canceled.
     if: ${{ success() }}
     needs:
       - deploy

--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -1,0 +1,10 @@
+This is a new automatic release of Mailu. The new version can be seen in the tag name.
+The main version X.Y (e.g. 1.8) will always reflect the latest version of the branch. To update your Mailu installation simply pull the latest images `docker-compose pull && docker-compose up -d`.
+The pinned version X.Y.Z (e.g. 1.8.1) is not updated. It is pinned to the commit that was used for creating this release. You can use a pinned version to make sure your Mailu installation is not suddenly updated when recreating containers. The pinned version allows the user to manually update. It also allows to go back to a previous pinned version.
+
+To check what was changed:
+- Go to https://github.com/Mailu/Mailu/tree/master/towncrier/newsfragments
+- Change the branch to the tag of this release.
+- Read the news fragment files to check what was changed.
+
+The release notes of the original release can be accessed via menu item 'Release notes' on [mailu.io](https://mailu.io/).

--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -21,9 +21,13 @@ RUN set -eu \
 
 # Actual application
 FROM $DISTRO
+ARG VERSION
 COPY --from=balenalib/rpi-alpine:3.14 /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN set -eu \

--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -11,8 +11,11 @@ RUN git clone https://github.com/grosjo/fts-xapian.git \
   && make install
 
 FROM $DISTRO
-
+ARG VERSION
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -1,7 +1,11 @@
 ARG DISTRO=alpine:3.14.2
 FROM $DISTRO
+ARG VERSION
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -1,7 +1,12 @@
 ARG DISTRO=alpine:3.14.2
+
 FROM $DISTRO
+ARG VERSION
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/core/rspamd/Dockerfile
+++ b/core/rspamd/Dockerfile
@@ -1,7 +1,10 @@
 ARG DISTRO=alpine:3.14.2
 FROM $DISTRO
-
+ARG VERSION
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -19,7 +19,11 @@ RUN apk add --no-cache --virtual .build-deps \
 FROM nginx:1.21-alpine
 
 ARG version=master
+ARG pinned_version=master
 ENV VERSION=$version
+ENV TZ Etc/UTC
+LABEL version=$VERSION
+RUN echo $pinned_version >> /version
 
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /build/$VERSION /build/$VERSION

--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -1,7 +1,11 @@
 ARG DISTRO=alpine:3.14.2
 FROM $DISTRO
+ARG VERSION
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/optional/fetchmail/Dockerfile
+++ b/optional/fetchmail/Dockerfile
@@ -1,7 +1,11 @@
 ARG DISTRO=alpine:3.14.2
 FROM $DISTRO
+ARG VERSION
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/optional/postgresql/Dockerfile
+++ b/optional/postgresql/Dockerfile
@@ -1,7 +1,11 @@
 ARG DISTRO=alpine:3.14.2
 FROM $DISTRO
+ARG VERSION
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -1,7 +1,11 @@
 ARG DISTRO=alpine:3.14.2
 FROM $DISTRO
+ARG VERSION
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/optional/traefik-certdumper/Dockerfile
+++ b/optional/traefik-certdumper/Dockerfile
@@ -1,6 +1,10 @@
 FROM ldez/traefik-certs-dumper
+ARG VERSION
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 RUN apk --no-cache add inotify-tools util-linux bash tzdata
 

--- a/optional/unbound/Dockerfile
+++ b/optional/unbound/Dockerfile
@@ -1,7 +1,11 @@
 ARG DISTRO=alpine:3.14.2
 FROM $DISTRO
+ARG VERSION
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # python3 shared with most images
 RUN apk add --no-cache \

--- a/setup/Dockerfile
+++ b/setup/Dockerfile
@@ -1,5 +1,9 @@
 ARG DISTRO=alpine:3.14.2
 FROM $DISTRO
+ARG VERSION
+ENV TZ Etc/UTC
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/tests/build.yml
+++ b/tests/build.yml
@@ -3,69 +3,114 @@ version: '3'
 services:
 
   front:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}nginx:${MAILU_VERSION:-local}
-    build: ../core/nginx
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}nginx:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../core/nginx
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   resolver:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}unbound:${MAILU_VERSION:-local}
-    build: ../optional/unbound
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}unbound:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../optional/unbound
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   imap:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}dovecot:${MAILU_VERSION:-local}
-    build: ../core/dovecot
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}dovecot:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../core/dovecot
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   smtp:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}postfix:${MAILU_VERSION:-local}
-    build: ../core/postfix
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}postfix:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../core/postfix
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   antispam:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}rspamd:${MAILU_VERSION:-local}
-    build: ../core/rspamd
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}rspamd:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../core/rspamd
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   antivirus:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}clamav:${MAILU_VERSION:-local}
-    build: ../optional/clamav
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}clamav:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../optional/clamav
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   webdav:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}radicale:${MAILU_VERSION:-local}
-    build: ../optional/radicale
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}radicale:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../optional/radicale
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   traefik-certdumper:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}traefik-certdumper:${MAILU_VERSION:-local}
-    build: ../optional/traefik-certdumper
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}traefik-certdumper:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../optional/traefik-certdumper
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   admin:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}admin:${MAILU_VERSION:-local}
-    build: ../core/admin
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}admin:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../core/admin
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   postgresql:
-    image: ${DOCKER_ORG:-mailu}/postgresql:${MAILU_VERSION:-local}
-    build: ../optional/postgresql
+    image: ${DOCKER_ORG:-mailu}/postgresql:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../optional/postgresql
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   roundcube:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}roundcube:${MAILU_VERSION:-local}
-    build: ../webmails/roundcube
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}roundcube:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../webmails/roundcube
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   rainloop:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}rainloop:${MAILU_VERSION:-local}
-    build: ../webmails/rainloop
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}rainloop:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../webmails/rainloop
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   fetchmail:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}fetchmail:${MAILU_VERSION:-local}
-    build: ../optional/fetchmail
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}fetchmail:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../optional/fetchmail
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   none:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}none:${MAILU_VERSION:-local}
-    build: ../core/none
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}none:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../core/none
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}
 
   docs:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}docs:${MAILU_VERSION:-local}
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}docs:${PINNED_MAILU_VERSION:-local}
     build:
       context: ../docs
       args:
         version: ${MAILU_VERSION:-local}
+        pinned_version: ${PINNED_MAILU_VERSION:-local}
 
   setup:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}setup:${MAILU_VERSION:-local}
-    build: ../setup
-
+    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}setup:${PINNED_MAILU_VERSION:-local}
+    build:
+      context: ../setup
+      args:
+        VERSION: ${PINNED_MAILU_VERSION:-local}

--- a/tests/deploy.sh
+++ b/tests/deploy.sh
@@ -1,7 +1,51 @@
 #!/bin/bash
 
 # Skip deploy for staging branch
-[ "$TRAVIS_BRANCH" = "staging" ] && exit 0
+[ "$BRANCH" = "staging" ] && exit 0
 
 docker login -u $DOCKER_UN -p $DOCKER_PW
+
+if [ "$BRANCH" = "testing" ]
+then
+  docker-compose -f tests/build.yml push
+  exit 0
+fi
+
+#Deploy for main releases
+#Images are built with tag PINNED_MAILU_VERSION (x.y.z).
+#We are tagging them as well with MAILU_VERSION (x.y)
+#After that, both tags are pushed to the docker repository.
+if [ "$PINNED_MAILU_VERSION" != "" ] && [ "$BRANCH" != "master" ]
+then
+  images=$(docker-compose -f tests/build.yml config | grep 'image: ' | awk -F ':' '{ print $2 }')
+  for image in $images
+  do
+    docker tag "${image}":"${PINNED_MAILU_VERSION}" "${image}":${MAILU_VERSION}
+  done
+#Push PINNED_MAILU_VERSION images
+  docker-compose -f tests/build.yml push
+#Push MAILU_VERSION images
+  PINNED_MAILU_VERSION=$MAILU_VERSION
+  docker-compose -f tests/build.yml push
+  exit 0
+fi
+
+#Deploy for master. For master we only publish images with tag master
+#Images are built with tag PINNED_MAILU_VERSION (commit hash).
+#We are tagging them as well with MAILU_VERSION (master)
+#Then we publish the images with tag master
+if [ "$PINNED_MAILU_VERSION" != "" ] && [ "$BRANCH" == "master" ]
+then
+  images=$(docker-compose -f tests/build.yml config | grep 'image: ' | awk -F ':' '{ print $2 }')
+  for image in $images
+  do
+    docker tag "${image}":"${PINNED_MAILU_VERSION}" "${image}":${MAILU_VERSION}
+  done
+#Push MAILU_VERSION images
+  PINNED_MAILU_VERSION=$MAILU_VERSION
+  docker-compose -f tests/build.yml push
+  exit 0
+fi
+
+#Fallback in case $PINNED_MAILU_VERSION is empty. This should never execute.
 docker-compose -f tests/build.yml push

--- a/towncrier/newsfragments/1182.feature
+++ b/towncrier/newsfragments/1182.feature
@@ -1,0 +1,10 @@
+Use semantic versioning for building releases.
+- Add versioning (tagging) for branch x.y (1.8). E.g. 1.8.0, 1.8.1 etc.
+  - docker repo will contain x.y (latest) and x.y.z (pinned version) images.
+  - The X.Y.Z tag is incremented automatically. E.g. if 1.8.0 already exists, then the next merge on 1.8 will result in the new tag 1.8.1 being used.
+- Make the version available in the image.
+  -  For X.Y and X.Y.Z write the version (X.Y.Z) into /version on the image and add a label with version=X.Y.Z
+	  -  This means that the latest X.Y image shows the pinned version (X.Y.Z e.g. 1.8.1) it was based on. Via the tag X.Y.Z you can see the commit hash that triggered the built.
+  -  For master write the commit hash into /version on the image and add a label with version={commit hash}
+-  Automatic releases. For x.y triggered builts (e.g. merge on 1.9) do a new github release for the pinned x.y.z (e.g. 1.9.2). 
+  -  Release shows a static message (see RELEASE_TEMPLATE.md) that explains how to reach the newsfragments folder and change the branch to the tag (x.y.z) mentioned in the release. Now you can get the changelog by reading all newsfragment files in this folder.

--- a/webmails/rainloop/Dockerfile
+++ b/webmails/rainloop/Dockerfile
@@ -2,9 +2,13 @@ ARG ARCH=""
 
 # NOTE: only add file if building for arm
 FROM ${ARCH}alpine:3.14
+ARG VERSION
 ONBUILD COPY --from=balenalib/rpi-alpine:3.14 /usr/bin/qemu-arm-static /usr/bin/qemu-arm-static
 
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 # Shared later between dovecot postfix nginx rspamd rainloop and roundloop
 RUN apk add --no-cache \

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -7,8 +7,11 @@ ONBUILD COPY --from=balenalib/rpi-alpine:3.14 /usr/bin/qemu-arm-static /usr/bin/
 FROM ${ARCH}php:7.4-apache as build_other
 
 FROM build_${QEMU}
-
+ARG VERSION
 ENV TZ Etc/UTC
+
+LABEL version=$VERSION
+RUN echo $VERSION >> /version
 
 #Shared layer between rainloop and roundcube
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## What type of PR?

Feature!

## What does this PR do?
This PR introduces 3 things
- Add versioning (tagging) for branch x.y (1.8). E.g. 1.8.0, 1.8.1 etc.
  - docker repo will contain x.y (latest) and x.y.z (pinned version) images.
  - The X.Y.Z tag is incremented automatically. E.g. if 1.8.0 already exists, then the next merge on 1.8 will result in the new tag 1.8.1 being used.
- Make the version available in the image.
  -  For X.Y and X.Y.Z write the version (X.Y.Z) into /version on the image and add a label with version=X.Y.Z
	  -  This means that the latest X.Y image shows the pinned version (X.Y.Z e.g. 1.8.1) it was based on. Via the tag X.Y.Z you can see the commit hash that triggered the built.
  -  For master write the commit hash into /version on the image and add a label with version={commit hash}
-  Automatic releases. For x.y triggered builts (e.g. merge on 1.9) do a new github release for the pinned x.y.z (e.g. 1.9.2). 
  -  Release shows a static message (see RELEASE_TEMPLATE.md) that explains how to reach the newsfragments folder and change the branch to the tag (x.y.z) mentioned in the release. Now you can get the changelog by reading all newsfragment files in this folder.

This PR does not change anything to our workflow (what we (human persons) do). Our processes are still exactly the same. The above introduced logic is automatic. When we backport to X.Y all the magic for creating the pinned version X.Y.Z is handled by the CI/CD workflow.

### Related issue(s)
- closes #1182

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.

## Testing
Suggested testing steps. This should cover all situations including BORS. It does require that you use your own docker repo or temporarily create a new one.
Suggested testing steps.
1. Create new github repo.
2. Add the required docker secrets to the project (see beginning of CI.yml for the secret names), DOCKER_UN, DOCKER_PW, DOCKER_ORG, DOCKER_ORG_TESTS.
3. Clone the project.
4. Copy the contents of the PR to the cloned project.
5. Push to your new github repo.
6. Now master images are built. Check that images with tag master are pushed to your docker repo
7. Check with docker inspect nginx:master that it has the label version={commit hash}.
8. Run an image, run `docker-compose exec <name> cat /version`. Note that /version also contains the pinned version. For master the pinned version is the commit hash.
9. Create branch 1.8. 
10. Push branch 1.8 to repo.
11. Note that tags 1.8 and 1.8.0 are built and pushed to docker repo
12. Inspect label and /version. Note that 1.8 and 1.8.0 both show version 1.8.0.
13. Push another commit to branch 1.8.
14. Note that tags 1.8 and 1.8.1 are built and pushed to docker repo
15. Inspect label and /version. Note that 1.8 and 1.8.1 both show version 1.8.1.
16. Let's check BORS stuff.
17. Create branch testing.
18. Push the commit with the exact commit text (IMPORTANT!!): `Try #1234:`'.
19. Note that images are built and pushed for tag `pr-1234`.
20. Inspect label and /version. Note that the version is `pr-1234`.
20. Create branch staging.
21. Push the commit with commit text: `Merge #1234`.
22. Note that this image is not pushed to docker (as expected).

but you could also check the GH repo and docker repo I used:
https://github.com/Diman0/Mailu_Fork
https://hub.docker.com/r/diman/rainloop/tags