### PR TITLE
Fix #2078 (login to webmail did not work when WEB_WEBMAIL=/ was set)

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -135,7 +135,7 @@ http {
 
       # Actual logic
       {% if ADMIN == 'true' or WEBMAIL != 'none' %}
-      location ~ ^/(sso|static) {
+      location ~ ^/(sso|static)/ {
         include /etc/nginx/proxy.conf;
         proxy_pass http://$admin;
       }
@@ -165,7 +165,12 @@ http {
         proxy_pass http://$webmail;
       }
 
+      {% if WEB_WEBMAIL == '/' %}
+      location /sso.php {
+      {% endif %}
+      {% if WEB_WEBMAIL != '/' %}
       location {{ WEB_WEBMAIL }}/sso.php {
+      {% endif %}
         {% if WEB_WEBMAIL != '/' %}
         rewrite ^({{ WEB_WEBMAIL }})$ $1/ permanent;
         rewrite ^{{ WEB_WEBMAIL }}/(.*) /$1 break;

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -167,8 +167,7 @@ http {
 
       {% if WEB_WEBMAIL == '/' %}
       location /sso.php {
-      {% endif %}
-      {% if WEB_WEBMAIL != '/' %}
+      {% else %}
       location {{ WEB_WEBMAIL }}/sso.php {
       {% endif %}
         {% if WEB_WEBMAIL != '/' %}

--- a/towncrier/newsfragments/2078.fix
+++ b/towncrier/newsfragments/2078.fix
@@ -1,0 +1,1 @@
+SSO login page to webmail did not work if WEB_WEBMAIL=/ was set.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
It fixes #2078. Login from SSO page to webmail did not work if WEB_WEBMAIL=/ was set in mailu.env.

I tested that it works with
- WEB_WEBMAIL=/webmail
- WEB_WEBMAIL=/

### Related issue(s)
- closes #2078 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] n/a In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
