### PR TITLE
Address sender restrictions to avoid forged mail

### DIFF
--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -9,6 +9,7 @@ smtp      inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_discard_ehlo_keywords=pipelining
   -o smtpd_client_restrictions=$check_ratelimit,reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit
+  -o smtpd_sender_restrictions=reject_unlisted_sender,reject_unknown_sender_domain,reject_unverified_sender,reject_unauthenticated_sender_login_mismatch,reject_non_fqdn_sender
   -o smtpd_reject_unlisted_recipient={% if REJECT_UNLISTED_RECIPIENT %}{{ REJECT_UNLISTED_RECIPIENT }}{% else %}no{% endif %}
   -o cleanup_service_name=outclean
 outclean  unix n       -       n       -       0       cleanup

--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -3,13 +3,13 @@
 
 # Exposed SMTP service
 smtp      inet  n       -       n       -       -       smtpd
+  -o smtpd_sender_restrictions=reject_unlisted_sender,reject_unknown_sender_domain,reject_unauthenticated_sender_login_mismatch,reject_non_fqdn_sender
 
 # Internal SMTP service
 10025     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_discard_ehlo_keywords=pipelining
   -o smtpd_client_restrictions=$check_ratelimit,reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit
-  -o smtpd_sender_restrictions=reject_unlisted_sender,reject_unknown_sender_domain,reject_unauthenticated_sender_login_mismatch,reject_non_fqdn_sender
   -o smtpd_reject_unlisted_recipient={% if REJECT_UNLISTED_RECIPIENT %}{{ REJECT_UNLISTED_RECIPIENT }}{% else %}no{% endif %}
   -o cleanup_service_name=outclean
 outclean  unix n       -       n       -       0       cleanup

--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -9,7 +9,7 @@ smtp      inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_discard_ehlo_keywords=pipelining
   -o smtpd_client_restrictions=$check_ratelimit,reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit
-  -o smtpd_sender_restrictions=reject_unlisted_sender,reject_unknown_sender_domain,reject_unverified_sender,reject_unauthenticated_sender_login_mismatch,reject_non_fqdn_sender
+  -o smtpd_sender_restrictions=reject_unlisted_sender,reject_unknown_sender_domain,reject_unauthenticated_sender_login_mismatch,reject_non_fqdn_sender
   -o smtpd_reject_unlisted_recipient={% if REJECT_UNLISTED_RECIPIENT %}{{ REJECT_UNLISTED_RECIPIENT }}{% else %}no{% endif %}
   -o cleanup_service_name=outclean
 outclean  unix n       -       n       -       0       cleanup


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?
Add address sender restrictions to avoid forged mail.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
