### PR TITLE
fix the default for DEFER_ON_TLS_ERROR

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -35,6 +35,7 @@ def is_valid_postconf_line(line):
             and not line == ''
 
 # Actual startup script
+os.environ['DEFER_ON_TLS_ERROR'] = os.environ['DEFER_ON_TLS_ERROR'] if 'DEFER_ON_TLS_ERROR' in os.environ else 'True'
 os.environ["FRONT_ADDRESS"] = system.get_host_address_from_environment("FRONT", "front")
 os.environ["ADMIN_ADDRESS"] = system.get_host_address_from_environment("ADMIN", "admin")
 os.environ["ANTISPAM_MILTER_ADDRESS"] = system.get_host_address_from_environment("ANTISPAM_MILTER", "antispam:11332")


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

The default wasn't set anywhere