### PR TITLE
Remove weblate from documentation

### DIFF
--- a/docs/contributors/localization.rst
+++ b/docs/contributors/localization.rst
@@ -1,14 +1,7 @@
 I18N and L10N
 =============
 
-Using Weblate
--------------
-
-We are hosting our localization effort using Weblate.If you would like to contribute to the localization process, feel free to ask us to add a language then you can contribute to translations.
-
-The project : https://translate.tedomum.net/projects/mailu/admin/
-
 Using Poedit
 ------------
 
-If you prefer to work locally, Poedit is one of the best tools available out there. Feel free to commit on your own fork and pull request your translations.
+Poedit is one of the best translation editors available. Feel free to commit on your own fork and pull request your translations.


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?
See #1869. The weblate instance is not available anymore. Therefore this not available weblate instance should not be mentioned in the documentation anymore.

This PR removes it from the documentation

### Related issue(s)
- #1869

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

