### PR TITLE
Fix docs build error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ project = 'Mailu'
 copyright = '2018, Mailu authors'
 author = 'Mailu authors'
 version = release = os.environ.get('VERSION', 'master')
-language = None
+language = 'en'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'Dockerfile', 'docker-compose.yml']
 pygments_style = 'sphinx'
 todo_include_todos = False


### PR DESCRIPTION
Set language to English for sphinx in conf.py

The docs have always been generated with the option to treat warnings as errors. 
Recently (due to an update?) sphinx-build reports using language=None as a warning. It is expected that a specific
language is set. This causes the build to fail. ALL open PR's are affected by this.
```
Warning, treated as error:
Invalid configuration value found: 'language = None'. Update your configuration to a valid langauge code. Falling back to 'en' (English).
```


## What type of PR?

bug-fix

