### PR TITLE
Adding missing semicolon after remote_addr

### DIFF
--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -47,7 +47,7 @@ Then on your own frontend, point to these local ports. In practice, you only nee
 
     location / {
       proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr
+      proxy_set_header X-Real-IP $remote_addr;
       proxy_pass https://localhost:8443;
     }
   }
@@ -68,7 +68,7 @@ Because the admin interface is served as ``/admin``, the Webmail as ``/webmail``
 
     location ~* ^/(admin|sso|static|webdav|webmail|(apple\.)?mobileconfig|(\.well\-known/autoconfig/)?mail/|Autodiscover/Autodiscover) {
       proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr
+      proxy_set_header X-Real-IP $remote_addr;
       proxy_pass https://localhost:8443;     
     }
 
@@ -111,7 +111,7 @@ Here is an example configuration :
 
     location /webmail {
       proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr
+      proxy_set_header X-Real-IP $remote_addr;
       proxy_pass https://localhost:8443/webmail;
     }
   }
@@ -123,7 +123,7 @@ Here is an example configuration :
 
     location /admin {
       proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr
+      proxy_set_header X-Real-IP $remote_addr;
       proxy_pass https://localhost:8443/admin;
       proxy_set_header Host $http_host;
     }


### PR DESCRIPTION
## What type of PR?

Documentation

## What does this PR do?

Minor fix - missing semicolon after $remote_addr

### Related issue(s)


## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
