### PR TITLE
Fix missing edit buttons in alias, relay and fetchmail lists in admin.

### DIFF
--- a/core/admin/mailu/ui/templates/alias/list.html
+++ b/core/admin/mailu/ui/templates/alias/list.html
@@ -28,7 +28,7 @@
   {%- for alias in domain.aliases %}
   <tr>
     <td>
-      <a href="{{ url_for('.alias_edit', alias=alias.email) }}" title="{% trans %}Edit{% endtrans %}"><i class="fa fa-pencil"></i></a>&nbsp;
+      <a href="{{ url_for('.alias_edit', alias=alias.email) }}" title="{% trans %}Edit{% endtrans %}"><i class="fa fa-pencil-alt"></i></a>&nbsp;
       <a href="{{ url_for('.alias_delete', alias=alias.email) }}" title="{% trans %}Delete{% endtrans %}"><i class="fa fa-trash"></i></a>
     </td>
     <td>{{ alias }}</td>

--- a/core/admin/mailu/ui/templates/fetch/list.html
+++ b/core/admin/mailu/ui/templates/fetch/list.html
@@ -30,7 +30,7 @@
   {%- for fetch in user.fetches %}
   <tr>
     <td>
-      <a href="{{ url_for('.fetch_edit', fetch_id=fetch.id) }}" title="{% trans %}Edit{% endtrans %}"><i class="fa fa-pencil"></i></a>&nbsp;
+      <a href="{{ url_for('.fetch_edit', fetch_id=fetch.id) }}" title="{% trans %}Edit{% endtrans %}"><i class="fa fa-pencil-alt"></i></a>&nbsp;
       <a href="{{ url_for('.fetch_delete', fetch_id=fetch.id) }}" title="{% trans %}Delete{% endtrans %}"><i class="fa fa-trash"></i></a>
     </td>
     <td>{{ fetch.protocol }}{{ 's' if fetch.tls else '' }}://{{ fetch.host }}:{{ fetch.port }}</td>

--- a/core/admin/mailu/ui/templates/relay/list.html
+++ b/core/admin/mailu/ui/templates/relay/list.html
@@ -26,7 +26,7 @@
   {%- for relay in relays %}
   <tr>
     <td>
-      <a href="{{ url_for('.relay_edit', relay_name=relay.name) }}" title="{% trans %}Edit{% endtrans %}"><i class="fa fa-pencil"></i></a>&nbsp;
+      <a href="{{ url_for('.relay_edit', relay_name=relay.name) }}" title="{% trans %}Edit{% endtrans %}"><i class="fa fa-pencil-alt"></i></a>&nbsp;
       <a href="{{ url_for('.relay_delete', relay_name=relay.name) }}" title="{% trans %}Delete{% endtrans %}"><i class="fa fa-trash"></i></a>&nbsp;
     </td>
     <td>{{ relay.name }}</td>

--- a/towncrier/newsfragments/2093.fix
+++ b/towncrier/newsfragments/2093.fix
@@ -1,0 +1,1 @@
+Alias, relay and fetchmail lists in the admin interface were missing the edit button.


### PR DESCRIPTION
## What type of PR?

bug fix

## What does this PR do?
With the upgrade to the new AdminLTE version, we forgot to update a couple classes from fa-pencil to fa-pencil-alt. As a result the edit button was missing in a couple of list views:
- Alias
- Fetched accounts 
- Relayed domains

### Related issue(s)
- closes #2093 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] n/a - In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
