### PR TITLE
fix 2114: redirect old path

### DIFF
--- a/core/admin/mailu/ui/views/base.py
+++ b/core/admin/mailu/ui/views/base.py
@@ -11,6 +11,10 @@ import flask_login
 def index():
     return flask.redirect(flask.url_for('.user_settings'))
 
+@ui.route('/ui/')
+def redirect_old_path():
+    return flask.redirect(flask.url_for('.index'), code=301)
+
 @ui.route('/announcement', methods=['GET', 'POST'])
 @access.global_admin
 def announcement():


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Old paths may still be cached in browsers, it's easy enough to redirect them

### Related issue(s)
- close #2114
