### PR TITLE
Update messaging on imap to include webmail

### DIFF
--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -80,7 +80,7 @@ class UserForm(flask_wtf.FlaskForm):
     pw = fields.PasswordField(_('Password'))
     pw2 = fields.PasswordField(_('Confirm password'), [validators.EqualTo('pw')])
     quota_bytes = fields_.IntegerSliderField(_('Quota'), default=10**9)
-    enable_imap = fields.BooleanField(_('Allow IMAP access'), default=True)
+    enable_imap = fields.BooleanField(_('Allow IMAP/Webmail access'), default=True)
     enable_pop = fields.BooleanField(_('Allow POP3 access'), default=True)
     displayed_name = fields.StringField(_('Displayed name'))
     comment = fields.StringField(_('Comment'))


### PR DESCRIPTION
Update messaging on imap to make clear that it also controls access to webmail as well.

## What type of PR?

Enhancement

## What does this PR do?

Improves the admin interface to be more self-documenting.

An admin disabling/not-enabling IMAP on an account might not immediately realize that this setting also disables webmail functionality on this account. This PR improves the admin experience in this area.

### Related issue(s)
none

## Prerequisites
none