### PR TITLE
postfix: wrap IPv6 CIDRs in square brackets for RELAYNETS

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -6,6 +6,7 @@ import shutil
 import multiprocessing
 import logging as log
 import sys
+import re
 
 from podop import run_server
 from pwd import getpwnam
@@ -49,6 +50,10 @@ os.environ["ANTISPAM_MILTER_ADDRESS"] = system.get_host_address_from_environment
 os.environ["LMTP_ADDRESS"] = system.get_host_address_from_environment("LMTP", "imap:2525")
 os.environ["POSTFIX_LOG_SYSLOG"] = os.environ.get("POSTFIX_LOG_SYSLOG","local")
 os.environ["POSTFIX_LOG_FILE"] = os.environ.get("POSTFIX_LOG_FILE", "")
+
+# Postfix requires IPv6 addresses to be wrapped in square brackets
+if 'RELAYNETS' in os.environ:
+    os.environ["RELAYNETS"] = re.sub(r'([0-9a-fA-F]+:[0-9a-fA-F:]+)/', '[\\1]/', os.environ["RELAYNETS"])
 
 for postfix_file in glob.glob("/conf/*.cf"):
     conf.jinja(postfix_file, os.environ, os.path.join("/etc/postfix", os.path.basename(postfix_file)))

--- a/towncrier/newsfragments/2325.bugfix
+++ b/towncrier/newsfragments/2325.bugfix
@@ -1,0 +1,1 @@
+postfix: wrap IPv6 CIDRs in square brackets for RELAYNETS


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

This PR wraps IPv6 CIDRs in the `RELAYNETS` environment variable in square brackets for the postfix configuration.

The `RELAYNETS` environment variable is used for configuring both postfix `mynetworks` and rspamd `local_networks`. Postfix requires IPv6 addresses to be wrapped in square brackets (eg. `[2001:db8::]/64`).

When an IPv6 address is not wrapped in square brackets in the postfix configuration for `mynetworks` it results in this error while processing an incoming email from an IPv6 sender:
```
postfix/smtpd[340]: warning: 2001:db8::/64 is unavailable. unsupported dictionary type: 2001
postfix/smtpd[340]: warning: smtpd_client_event_limit_exceptions: 2001:db8::/64: table lookup problem
```

The sender sees an error and the incoming email is refused:
```
451 4.3.0 <unknown[2001:xxx:xxx:xxx:xxx:xxx:xxx:xxx]>: Temporary lookup failure
```

I tried to work around this issue by wrapping the IPv6 CIDR in square brackets in the `RELAYNETS` environment variable, but it segfaults rspamd, because it can't deal with this non-standard IPv6 notation used by postfix:
```
kernel: [4305632.603704] rspamd[1954299]: segfault at 0 ip 00007fb848983871 sp 00007ffe02cc6d1
8 error 4 in ld-musl-x86_64.so.1[7fb848948000+48000]
```

### Related issue(s)
- #2293
- #2272

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

**No changelog or documentation necessary for this minor change.**