### PR TITLE
Fix broken setup. Not all dependencies were pinned. As usual a depend…

### DIFF
--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -2,3 +2,11 @@ Flask==1.0.2
 Flask-Bootstrap==3.3.7.1
 gunicorn==19.9.0
 redis==3.2.1
+Jinja2==3.0.3
+MarkupSafe==2.1.0
+Werkzeug==2.0.3
+click==8.0.3
+dominate==2.6.0
+itsdangerous==2.0.1
+redis==3.2.1
+visitor==0.1.3

--- a/towncrier/newsfragments/2249.bugfix
+++ b/towncrier/newsfragments/2249.bugfix
@@ -1,0 +1,1 @@
+Fix broken setup. Not all dependencies were pinned resulting in a broken update being pulled.


### PR DESCRIPTION
…ency had a breaking update.

## What type of PR?

bug-fix

## What does this PR do?
The dependencies pulled in by the python packages required for setup were not pinned. Unfortunately one of the dependencies had a breaking update. This PR also pins all dependencies to the last working version.

### Related issue(s)
- closes #2249 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
