### PR TITLE
Fix Postfix FileExistsError on startup

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -15,7 +15,8 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
 def start_podop():
     os.setuid(getpwnam('postfix').pw_uid)
-    os.mkdir('/dev/shm/postfix',mode=0o700)
+    if not os.path.exists('/dev/shm/postfix'):
+        os.mkdir('/dev/shm/postfix',mode=0o700)
     url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/postfix/"
     # TODO: Remove verbosity setting from Podop?
     run_server(0, "postfix", "/tmp/podop.socket", [

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -15,8 +15,7 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
 def start_podop():
     os.setuid(getpwnam('postfix').pw_uid)
-    if not os.path.exists('/dev/shm/postfix'):
-        os.mkdir('/dev/shm/postfix',mode=0o700)
+    os.makedirs('/dev/shm/postfix',mode=0o700, exist_ok=True)
     url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/postfix/"
     # TODO: Remove verbosity setting from Podop?
     run_server(0, "postfix", "/tmp/podop.socket", [


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

I'm running mailu with the mailu helm-chart on kubernetes. Sometimes when a Pod restarts I get the following error during startup:
```
Process Process-1:
Traceback (most recent call last):
File "/usr/lib/python3.9/multiprocessing/process.py", line 315, in _bootstrap
self.run()
File "/usr/lib/python3.9/multiprocessing/process.py", line 108, in run
self._target(*self._args, **self._kwargs)
File "/start.py", line 18, in start_podop
os.mkdir('/dev/shm/postfix',mode=0o700)
FileExistsError: [Errno 17] File exists: '/dev/shm/postfix'
INFO:MAIN:MTA-STS daemon starting...
```

But that does not prevent the container startup. When mails arrive it will fail with something like:

```
postfix/trivial-rewrite[94979]: warning: connect to /tmp/podop.socket: No such file or directory
postfix/trivial-rewrite[94979]: warning: table socketmap:unix:/tmp/podop.socket:transport lookup error: No such file or directory
postfix/trivial-rewrite[94979]: warning: socketmap:unix:/tmp/podop.socket:transport lookup error for "*"
```

I'm running this quick fix now since almost two months without problems. Maybe you got a better approach how to solve this, but this works fine for me.

### Related issue(s)
- none

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

<!--
- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
--->

**No changelog or documentation necessary for this minor change.**
