### PR TITLE
Fixes #2131 - Carddav synchronization issue

### DIFF
--- a/webmails/rainloop/Dockerfile
+++ b/webmails/rainloop/Dockerfile
@@ -32,7 +32,7 @@ RUN apk add --no-cache \
 #     php7-pdo_sqlite Access to SQLite 3 databases
 RUN apk add --no-cache \
     nginx \
-    php7 php7-fpm php7-curl php7-iconv php7-json php7-xml php7-dom php7-openssl php7-pdo php7-pdo_sqlite \
+    php7 php7-fpm php7-curl php7-iconv php7-json php7-xml php7-simplexml php7-dom php7-openssl php7-pdo php7-pdo_sqlite \
  && rm /etc/nginx/http.d/default.conf \
  && rm /etc/php7/php-fpm.d/www.conf \
  && mkdir -p /run/nginx \


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
Adds php support for `simplexml` extension which is apparently needed by rainloop to handle carddav synchronizations.

### Related issue(s)
- closes #2131

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
