### PR TITLE
Update RainLoop application.ini

### DIFF
--- a/webmails/rainloop/defaults/application.ini
+++ b/webmails/rainloop/defaults/application.ini
@@ -15,5 +15,5 @@ custom_logout_link='/sso/logout'
 enable = On
 allow_sync = On
 
-[plugins]
+[defaults]
 contacts_autosave = On


### PR DESCRIPTION
`contacts_autosave` is part of `[defaults]`, not `[plugins]`