### PR TITLE
resolve #1972 authentication using external proxy

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -68,6 +68,8 @@ DEFAULT_CONFIG = {
     'LOGO_URL': None,
     'LOGO_BACKGROUND': None,
     # Advanced settings
+    'PROXY_CREATE': False,
+    'PROXY_SECRET': None,
     'LOG_LEVEL': 'WARNING',
     'SESSION_KEY_BITS': 128,
     'SESSION_TIMEOUT': 3600,

--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -6,6 +6,7 @@ from mailu.ui import access
 from flask import current_app as app
 import flask
 import flask_login
+import secrets
 
 @sso.route('/login', methods=['GET', 'POST'])
 def login():
@@ -47,6 +48,81 @@ def login():
             flask.current_app.logger.warn(f'Login failed for {username} from {client_ip}.')
             flask.flash('Wrong e-mail or password', 'error')
     return flask.render_template('login.html', form=form, fields=fields)
+
+@sso.route('/proxy', methods=['GET'])
+def proxy():
+    client_ip = flask.request.headers.get('X-Real-IP', flask.request.remote_addr)
+    username=flask.request.headers.get('X-Auth-Email') or ""
+    secret=flask.request.headers.get('X-Auth-Proxy-Secret') or ""
+    target=flask.request.headers.get('X-Auth-Proxy-Target') or ""
+    tokens=username.split("@")
+    domain_name=""
+    if (len(tokens)==2):
+        domain_name=tokens[1]
+        localpart=tokens[0]
+    domain = models.Domain.query.get(domain_name)
+    if not domain or domain=="None":
+        return flask.redirect(flask.url_for('.login'))
+
+    form = forms.LoginForm()
+    form.submitAdmin.label.text = form.submitAdmin.label.text + ' Admin'
+    form.submitWebmail.label.text = form.submitWebmail.label.text + ' Webmail'
+
+    fields = []
+    if str(app.config["WEBMAIL"]).upper() != "NONE":
+        fields.append(form.submitWebmail)
+    if str(app.config["ADMIN"]).upper() != "FALSE":
+        fields.append(form.submitAdmin)
+    fields = [fields]
+
+    if str(target).upper()=="ADMIN":
+        destination = "0; url="+ app.config['WEB_ADMIN']
+    else:
+        destination = "0; url="+ app.config['WEB_WEBMAIL']
+
+    payload_dict = {
+        'Refresh': destination
+    }
+
+    device_cookie, device_cookie_username = utils.limiter.parse_device_cookie(flask.request.cookies.get('rate_limit'))
+    if username != device_cookie_username and utils.limiter.should_rate_limit_ip(client_ip):
+        flask.flash('Too many attempts from your IP (rate-limit)', 'error')
+        return flask.render_template('login.html', form=form, fields=fields)
+    if utils.limiter.should_rate_limit_user(username, client_ip, device_cookie, device_cookie_username):
+        flask.flash('Too many attempts for this user (rate-limit)', 'error')
+        return flask.render_template('login.html', form=form, fields=fields)
+
+    if not (app.config['PROXY_SECRET'] in (None, '') or not app.config['PROXY_SECRET']) and app.config['PROXY_SECRET'] == secret and username != "":
+        user = models.User.get(flask.request.headers.get('X-Auth-Email'))
+        if user:
+            flask.session.regenerate()
+            flask_login.login_user(user)
+            return flask.render_template('login.html', form=form, fields=fields), payload_dict
+        else:
+            if app.config['PROXY_CREATE']:
+                if domain.has_email(localpart):
+                    flask.flash('Email is already used', 'error')
+                    return flask.redirect(flask.url_for('.login'))
+                else:
+                    #Create a user
+                    user = models.User(
+                        localpart=localpart,
+                        domain=domain,
+                        global_admin=False
+                    )
+                    user.set_password(secrets.token_urlsafe(32))
+                    models.db.session.add(user)
+                    models.db.session.commit()
+                    user.send_welcome()
+                    flask.session.regenerate()
+                    flask_login.login_user(user)
+                    flask.current_app.logger.info(f'Login succeeded by proxy created user: {username} from {client_ip}.')
+                    return flask.render_template('login.html', form=form, fields=fields), payload_dict
+            else:
+                utils.limiter.rate_limit_user(username, client_ip, device_cookie, device_cookie_username) if models.User.get(username) else utils.limiter.rate_limit_ip(client_ip)
+                flask.current_app.logger.warn(f'Login failed by proxy for {username} from {client_ip}.')
+                flask.flash('Auth by proxy failed - try to login by credentials', 'error')
+    return flask.redirect(flask.url_for('.login'))
 
 @sso.route('/logout', methods=['GET'])
 @access.authenticated


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

This PR enables header authentication on frontends. A proxy sends the username in a header (X-Auth-Email) to the backend server, which logs in the user without requesting a password or login action.

Therefore 2 Headers need to be set by proxy:
X-Auth-Proxy-Secret
X-Auth-Email

I m using openresty so the lines would look like:
```
ngx.req.set_header("X-Auth-Proxy-Secret", "aa0111f948a1cb2a947137e56922cb68") 
ngx.req.set_header("X-Auth-Email", res.id_token.email)
ngx.req.set_header("X-Auth-Proxy-Target", "Admin")  # optional
```
The third header is optional, its possible to choose the target after successful proxy login. Start at admin interface or webmail.

You need to add to values in mailu.env
```
PROXY_SECRET=aa0111f948a1cb2a947137e56922cb68
PROXY_CREATE=True 
```
The secret is the same as used by proxy. It substitutes user credentials and has to be kept secret.
With the second value you can decide what happens if the user is not found. User can be created automatically if it does not exist (The username must specify a user form a domain used by mailu instance) 

Now there is a new route `/sso/proxy`. If called and the proxy credentials are correct the user gets logged in. Its possible to set `WEBROOT_REDIRECT=/sso/proxy`  to enable auto login.

Thats it.
 
### Related issue(s)
- Auto close an issue like: closes #1972 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
