### PR TITLE
rspamd may trigger HFILTER_HOSTNAME_UNKNOWN if part of the delivery chain is using ipv6

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -17,7 +17,7 @@ http {
     keepalive_timeout 65;
     server_tokens off;
     absolute_redirect off;
-    resolver {{ RESOLVER }} ipv6=off valid=30s;
+    resolver {{ RESOLVER }} valid=30s;
 
     {% if REAL_IP_HEADER %}
     real_ip_header {{ REAL_IP_HEADER }};
@@ -254,7 +254,7 @@ mail {
     server_name {{ HOSTNAMES.split(",")[0] }};
     auth_http http://127.0.0.1:8000/auth/email;
     proxy_pass_error_message on;
-    resolver {{ RESOLVER }} ipv6=off valid=30s;
+    resolver {{ RESOLVER }} valid=30s;
     error_log /dev/stderr info;
 
     {% if TLS and not TLS_ERROR %}

--- a/setup/templates/steps/compose/03_expose.html
+++ b/setup/templates/steps/compose/03_expose.html
@@ -31,7 +31,7 @@ avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</co
 </div>
 
 <div class="form-group" id="ipv6" style="display: none">
-  <p><span class="label label-danger">Read this:</span> Docker currently does not expose the IPv6 ports properly, as it does not interface with <code>ip6tables</code>. Be sure to read our <a href="https://mailu.io/{{ version }}/faq.html#how-to-make-ipv6-work">FAQ section</a> and be <b>very careful</b> if you still wish to enable this!</p>
+  <p><span class="label label-danger">Read this:</span> Docker currently does not expose the IPv6 ports properly, as it does not interface with <code>ip6tables</code>. Read <a href="https://mailu.io/{{ version }}/faq.html#how-to-make-ipv6-work">FAQ section</a> and be <b>very careful</b>. We do <b>NOT</b> recommend that you enable this!</p>
   <label>IPv6 listen address</label>
 <!--   Validates IPv6 address -->
   <input class="form-control" type="text" name="bind6" value="::1"

--- a/towncrier/newsfragments/2260.bugfix
+++ b/towncrier/newsfragments/2260.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where rspamd may trigger HFILTER_HOSTNAME_UNKNOWN if part of the delivery chain was using ipv6


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

This PR addresses the problem raised in #2260 : where rspamd may trigger HFILTER_HOSTNAME_UNKNOWN if part of the delivery chain is using ipv6. It may affect non v6 enabled setup and this is why it's proposed for backport.

The PR also sturdies up the warning about enabling v6 (as discussed during the last dev-meeting).

AAAA lookups in nginx were disabled when SSO was introduced as IP addresses were used to differentiate in between logins from webmails and others. Nowadays Mailu uses ports instead, so there is no reason not to re-enable it.

### Related issue(s)
- closes #2260
- #2272

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
