### PR TITLE
Silence some errors in nginx

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -278,7 +278,6 @@ mail {
     server_name {{ HOSTNAMES.split(",")[0] }};
     auth_http http://127.0.0.1:8000/auth/email;
     proxy_pass_error_message on;
-    resolver {{ RESOLVER }} valid=30s;
     error_log /dev/stderr info;
 
     {% if TLS and not TLS_ERROR %}

--- a/towncrier/newsfragments/2346.bugfix
+++ b/towncrier/newsfragments/2346.bugfix
@@ -1,0 +1,1 @@
+Disable the built-in nginx resolver for traffic going through the mail plugin. This will silence errors about DNS resolution when the connecting host has no rDNS.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

It silences some errors in nginx by disabling the built-in resolver stub.
"could not be resolved (3: Host not found) while in resolving client address, client:"

I've talked about it on #mailu-dev ; There is a possibility that this has an impact on performance.

### Related issue(s)
- closes #2346
- #2290
- #1789

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
