### PR TITLE
Update nginx-rainloop.conf

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -84,7 +84,7 @@ http {
       {% if WEBDAV_ADDRESS %}
       set $webdav {{ WEBDAV_ADDRESS }};
       {% endif %}
-      {% if MESSAGE_SIZE_LIMIT == 0 %}
+      {% if MESSAGE_SIZE_LIMIT|int == 0 %}
       client_max_body_size 0;
       {% else %}
       client_max_body_size {{ MESSAGE_SIZE_LIMIT|int + 8388608 }};

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -84,7 +84,11 @@ http {
       {% if WEBDAV_ADDRESS %}
       set $webdav {{ WEBDAV_ADDRESS }};
       {% endif %}
+      {% if MESSAGE_SIZE_LIMIT == 0 %}
+      client_max_body_size 0;
+      {% else %}
       client_max_body_size {{ MESSAGE_SIZE_LIMIT|int + 8388608 }};
+      {% endif %}
 
       # Listen on HTTP only in kubernetes or behind reverse proxy
       {% if KUBERNETES_INGRESS == 'true' or TLS_FLAVOR in [ 'mail-letsencrypt', 'notls', 'mail' ] %}

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,6 +69,8 @@ The ``MESSAGE_SIZE_LIMIT`` is the maximum size of a single email. It should not
 be too low to avoid dropping legitimate emails and should not be too high to
 avoid filling the disks with large junk emails.
 
+.. note:: Albeit ``MESSAGE_SIZE_LIMIT=0`` (no limit) is possible technically, this likely won't be the case for your external recipients. Use with care.
+
 The ``MESSAGE_RATELIMIT`` (default: 200/day) is the maximum number of messages
 a single user can send. ``MESSAGE_RATELIMIT_EXEMPTION`` contains a comma delimited
 list of user email addresses that are exempted from any restriction.  Those

--- a/towncrier/newsfragments/2187.bugfix
+++ b/towncrier/newsfragments/2187.bugfix
@@ -1,3 +1,4 @@
-added missing `client_max_body_size 0;` in server directive of webmail rainloop
+added missing `client_max_body_size 0;` in rainloop nginx server directive of webmail rainloop
+added bugfix for client_max_body_size in front nginx conf when `MESSAGE_SIZE_LIMIT=0`
 - closes #2149
 - closes #2186

--- a/towncrier/newsfragments/2187.bugfix
+++ b/towncrier/newsfragments/2187.bugfix
@@ -1,0 +1,3 @@
+added missing `client_max_body_size 0;` in server directive of webmail rainloop
+- closes #2149
+- closes #2186

--- a/towncrier/newsfragments/2187.doc
+++ b/towncrier/newsfragments/2187.doc
@@ -1,0 +1,1 @@
+note and warning on the use of `MESSAGE_SIZE_LIMIT=0` in configuration

--- a/webmails/rainloop/config/nginx-rainloop.conf
+++ b/webmails/rainloop/config/nginx-rainloop.conf
@@ -11,6 +11,7 @@ server {
     error_log /dev/stderr warn;
 
     index index.php;
+    client_max_body_size 0;
 
     location / {
         try_files $uri /index.php?$query_string;


### PR DESCRIPTION
added missing `client_max_body_size 0;` in server directive

## What type of PR?
bug-fix

## What does this PR do?

### Related issue(s)
- closes #2186

## Prerequisites
- none; tested and working