### PR TITLE
update roundcube to 1.5.2 (security fix)

### DIFF
--- a/towncrier/newsfragments/2141.bugfix
+++ b/towncrier/newsfragments/2141.bugfix
@@ -1,0 +1,1 @@
+Update roundcube to 1.5.2 to fixe an XSS

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -39,7 +39,7 @@ RUN set -eu \
  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
  && rm -rf /var/lib/apt/lists
 
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.5.1/roundcubemail-1.5.1-complete.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.5.2/roundcubemail-1.5.2-complete.tar.gz
 ENV CARDDAV_URL https://github.com/mstilkerich/rcmcarddav/releases/download/v4.3.0/carddav-v4.3.0.tar.gz
 
 RUN set -eu \


### PR DESCRIPTION
New roundcube release (1.5.2) where a XSS is addressed: https://roundcube.net/news/2021/12/30/update-1.5.2-released

## What type of PR?
security fix

## What does this PR do?
Update roundcube from 1.5.1 to 1.5.2
This update fixes an XSS: https://roundcube.net/news/2021/12/30/update-1.5.2-released

### Related issue(s)
None

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
