### PR TITLE
Roundcube: add button to taskmenu for mailu

### DIFF
--- a/towncrier/newsfragments/2367.feature
+++ b/towncrier/newsfragments/2367.feature
@@ -1,0 +1,1 @@
+Adds a button to the roundcube interface that gets you back to the admin interface

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -63,6 +63,7 @@ RUN set -eu \
 # enable database_attachments (and memcache?)
 
 COPY mailu.php /var/www/html/plugins/mailu/mailu.php
+COPY mailu.js /var/www/html/plugins/mailu/mailu.js
 COPY php.ini /
 COPY config.inc.php /
 COPY start.py /

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -63,7 +63,7 @@ RUN set -eu \
 # enable database_attachments (and memcache?)
 
 COPY mailu.php /var/www/html/plugins/mailu/mailu.php
-COPY mailu.js /var/www/html/plugins/mailu/mailu.js
+COPY mailu.js /
 COPY php.ini /
 COPY config.inc.php /
 COPY start.py /

--- a/webmails/roundcube/mailu.js
+++ b/webmails/roundcube/mailu.js
@@ -1,0 +1,9 @@
+rcmail.addEventListener('init', function(evt) {
+      var btn = document.createElement('a');
+      btn.setAttribute("href", "/admin");
+      btn.setAttribute("role", "button");
+      btn.setAttribute("class", "showurl");
+      btn.innerHTML = '<span class="inner">To Mailu</span>';
+
+      document.getElementById("taskmenu").appendChild(btn);
+});

--- a/webmails/roundcube/mailu.js
+++ b/webmails/roundcube/mailu.js
@@ -1,6 +1,6 @@
 rcmail.addEventListener('init', function(evt) {
       var btn = document.createElement('a');
-      btn.setAttribute("href", "/admin");
+      btn.setAttribute("href", "{{ WEB_ADMIN }}");
       btn.setAttribute("role", "button");
       btn.setAttribute("class", "showurl");
       btn.innerHTML = '<span class="inner">To Mailu</span>';

--- a/webmails/roundcube/mailu.js
+++ b/webmails/roundcube/mailu.js
@@ -1,9 +1,11 @@
-rcmail.addEventListener('init', function(evt) {
-      var btn = document.createElement('a');
-      btn.setAttribute("href", "{{ WEB_ADMIN }}");
-      btn.setAttribute("role", "button");
-      btn.setAttribute("class", "showurl");
-      btn.innerHTML = '<span class="inner">To Mailu</span>';
+if ({{ ADMIN }}) {
+      rcmail.addEventListener('init', function(evt) {
+            var btn = document.createElement('a');
+            btn.setAttribute("href", "{{ WEB_ADMIN }}");
+            btn.setAttribute("role", "button");
+            btn.setAttribute("class", "showurl");
+            btn.innerHTML = '<span class="inner">To {{ SITENAME }}</span>';
 
-      document.getElementById("taskmenu").appendChild(btn);
-});
+            document.getElementById("taskmenu").appendChild(btn);
+      });
+}

--- a/webmails/roundcube/mailu.php
+++ b/webmails/roundcube/mailu.php
@@ -5,6 +5,7 @@ class mailu extends rcube_plugin
 
   function init()
   {
+    $this->include_script('mailu.js');
     $this->add_hook('startup', array($this, 'startup'));
     $this->add_hook('authenticate', array($this, 'authenticate'));
     $this->add_hook('login_after', array($this, 'login'));

--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -68,6 +68,7 @@ context["SESSION_TIMEOUT_MINUTES"] = max(int(env.get("SESSION_TIMEOUT", "3600"))
 # create config files
 conf.jinja("/php.ini", context, "/usr/local/etc/php/conf.d/roundcube.ini")
 conf.jinja("/config.inc.php", context, "/var/www/html/config/config.inc.php")
+conf.jinja("/mailu.js", context, "/var/www/html/plugins/mailu/mailu.js")
 
 # create dirs
 os.system("mkdir -p /data/gpg")


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Adds a button to the roundcube interface. This button gets you back to the admin interface. Now you can switch between both without any issues

### Related issue(s)
- Did not found any but was bothering me

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
