### PR TITLE
Fix 2125: Make the caller responsible to know whether the rate-limit code should be called or not

### DIFF
--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -31,6 +31,7 @@ def nginx_authentication():
     for key, value in headers.items():
         response.headers[key] = str(value)
     is_valid_user = False
+    is_from_webmail = headers['Auth-Port'] in ['10143', '10025']
     if response.headers.get("Auth-User-Exists"):
         username = response.headers["Auth-User"]
         if utils.limiter.should_rate_limit_user(username, client_ip):
@@ -47,7 +48,7 @@ def nginx_authentication():
         utils.limiter.exempt_ip_from_ratelimits(client_ip)
     elif is_valid_user:
         utils.limiter.rate_limit_user(username, client_ip)
-    else:
+    elif not is_from_webmail:
         utils.limiter.rate_limit_ip(client_ip)
     return response
 

--- a/core/admin/mailu/limiter.py
+++ b/core/admin/mailu/limiter.py
@@ -53,11 +53,10 @@ class LimitWraperFactory(object):
         return is_rate_limited
 
     def rate_limit_ip(self, ip):
-        if ip != app.config['WEBMAIL_ADDRESS']:
-            limiter = self.get_limiter(app.config["AUTH_RATELIMIT_IP"], 'auth-ip')
-            client_network = utils.extract_network_from_ip(ip)
-            if self.is_subject_to_rate_limits(ip):
-                limiter.hit(client_network)
+        limiter = self.get_limiter(app.config["AUTH_RATELIMIT_IP"], 'auth-ip')
+        client_network = utils.extract_network_from_ip(ip)
+        if self.is_subject_to_rate_limits(ip):
+            limiter.hit(client_network)
 
     def should_rate_limit_user(self, username, ip, device_cookie=None, device_cookie_name=None):
         limiter = self.get_limiter(app.config["AUTH_RATELIMIT_USER"], 'auth-user')

--- a/towncrier/newsfragments/2125.bugfix
+++ b/towncrier/newsfragments/2125.bugfix
@@ -1,0 +1,1 @@
+Fix a bug preventing mailu from being usable when no webmail is configured


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Make the caller responsible to know whether the rate-limit code should be called or not. If the webmail isn't configured its address can't be determined.

The rate limiting code should always be called except when we are verifying temporary tokens from the webmail.

### Related issue(s)
- close #2125 
- close #2129 
- close #2128

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
