### PR TITLE
Prevent an exception from being thrown if the username isn't an email address

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -94,7 +94,7 @@ def handle_authentication(headers):
         else:
             try:
                 user = models.User.query.get(user_email) if '@' in user_email else None
-                is_valid_user = bool(user)
+                is_valid_user = user is not None
             except sqlalchemy.exc.StatementError as exc:
                 exc = str(exc).split('\n', 1)[0]
                 app.logger.warn(f'Invalid user {user_email!r}: {exc}')

--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -93,9 +93,8 @@ def handle_authentication(headers):
             app.logger.warn(f'Received undecodable user/password from nginx: {raw_user_email!r}/{raw_password!r}')
         else:
             try:
-                if '@' in user_email:
-                    user = models.User.query.get(user_email)
-                    is_valid_user = True
+                user = models.User.query.get(user_email) if '@' in user_email else None
+                is_valid_user = bool(user)
             except sqlalchemy.exc.StatementError as exc:
                 exc = str(exc).split('\n', 1)[0]
                 app.logger.warn(f'Invalid user {user_email!r}: {exc}')

--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -93,10 +93,9 @@ def handle_authentication(headers):
             app.logger.warn(f'Received undecodable user/password from nginx: {raw_user_email!r}/{raw_password!r}')
         else:
             try:
-                user = models.User.query.get(user_email)
-                is_valid_user = True
-            except ValueError:
-                pass
+                if '@' in user_email:
+                    user = models.User.query.get(user_email)
+                    is_valid_user = True
             except sqlalchemy.exc.StatementError as exc:
                 exc = str(exc).split('\n', 1)[0]
                 app.logger.warn(f'Invalid user {user_email!r}: {exc}')

--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -95,6 +95,8 @@ def handle_authentication(headers):
             try:
                 user = models.User.query.get(user_email)
                 is_valid_user = True
+            except ValueError:
+                pass
             except sqlalchemy.exc.StatementError as exc:
                 exc = str(exc).split('\n', 1)[0]
                 app.logger.warn(f'Invalid user {user_email!r}: {exc}')

--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -12,7 +12,7 @@ def nginx_authentication():
     """
     client_ip = flask.request.headers["Client-Ip"]
     headers = flask.request.headers
-    if headers["Auth-Port"] == '25' and headers['Auth-Method'] == 'plain':
+    if headers["Auth-Port"] == '25':
         response = flask.Response()
         response.headers['Auth-Status'] = 'AUTH not supported'
         response.headers['Auth-Error-Code'] = '502 5.5.1'

--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -159,9 +159,9 @@ def postfix_sender_rate(sender):
 def postfix_sender_access(sender):
     """ Simply reject any sender that pretends to be from a local domain
     """
-    if '@' in email:
-        if email.startswith('<') and email.endswith('>'):
-            email = email[1:-1]
+    if '@' in sender:
+        if sender.startswith('<') and sender.endswith('>'):
+            sender = sender[1:-1]
         try:
             localpart, domain_name = models.Email.resolve_domain(sender)
             if models.Domain.query.get(domain_name):

--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -159,20 +159,13 @@ def postfix_sender_rate(sender):
 def postfix_sender_access(sender):
     """ Simply reject any sender that pretends to be from a local domain
     """
-    try:
-        if not is_void_address(sender):
+    if '@' in email:
+        if email.startswith('<') and email.endswith('>'):
+            email = email[1:-1]
+        try:
             localpart, domain_name = models.Email.resolve_domain(sender)
-            return flask.jsonify("REJECT") if models.Domain.query.get(domain_name) else flask.abort(404)
-    except sqlalchemy.exc.StatementError:
-        pass
+            if models.Domain.query.get(domain_name):
+                return flask.jsonify("REJECT")
+        except sqlalchemy.exc.StatementError:
+            pass
     return flask.abort(404)
-
-
-def is_void_address(email):
-    '''True if the email is void (null) email address.
-    '''
-    if email.startswith('<') and email.endswith('>'):
-        email = email[1:-1]
-    # Some MTAs use things like '<MAILER-DAEMON>' instead of '<>'; so let's
-    # consider void any such thing.
-    return '@' not in email

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -636,7 +636,7 @@ in clear-text regardless of the presence of the cache.
     @classmethod
     def get(cls, email):
         """ find user object for email address """
-        '@' in email and return cls.query.get(email)
+        return cls.query.get(email)
 
     @classmethod
     def login(cls, email, password):

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -636,7 +636,7 @@ in clear-text regardless of the presence of the cache.
     @classmethod
     def get(cls, email):
         """ find user object for email address """
-        return cls.query.get(email)
+        '@' in email and return cls.query.get(email)
 
     @classmethod
     def login(cls, email, password):


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Mailu expects users to identify using an email address; some brute-force script don't send just an username and this leads to an exception... that makes the error message and return code vary.

This PR prevents the exceptions from being thrown in the first place

```
WARNING in nginx: Invalid user 'xxxx': (builtins.ValueError) invalid email address (no "@")"
```

### Related issue(s)
- closes #2261
- #1750