### PR TITLE
Fix build dependencies pycares

### DIFF
--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -19,9 +19,10 @@ RUN pip3 install socrate==0.2.0
 RUN pip3 install "podop>0.2.5"
 
 # Image specific layers under this line
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev python3-dev
-RUN pip3 install --no-binary :all: postfix-mta-sts-resolver==1.0.1
-RUN apk del .build-deps gcc musl-dev python3-dev
+# Building pycares from source requires py3-wheel and libffi-dev packages
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev python3-dev py3-wheel libffi-dev \
+  && pip3 install --no-binary :all: postfix-mta-sts-resolver==1.0.1 \
+  && apk del .build-deps
 
 RUN apk add --no-cache postfix postfix-pcre cyrus-sasl-login rsyslog logrotate
 

--- a/towncrier/newsfragments/2106.fix
+++ b/towncrier/newsfragments/2106.fix
@@ -1,0 +1,1 @@
+Fix build dependencies postfix-mta-sts-resolver.


### PR DESCRIPTION
## What type of PR?

Fix missing build dependencies `postfix-mta-sts-resolver` for `pycares` which requires `py3-wheel` and `libffi-dev` packages.
Restore virtual build in single RUN line.

## What does this PR do?

### Related issue(s)
- Mention an issue like: #2106
- Auto close an issue like: closes #2106