### PR TITLE
Documentation for switching database-backend and for migrating from Mailu PostgreSQL

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -121,6 +121,8 @@ additional fields:
 
 * wildcard
 
+.. _config-export:
+
 config-export
 -------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -124,12 +124,12 @@ Full-text search is enabled for IMAP is enabled by default. This feature can be 
 Web settings
 ------------
 
-- ``WEB_ADMIN`` contains the path to the main admin interface 
+- ``WEB_ADMIN`` contains the path to the main admin interface
 
 - ``WEB_WEBMAIL`` contains the path to the Web email client.
 
 - ``WEBROOT_REDIRECT`` redirects all non-found queries to the set path.
-  An empty ``WEBROOT_REDIRECT`` value disables redirecting and enables classic behavior of a 404 result when not found. 
+  An empty ``WEBROOT_REDIRECT`` value disables redirecting and enables classic behavior of a 404 result when not found.
   Alternatively, ``WEBROOT_REDIRECT`` can be set to ``none`` if you are using an Nginx override for ``location /``.
 
 All three options need a leading slash (``/``) to work.
@@ -238,6 +238,8 @@ Alternatively, ``*_ADDRESS`` can directly be set. In this case, the values of ``
 resolved. This can be used to rely on DNS based service discovery with changing services IP addresses.
 When using ``*_ADDRESS``, the hostnames must be full-qualified hostnames. Otherwise nginx will not be able to
 resolve the hostnames.
+
+.. _db_settings:
 
 Database settings
 -----------------

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -2,7 +2,7 @@ Changing the database back-end
 ==============================
 
 By default Mailu uses a SQLite database. We have changed the internals of Mailu
-to enable the support of alternative database solutions as PostgreSQL and MySQL/MariaDB.
+to enable the support of alternative database solutions such as PostgreSQL and MySQL/MariaDB.
 
 
 Migrating to a different database back-end
@@ -10,7 +10,7 @@ Migrating to a different database back-end
 
 From Mailu 1.9, Mailu has a :ref:`cli command (link) <config-export>` for exporting and importing the complete Mailu configuration.
 Using this tool it is very easy to switch what database back-end is used for Mailu.
-Unfortunately roundcube does not have a tool for exporting/importing roundcube configuration.
+Unfortunately roundcube does not have a tool for exporting/importing its configuration.
 This means it is not possible to switch the database back-end used by roundcube using out of box tools.
 
 To switch to a different database back-end:
@@ -42,12 +42,10 @@ Adjust this to your own liking.
 .. code-block:: sql
 
   mysql> CREATE DATABASE mailu;
-  mysql> CREATE USER 'mailu'@'%' IDENTIFIED BY 'my-strong-password-here';
+  mysql> CREATE USER `mailu`@`%` IDENTIFIED WITH mysql_native_password BY `my-strong-password-here`;
   mysql> GRANT ALL PRIVILEGES ON mailu.* TO 'mailu'@'%';
   mysql> FLUSH PRIVILEGES;
 
-Note that if you get any errors related to ``caching_sha2_password`` it can be solved by changing the encryption
-of the password to ``mysql_native_password`` instead of the latest authentication plugin ``caching_sha2_password``.
 
 .. code-block:: sql
 

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -47,26 +47,6 @@ Adjust this to your own liking.
   mysql> FLUSH PRIVILEGES;
 
 
-.. code-block:: sql
-
-  mysql> SELECT host, user, plugin FROM mysql.user;
-
-  +-----------+-------+-----------------------+
-  | host      | user  | plugin                |
-  +-----------+-------+-----------------------+
-  | %         | mailu | caching_sha2_password |
-  +-----------+-------+-----------------------+
-
-  mysql> update mysql.user set plugin = 'mysql_native_password' where user = 'mailu';
-  mysql> SELECT host, user, plugin FROM mysql.user;
-
-  +------+-------+-----------------------+
-  | host | user  | plugin                |
-  +------+-------+-----------------------+
-  | %    | mailu | mysql_native_password |
-  +------+-------+-----------------------+
-
-
 External PostgreSQL
 -------------------
 

--- a/towncrier/newsfragments/1037.doc
+++ b/towncrier/newsfragments/1037.doc
@@ -1,0 +1,2 @@
+Added documentation for how to switch the database back-end used by Mailu.
+Added documentation for migrating from the deprecated Mailu PostgreSQL image to a different PostgreSQL database.


### PR DESCRIPTION
## What type of PR?

Documentation

## What does this PR do?

Added documentation for how to switch the database back-end used by Mailu.
Added documentation for migrating from the deprecated Mailu PostgreSQL image to a different PostgreSQL database.

### Related issue(s)
- closes #1037 
- closes #1216 
- closes #1675 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
