### PR TITLE
Add support for native mail replication

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -56,6 +56,8 @@ DEFAULT_CONFIG = {
     'MESSAGE_RATELIMIT': '200/day',
     'MESSAGE_RATELIMIT_EXEMPTION': '',
     'RECIPIENT_DELIMITER': '',
+    'REPLICATION': False,
+    'REPLICATION_TARGET': '',
     # Web settings
     'SITENAME': 'Mailu',
     'WEBSITE': 'https://mailu.io',
@@ -86,6 +88,7 @@ DEFAULT_CONFIG = {
     'HOST_WEBDAV': 'webdav:5232',
     'HOST_REDIS': 'redis',
     'HOST_FRONT': 'front',
+    'HOST_DSYNC': None,
     'SUBNET': '192.168.203.0/24',
     'SUBNET6': None,
     'POD_ADDRESS_RANGE': None
@@ -116,6 +119,8 @@ class ConfigManager:
             self.config[f'{key}_ADDRESS'] = self.get_host_address(key)
         if self.config['WEBMAIL'] != 'none':
             self.config['WEBMAIL_ADDRESS'] = self.get_host_address('WEBMAIL')
+        if self.config['REPLICATION'] and self.config['REPLICATION_TARGET'].startswith('tcp:'):
+            self.config['HOST_DSYNC'] = system.resolve_address(self.config['REPLICATION_TARGET'].split(":")[1])
 
     def __get_env(self, key, value):
         key_file = key + "_FILE"

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -15,6 +15,9 @@ def dovecot_passdb_dict(user_email):
         allow_nets.append(app.config["SUBNET6"])
     if app.config["POD_ADDRESS_RANGE"]:
         allow_nets.append(app.config["POD_ADDRESS_RANGE"])
+    if app.config["HOST_DSYNC"]:
+        allow_nets.append("local")
+        allow_nets.append(app.config["HOST_DSYNC"])
     return flask.jsonify({
         "password": None,
         "nopassword": "Y",

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -22,6 +22,13 @@ def dovecot_passdb_dict(user_email):
     })
 
 
+@internal.route("/dovecot/userdb/")
+def dovecot_userdb_dict_list():
+    return flask.jsonify([
+        user.email for user in models.User.query.all() if user.is_active
+    ])
+
+
 @internal.route("/dovecot/userdb/<path:user_email>")
 def dovecot_userdb_dict(user_email):
     user = models.User.query.get(user_email) or flask.abort(404)

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -25,7 +25,8 @@ def dovecot_passdb_dict(user_email):
 @internal.route("/dovecot/userdb/")
 def dovecot_userdb_dict_list():
     return flask.jsonify([
-        user.email for user in models.User.query.all() if user.is_active
+        user.email for user in models.User.query.all()
+            if user.enabled and (user.enable_imap or user.enable_pop)
     ])
 
 

--- a/core/dovecot/conf/auth.conf
+++ b/core/dovecot/conf/auth.conf
@@ -1,5 +1,5 @@
 uri = proxy:/tmp/podop.socket:auth
-iterate_disable = yes
+iterate_prefix = userdb/
 default_pass_scheme = plain
 password_key = passdb/%u
 user_key = userdb/%u

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -25,6 +25,9 @@ mail_plugins = $mail_plugins quota quota_clone{{ ' ' }}
   {%- if COMPRESSION -%}
   zlib{{ ' ' }}
   {%- endif %}
+  {%- if REPLICATION in ['on', 'true', '1'] -%}
+  notify replication{{ ' ' }}
+  {%- endif %}
   {%- if (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] -%}
   fts fts_xapian
   {%- endif %}
@@ -32,34 +35,35 @@ default_vsz_limit = 2GB
 
 namespace inbox {
   inbox = yes
-  {% for mailbox in ("Trash", "Drafts", "Sent", "Junk") %}
+  {%- for mailbox in ("Trash", "Drafts", "Sent", "Junk") %}
+
   mailbox {{ mailbox }} {
     auto = subscribe
     special_use = \{{ mailbox }}
   }
-  {% endfor %}
+  {%- endfor %}
 }
 
 plugin {
   quota = count:User quota
   quota_vsizes = yes
   quota_clone_dict = proxy:/tmp/podop.socket:quota
+  {%- if (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
 
-  {% if (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
   fts = xapian
   fts_xapian = partial=2 full=30
   fts_autoindex = yes
   fts_enforced = yes
   fts_autoindex_exclude = \Trash
-  {% endif %}
+  {%- endif %}
+  {%- if COMPRESSION in [ 'gz', 'bz2', 'lz4', 'zstd' ] %}
 
-  {% if COMPRESSION in [ 'gz', 'bz2', 'lz4', 'zstd' ] %}
   zlib_save = {{ COMPRESSION }}
-  {% endif %}
+  {%- endif %}
+  {%- if COMPRESSION_LEVEL %}
 
-  {% if COMPRESSION_LEVEL %}
   zlib_save_level = {{ COMPRESSION_LEVEL }}
-  {% endif %}
+  {%- endif %}
 }
 
 ###############
@@ -93,6 +97,59 @@ service auth-worker {
   }
   user = mail
 }
+{%- if REPLICATION in ['on', 'true', '1'] %}
+
+###############
+# Replication
+###############
+service replicator {
+  process_min_avail = 1
+  unix_listener replicator-doveadm {
+    user = mail
+    group = mail
+    mode = 0660
+  }
+}
+
+plugin {
+  mail_replica = {{ REPLICATION_TARGET }}
+}
+
+service aggregator {
+  fifo_listener replication-notify-fifo {
+    user = mail
+    group = mail
+    mode = 0660
+  }
+
+  unix_listener replication-notify {
+    user = mail
+    group = mail
+    mode = 0660
+  }
+}
+
+service doveadm {
+  inet_listener {
+    port = {{ REPLICATION_PORT }}
+  }
+}
+
+service stats {
+  unix_listener stats-writer {
+    user = mail
+    group = mail
+    mode = 0660
+  }
+}
+
+doveadm_password = {{ REPLICATION_SECRET }}
+doveadm_port = {{ REPLICATION_PORT }}
+
+replication_max_conns = 10
+replication_dsync_parameters = -d -n inbox -l 30 -U
+replication_full_sync_interval = 1 hour
+{%- endif %}
 
 ###############
 # IMAP & POP
@@ -176,5 +233,4 @@ plugin {
 ###############
 # Extensions
 ###############
-
 !include_try /overrides/dovecot.conf

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -105,6 +105,18 @@ COMPRESSION_LEVEL=
 # IMAP full-text search is enabled by default. Set the following variable to off in order to disable the feature.
 # FULL_TEXT_SEARCH=off
 
+# Mail Replication, default: none (set to on to enable the feature)
+# REPLICATION=on
+
+# Replication Target, default: none (required when enabled, value: tcp:<host>(:<port>))
+# REPLICATION_TARGET=
+
+# Replication Port, default: none (required when enabled, value: <tcp-port>)
+# REPLICATION_PORT=
+
+# Replication Shared Secret, default: none (required when enabled, value: <secret>)
+# REPLICATION_SECRET=
+
 ###################################
 # Web settings
 ###################################

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -119,6 +119,23 @@ the localpart for DMARC rua and ruf email addresses.
 Full-text search is enabled for IMAP is enabled by default. This feature can be disabled
 (e.g. for performance reasons) by setting the optional variable ``FULL_TEXT_SEARCH`` to ``off``.
 
+The `mail replication`_ feature in Dovecot is disabled by default. It can be enabled
+in a two-node Mailu setup by setting the optional variable ``REPLICATION`` to ``on``.
+
+.. _`mail replication`: https://doc.dovecot.org/configuration_manual/replication/
+
+The ``REPLICATION_TARGET`` is a mandatory setting when replication is enabled and
+points to the remote replication host in following format: ``tcp:HOST[:PORT]``.
+``Port`` defaults to ``REPLICATION_PORT`` when not specified.
+
+The ``REPLICATION_PORT`` is a mandatory setting when replication is enabled and
+defines the local listening port of the replicator. Don't forget to publish this
+container's port on both Mailu nodes to allow connectivity between them.
+
+The ``REPLICATION_SECRET`` is a mandatory setting when replication is enabled and
+defines the shared secret of the replicator. It must be identical on both Mailu
+nodes.
+
 .. _web_settings:
 
 Web settings

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -126,11 +126,11 @@ in a two-node Mailu setup by setting the optional variable ``REPLICATION`` to ``
 
 The ``REPLICATION_TARGET`` is a mandatory setting when replication is enabled and
 points to the remote replication host in following format: ``tcp:HOST[:PORT]``.
-``Port`` defaults to ``REPLICATION_PORT`` when not specified.
+The port defaults to ``REPLICATION_PORT`` when not specified.
 
 The ``REPLICATION_PORT`` is a mandatory setting when replication is enabled and
-defines the local listening port of the replicator. Don't forget to publish this
-container's port on both Mailu nodes to allow connectivity between them.
+defines the local listening port of the replicator. It is necessary to publish this
+port on both Mailu nodes to allow connectivity between them.
 
 The ``REPLICATION_SECRET`` is a mandatory setting when replication is enabled and
 defines the shared secret of the replicator. It must be identical on both Mailu

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -104,6 +104,18 @@ COMPRESSION_LEVEL={{ compression_level }}
 # IMAP full-text search is enabled by default. Set the following variable to off in order to disable the feature.
 # FULL_TEXT_SEARCH=off
 
+# Mail Replication, default: none (set to on to enable the feature)
+# REPLICATION=on
+
+# Replication Target, default: none (required when enabled, value: tcp:<host>(:<port>))
+# REPLICATION_TARGET=
+
+# Replication Port, default: none (required when enabled, value: <tcp-port>)
+# REPLICATION_PORT=
+
+# Replication Shared Secret, default: none (required when enabled, value: <secret>)
+# REPLICATION_SECRET=
+
 ###################################
 # Web settings
 ###################################


### PR DESCRIPTION
## What type of PR?

`Feature`

## What does this PR do?

Dovecot includes native support for active/active [mail replication](https://doc.dovecot.org/configuration_manual/replication/) using dsync, an supported alternative as opposed to unreliable network file system usage (NFS, GlusterFS). This change provides basic configuration support for mail replication.

Limitations:
- Excluding specific users from replication is currently not possible. While Dovecot provides the `noreplicate` userdb field for this, it would require both modification of the Mailu database schema and configuration support in the `Admin` UI.
- Only `TCP` replication is supported yet, replication via `SSH` is currently not in scope.
- Replication via `TCPS` (`TLS`) should be possible via override config (not tested), but only on a global level and would therefore affect all enabled Dovecot services (see linked document for further details). For now it is recommended to use `IPsec` & co on the network layer.
- No configuration support for `Setup` has been added so far.
- No tests have been added so far (do we need any?).

Dependencies:
- Mailu/Podop#9

Note that while the provided code works, there are probably better ways to express it.

## Prerequisites
- [X] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.