### PR TITLE
Fixing AUTH_RATELIMIT_IP not working on imap/pop3/smtp

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -94,11 +94,11 @@ def handle_authentication(headers):
         else:
             try:
                 user = models.User.query.get(user_email) if '@' in user_email else None
-                is_valid_user = user is not None
             except sqlalchemy.exc.StatementError as exc:
                 exc = str(exc).split('\n', 1)[0]
                 app.logger.warn(f'Invalid user {user_email!r}: {exc}')
             else:
+                is_valid_user = user is not None
                 ip = urllib.parse.unquote(headers["Client-Ip"])
                 if check_credentials(user, password, ip, protocol, headers["Auth-Port"]):
                     server, port = get_server(headers["Auth-Protocol"], True)

--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -32,7 +32,7 @@ def nginx_authentication():
     for key, value in headers.items():
         response.headers[key] = str(value)
     is_valid_user = False
-    if response.headers.get("Auth-User-Exists")=="True":
+    if response.headers.get("Auth-User-Exists") == "True":
         username = response.headers["Auth-User"]
         if utils.limiter.should_rate_limit_user(username, client_ip):
             # FIXME could be done before handle_authentication()

--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -32,7 +32,7 @@ def nginx_authentication():
     for key, value in headers.items():
         response.headers[key] = str(value)
     is_valid_user = False
-    if response.headers.get("Auth-User-Exists"):
+    if response.headers.get("Auth-User-Exists")=="True":
         username = response.headers["Auth-User"]
         if utils.limiter.should_rate_limit_user(username, client_ip):
             # FIXME could be done before handle_authentication()

--- a/towncrier/newsfragments/2284.bugfix
+++ b/towncrier/newsfragments/2284.bugfix
@@ -1,0 +1,1 @@
+Fixed AUTH_RATELIMIT_IP not working on imap/pop3/smtp.


### PR DESCRIPTION
#2283

## What type of PR?

bug-fix

## What does this PR do?
This fixes AUTH_RATELIMIT_IP not working on imap/pop3/smtp.

### Related issue(s)
closes #2283

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.