### PR TITLE
Add pytz module to webdav container

### DIFF
--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -13,7 +13,7 @@ RUN apk add --no-cache \
 
 # Image specific layers under this line
 RUN apk add --no-cache curl \
- && pip3 install radicale~=3.0
+ && pip3 install pytz radicale~=3.0
 
 
 COPY radicale.conf /radicale.conf


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Get rid of radicale error "[ERROR] No module named 'pytz'"

### Related issue(s)
- closes #2315
