### PR TITLE
The DB_PORT and ROUNDCUBE_DB_PORT env vars were not used

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -21,6 +21,7 @@ DEFAULT_CONFIG = {
     'DB_USER': 'mailu',
     'DB_PW': None,
     'DB_HOST': 'database',
+    'DB_PORT': None,
     'DB_NAME': 'mailu',
     'SQLITE_DATABASE_FILE':'data/main.db',
     'SQLALCHEMY_DATABASE_URI': 'sqlite:////data/main.db',
@@ -144,6 +145,8 @@ class ConfigManager:
 
         # automatically set the sqlalchemy string
         if self.config['DB_FLAVOR']:
+            if self.config['DB_PORT']:
+                self.config['DB_HOST'] = f'{self.config["DB_HOST"]}:{str(self.config["DB_PORT"])}'
             template = self.DB_TEMPLATES[self.config['DB_FLAVOR']]
             self.config['SQLALCHEMY_DATABASE_URI'] = template.format(**self.config)
 

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -145,7 +145,7 @@ class ConfigManager:
 
         # automatically set the sqlalchemy string
         if self.config['DB_FLAVOR']:
-            if self.config['DB_PORT']:
+            if self.config['DB_PORT'] and self.config['DB_FLAVOR'] != 'sqlite':
                 self.config['DB_HOST'] = f'{self.config["DB_HOST"]}:{str(self.config["DB_PORT"])}'
             template = self.DB_TEMPLATES[self.config['DB_FLAVOR']]
             self.config['SQLALCHEMY_DATABASE_URI'] = template.format(**self.config)

--- a/towncrier/newsfragments/2073.bugfix
+++ b/towncrier/newsfragments/2073.bugfix
@@ -1,0 +1,1 @@
+The DB_PORT and ROUNDCUBE_DB_PORT environment variables were not actually used. This fix addresses that.

--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -11,22 +11,41 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 os.environ["MAX_FILESIZE"] = str(int(int(os.environ.get("MESSAGE_SIZE_LIMIT")) * 0.66 / 1048576))
 
 db_flavor = os.environ.get("ROUNDCUBE_DB_FLAVOR", "sqlite")
+db_port = os.environ.get("ROUNDCUBE_DB_PORT")
 if db_flavor == "sqlite":
     os.environ["DB_DSNW"] = "sqlite:////data/roundcube.db"
 elif db_flavor == "mysql":
-    os.environ["DB_DSNW"] = "mysql://%s:%s@%s/%s" % (
-        os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
-        os.environ.get("ROUNDCUBE_DB_PW"),
-        os.environ.get("ROUNDCUBE_DB_HOST", "database"),
-        os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
-    )
+    if db_port:
+        os.environ["DB_DSNW"] = "mysql://%s:%s@%s:%s/%s" % (
+            os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
+            os.environ.get("ROUNDCUBE_DB_PW"),
+            os.environ.get("ROUNDCUBE_DB_HOST", "database"),
+            db_port,
+            os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
+        )
+    else:
+        os.environ["DB_DSNW"] = "mysql://%s:%s@%s/%s" % (
+            os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
+            os.environ.get("ROUNDCUBE_DB_PW"),
+            os.environ.get("ROUNDCUBE_DB_HOST", "database"),
+            os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
+        )
 elif db_flavor == "postgresql":
-    os.environ["DB_DSNW"] = "pgsql://%s:%s@%s/%s" % (
-        os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
-        os.environ.get("ROUNDCUBE_DB_PW"),
-        os.environ.get("ROUNDCUBE_DB_HOST", "database"),
-        os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
-    )
+    if db_port:
+        os.environ["DB_DSNW"] = "pgsql://%s:%s@%s:%s/%s" % (
+            os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
+            os.environ.get("ROUNDCUBE_DB_PW"),
+            os.environ.get("ROUNDCUBE_DB_HOST", "database"),
+            db_port,
+            os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
+        )
+    else:
+        os.environ["DB_DSNW"] = "pgsql://%s:%s@%s/%s" % (
+            os.environ.get("ROUNDCUBE_DB_USER", "roundcube"),
+            os.environ.get("ROUNDCUBE_DB_PW"),
+            os.environ.get("ROUNDCUBE_DB_HOST", "database"),
+            os.environ.get("ROUNDCUBE_DB_NAME", "roundcube")
+        )
 else:
     print("Unknown ROUNDCUBE_DB_FLAVOR: %s", db_flavor)
     exit(1)


### PR DESCRIPTION
## What type of PR?

Bug fix 

## What does this PR do?
The DB_PORT and ROUNDCUBE_DB_PORT env vars can be used to configure a custom port for the database connection. These environment variables were documented, but not actually used. 

This fix addresses that. The syntax should be correct. I did not test it yet. I will do that later this week.

### Related issue(s)
- See #2073

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ n/a ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
