### PR TITLE
Fix #2117. Gpg-agent package was missing for roundcube image.

### DIFF
--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,7 +15,7 @@ Quite a lot of new features have been implemented. Of these new features we'd li
 Security
 ^^^^^^^^
 
-A far amount of work went in this release; In no particular order:
+A fair amount of work went in this release; In no particular order:
 
 - outbound SMTP connections from Mailu are now enjoying some protection against active attackers thanks to DANE and MTA-STS support. Specific policies can be configured for specific destinations thanks to ``tls_policy_maps`` and configuring your system to publish a policy has been documented in the FAQ.
 - outbound emails can now be rate-limited (to mitigate SPAM in case an account is taken over)

--- a/towncrier/newsfragments/2117.bugfix
+++ b/towncrier/newsfragments/2117.bugfix
@@ -1,0 +1,3 @@
+The gpg-agent package was missing due to updating to a new debian version.
+This fix adds gpg-agent back to the roundcube image.
+It is used for the enigmail roundcube plugin.

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -17,7 +17,7 @@ RUN set -eu \
  && echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections \
  && apt install -y --no-install-recommends \
       python3 curl python3-pip git python3-multidict \
-      python3-jinja2 gpg tzdata \
+      python3-jinja2 gpg gpg-agent tzdata \
  && pip3 install socrate \
  && echo date.timezone=UTC > /usr/local/etc/php/conf.d/timezone.ini \
  && echo "ServerSignature Off\nServerName roundcube" >> /etc/apache2/apache2.conf \


### PR DESCRIPTION
## What type of PR?

Bug fix

## What does this PR do?
In the past gpg-agent was installed as dependency of gpg for the roundcube image.
The packages gpg and gpgagent are used by the enigmail plugin in roundcube. This plugin is one of the default plugins for roundcube.
After updating to a newer php (debian) image in 1.9, gpg-agent is not installed anymore together with gpg. I suspect this was changed in a newer debian version.

The fix has already been confirmed by the issue reporter. See #2117.

### Related issue(s)
- closes #2117 


## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
