### PR TITLE
Create 2187.bugfix

### DIFF
--- a/towncrier/newsfragments/2187.bugfix
+++ b/towncrier/newsfragments/2187.bugfix
@@ -1,0 +1,1 @@
+added missing client_max_body_size 0; in server directive


### PR DESCRIPTION
added missing client_max_body_size 0; in server directive

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
- closes #2187

