### PR TITLE
fix keyError WEBMAIL_ADDRESS

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -63,6 +63,7 @@ DEFAULT_CONFIG = {
     'WEB_ADMIN': '/admin',
     'WEB_WEBMAIL': '/webmail',
     'WEBMAIL': 'none',
+    'WEBMAIL_ADDRESS': None,
     'RECAPTCHA_PUBLIC_KEY': '',
     'RECAPTCHA_PRIVATE_KEY': '',
     'LOGO_URL': None,


### PR DESCRIPTION
## What type of PR?
bugfix WEBMAIL_ADDRESS not initialized in admin/mailu/configuration.py, leading to lot of errors in log.

## What does this PR do?
Initialize 'WEBMAIL_ADDRESS' to None in the admin configuration

### Related issue(s)
- closes #2125

## Prerequisites
None