### PR TITLE
roundcube: Add /overrides directory in include

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -267,6 +267,7 @@ correct syntax. The following file names will be taken as override configuration
 - `Dovecot`_ - ``dovecot.conf`` in dovecot sub-directory;
 - `Nginx`_ - All ``*.conf`` files in the ``nginx`` sub-directory;
 - `Rspamd`_ - All files in the ``rspamd`` sub-directory.
+- Roundcube - All ``*.inc`` files in the ``roundcube`` sub directory.
 
 To override the root location (``/``) in Nginx ``WEBROOT_REDIRECT`` needs to be set to ``none`` in the env file (see :ref:`web settings <web_settings>`).
 

--- a/towncrier/newsfragments/2195.bugfix
+++ b/towncrier/newsfragments/2195.bugfix
@@ -1,0 +1,1 @@
+Added the /overrides directory in the roundcube config.inc.php file

--- a/webmails/roundcube/config.inc.php
+++ b/webmails/roundcube/config.inc.php
@@ -61,6 +61,6 @@ $config['mdn_use_from'] = true;
 
 // includes
 {%- for inc in INCLUDES %}
-include('{{ inc }}');
+include('/overrides/{{ inc }}');
 {%- endfor %}
 


### PR DESCRIPTION
Added the /overrides directory in the roundcube config.inc.php file

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
none