### PR TITLE
Ensure we use IMAP IDLE like it's supposed to work

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -100,6 +100,7 @@ service auth-worker {
 protocol imap {
   mail_plugins = $mail_plugins imap_quota imap_sieve
   mail_max_userip_connections = 20
+  imap_idle_notify_interval = 29 mins
 }
 
 protocol pop3 {

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -100,7 +100,7 @@ service auth-worker {
 protocol imap {
   mail_plugins = $mail_plugins imap_quota imap_sieve
   mail_max_userip_connections = 20
-  imap_idle_notify_interval = 29 mins
+  imap_idle_notify_interval = 29mins
 }
 
 protocol pop3 {

--- a/towncrier/newsfragments/2211.misc
+++ b/towncrier/newsfragments/2211.misc
@@ -1,0 +1,1 @@
+Set imap_idle_notify_interval to 29 mins (see rfc2177) to ensure we use IMAP IDLE effectively


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Increase IMAP IDLE time from 2min to 29mins: this should massively help reduce network traffic & increase battery life of clients

See https://peterkieser.com/2011/03/25/androids-k-9-mail-battery-life-and-dovecots-push-imap/

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
