### PR TITLE
Update main.cf

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -105,6 +105,7 @@ smtpd_sender_login_maps = ${podop}senderlogin
 
 # Restrictions for incoming SMTP, other restrictions are applied in master.cf
 smtpd_helo_required = yes
+smtp_helo_name = $mydomain
 
 check_ratelimit = check_sasl_access ${podop}senderrate
 


### PR DESCRIPTION
added `smtp_helo_name = $mydomain` to improve the _SpamAssassin thinks you can improve_ section `-0.001		SPF_HELO_NONE		SPF: HELO does not publish an SPF Record`
this was tested and the score is now `0.001		SPF_HELO_PASS		SPF: HELO matches SPF record`

## What type of PR?
enhancement

## What does this PR do?

### Related issue(s)
- closes #2188 

## Prerequisites
none that i can think of. it just works