### PR TITLE
Update php.ini

### DIFF
--- a/towncrier/newsfragments/2193.bugfix
+++ b/towncrier/newsfragments/2193.bugfix
@@ -1,0 +1,1 @@
+matching rainloop php to roundcube's: timezone is a parameter in mailu.env

--- a/webmails/rainloop/defaults/php.ini
+++ b/webmails/rainloop/defaults/php.ini
@@ -1,5 +1,5 @@
 expose_php=Off
-date.timezone=UTC
+date.timezone={{ TZ }}
 upload_max_filesize = {{ MAX_FILESIZE }}M
 post_max_size = {{ MAX_FILESIZE }}M
 


### PR DESCRIPTION
matching rainloop php to roundcube's: timezone is a parameter in mailu.env

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
- none
