### PR TITLE
Fixed typo in Traefik reverse proxy docs

### DIFF
--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -187,7 +187,7 @@ Mailu must also be configured with the information what header is used by the re
 .. code-block:: docker
   
   #mailu.env file
-  REAL_IP_HEADER=X-Real-IP
+  REAL_IP_HEADER=X-Real-Ip
   REAL_IP_FROM=x.x.x.x,y.y.y.y.y
   #x.x.x.x,y.y.y.y.y is the static IP address your reverse proxy uses for connecting to Mailu. 
 


### PR DESCRIPTION
Slight typo in the Traefik reverse proxy docs. Found through running into the issue on my own instance.

## What type of PR?
Documentation
(Feature, enhancement, bug-fix, documentation)

## What does this PR do?
Fixes Typo in docs regarding using Traefik as a reverse proxy
### Related issue(s)
N/A

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
