### PR TITLE
Update nginx.conf

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -103,7 +103,7 @@ http {
       ssl_session_cache shared:SSLHTTP:50m;
       add_header Strict-Transport-Security 'max-age=31536000';
 
-      {% if not TLS_FLAVOR in [ 'mail', 'mail-letsencrypt' ] %}
+      {% if not TLS_FLAVOR in [ 'mail', 'mail-letsencrypt', 'notls' ] %}
       if ($proxy_x_forwarded_proto = http) {
         return 301 https://$host$request_uri;
       }
@@ -127,7 +127,7 @@ http {
       {% endif %}
 
       # If TLS is failing, prevent access to anything except certbot
-      {% if KUBERNETES_INGRESS != 'true' and TLS_ERROR and not (TLS_FLAVOR in [ 'mail-letsencrypt', 'mail' ]) %}
+      {% if KUBERNETES_INGRESS != 'true' and TLS_ERROR and not (TLS_FLAVOR in [ 'mail-letsencrypt', 'mail', 'notls' ]) %}
       location / {
         return 403;
       }

--- a/towncrier/newsfragments/2204.bugfix
+++ b/towncrier/newsfragments/2204.bugfix
@@ -1,0 +1,1 @@
+`notls` was missing from the exclusions to redirect 403 or https


### PR DESCRIPTION
`notls` was missing from the exclusions to redirect 403 or https

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
- closes #2204

## Prerequisites
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
