### PR TITLE
roundcube-carddav : Use des_key for pwstore_scheme 

### DIFF
--- a/towncrier/newsfragments/2196.bugfix
+++ b/towncrier/newsfragments/2196.bugfix
@@ -1,0 +1,2 @@
+Configuring pwstore_scheme in carddav plugin with des_key because Mailu is incompatible with encrypted
+https://github.com/mstilkerich/rcmcarddav/blob/master/doc/ADMIN-SETTINGS.md#password-storing-scheme

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -66,6 +66,7 @@ COPY mailu.php /var/www/html/plugins/mailu/mailu.php
 COPY php.ini /
 COPY config.inc.php /
 COPY start.py /
+COPY config.inc.carddav.php /var/www/html/plugins/carddav/config.inc.php
 
 EXPOSE 80/tcp
 VOLUME /data

--- a/webmails/roundcube/config.inc.carddav.php
+++ b/webmails/roundcube/config.inc.carddav.php
@@ -1,0 +1,5 @@
+<?php
+
+// Scheme for storing the CardDAV passwords, in order from least to best security.
+// Options: plain, base64, des_key, encrypted (default)
+$prefs['_GLOBAL']['pwstore_scheme'] = 'des_key';


### PR DESCRIPTION
roundcube-carddav: Configuring pwstore_scheme in carddav plugin with des_key because Mailu is incompatible with encrypted

https://github.com/mstilkerich/rcmcarddav/blob/master/doc/ADMIN-SETTINGS.md#password-storing-scheme

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
- closes #2230