### PR TITLE
Update deprecated rspamd config option

### DIFF
--- a/core/rspamd/conf/antivirus.conf
+++ b/core/rspamd/conf/antivirus.conf
@@ -1,6 +1,6 @@
 {% if ANTIVIRUS == 'clamav' %}
 clamav {
-  attachments_only = true;
+  scan_mime_parts = true;
   symbol = "CLAM_VIRUS";
   type = "clamav";
   servers = "{{ ANTIVIRUS_ADDRESS }}";


### PR DESCRIPTION
## What type of PR?

Configuration update

## What does this PR do?

This is just a small config update to get rid of the following warning message:
`lua; antivirus.lua:109: CLAM_VIRUS [clamav]: Using attachments_only is deprecated. Please use scan_mime_parts = true instead`

As per the rspamd documentation https://rspamd.com/doc/modules/antivirus.html
> attachments_only = true; # Before 1.8.1
> scan_mime_parts = true; # After 1.8.1

The currently used version of rspamd is 3.1.

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
