### PR TITLE
The DB_PORT and ROUNDCUBE_DB_PORT env vars were not used

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -248,8 +248,7 @@ Database settings
 The admin service stores configurations in a database.
 
 - ``DB_FLAVOR``: the database type for mailu admin service. (``sqlite``, ``postgresql``, ``mysql``)
-- ``DB_HOST``: the database host for mailu admin service. (when not ``sqlite``)
-- ``DB_PORT``: the database port for mailu admin service. (when not ``sqlite``)
+- ``DB_HOST``: the database host for mailu admin service. For non-default ports use the notation `host:port`. (when not ``sqlite``)
 - ``DB_PW``: the database password for mailu admin service. (when not ``sqlite``)
 - ``DB_USER``: the database user for mailu admin service. (when not ``sqlite``)
 - ``DB_NAME``: the database name for mailu admin service. (when not ``sqlite``)
@@ -257,8 +256,7 @@ The admin service stores configurations in a database.
 The roundcube service stores configurations in a database.
 
 - ``ROUNDCUBE_DB_FLAVOR``: the database type for roundcube service. (``sqlite``, ``postgresql``, ``mysql``)
-- ``ROUNDCUBE_DB_HOST``: the database host for roundcube service. (when not ``sqlite``)
-- ``ROUNDCUBE_DB_PORT``: the database port for roundcube service. (when not ``sqlite``)
+- ``ROUNDCUBE_DB_HOST``: the database host for roundcube service. For non-default ports use the notation `host:port`. (when not ``sqlite``)
 - ``ROUNDCUBE_DB_PW``: the database password for roundcube service. (when not ``sqlite``)
 - ``ROUNDCUBE_DB_USER``: the database user for roundcube service. (when not ``sqlite``)
 - ``ROUNDCUBE_DB_NAME``: the database name for roundcube service. (when not ``sqlite``)

--- a/setup/templates/steps/database.html
+++ b/setup/templates/steps/database.html
@@ -14,7 +14,7 @@
 		<input class="form-control" type="text" name="db_user" placeholder="Username" id="db_user">
 		<label>Db Password</label>
 		<input class="form-control" type="password" name="db_pw" placeholder="Password" id="db_pw">
-		<label>Db URL</label>
+		<label>Db URL (for using a different port use the notation host:port )</label>
 		<input class="form-control" type="text" name="db_url" placeholder="URL" id="db_url">
 		<label>Db Name</label>
 		<input class="form-control" type="text" name="db_name" placeholder="Database Name" id="db_name">
@@ -33,7 +33,7 @@
 				<input class="form-control" type="text" name="roundcube_db_user" placeholder="Username" id="roundcube_db_user">
 				<label>DB Password</label>
 				<input class="form-control" type="password" name="roundcube_db_pw" placeholder="Password" id="roundcube_db_pw">
-				<label>DB URL</label>
+				<label>DB URL (for using a different port use the notation host:port )</label>
 				<input class="form-control" type="text" name="roundcube_db_url" placeholder="URL" id="roundcube_db_url">
 				<label>DB Name</label>
 				<input class="form-control" type="text" name="roundcube_db_name" placeholder="Database Name" id="roundcube_db_name">

--- a/towncrier/newsfragments/2073.bugfix
+++ b/towncrier/newsfragments/2073.bugfix
@@ -1,0 +1,1 @@
+The DB_PORT and ROUNDCUBE_DB_PORT environment variables were not actually used. They are removed from the documentation. For using different ports you can already use the notation host:port .


### PR DESCRIPTION
## What type of PR?

Bug fix

## What does this PR do?
The DB_PORT and ROUNDCUBE_DB_PORT env vars were not used and are not required. 
This PR removes these not used environment variables from the documentation.
The documentation and setup utility are enhanced with instructions how to specify a different port for the database url.

### Related issue(s)
- See #2073


## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
