### PR TITLE
disabled rsyslogd pidfile

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -85,7 +85,7 @@ if "RELAYUSER" in os.environ:
 
 # Configure and start local rsyslog server
 conf.jinja("/conf/rsyslog.conf", os.environ, "/etc/rsyslog.conf")
-os.system("/usr/sbin/rsyslogd -n &")
+os.system("/usr/sbin/rsyslogd -niNONE &")
 # Configure logrotate and start crond
 if os.environ["POSTFIX_LOG_FILE"] != "":
     conf.jinja("/conf/logrotate.conf", os.environ, "/etc/logrotate.d/postfix.conf")


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

The change disables the pidfile for rsyslog in the mailu/postfix container image. This fixes an issue where rsyslogd exits after `docker-compose up -d` / `docker-compose stop` / `docker-compose start` with
```
smtp_1      | rsyslogd: pidfile '/var/run/rsyslogd.pid' and pid 8 already exist.
smtp_1      | rsyslogd: run failed with error -3000 (see rsyslog.h or try https://www.rsyslog.com/e/3000 to learn what that number means)
```
due to a conflict with already existing pidfile.

### Related issue(s)

## Prerequisites
