### PR TITLE
Handle IPv6 resolvers correctly

### DIFF
--- a/core/nginx/config.py
+++ b/core/nginx/config.py
@@ -2,6 +2,7 @@
 
 import os
 import logging as log
+import ipaddress
 import sys
 from socrate import system, conf
 
@@ -12,7 +13,11 @@ log.basicConfig(stream=sys.stderr, level=args.get("LOG_LEVEL", "WARNING"))
 # Get the first DNS server
 with open("/etc/resolv.conf") as handle:
     content = handle.read().split()
-    args["RESOLVER"] = content[content.index("nameserver") + 1]
+    resolver = ipaddress.ip_address(content[content.index("nameserver") + 1])
+    if isinstance(resolver, ipaddress.IPv6Address):
+        args["RESOLVER"] = f"[{resolver}]"
+    else:
+        args["RESOLVER"] = str(resolver)
 
 args["ADMIN_ADDRESS"] = system.get_host_address_from_environment("ADMIN", "admin")
 args["ANTISPAM_WEBUI_ADDRESS"] = system.get_host_address_from_environment("ANTISPAM_WEBUI", "antispam:11334")


### PR DESCRIPTION
## What type of PR?
Bug fix

## What does this PR do?
NGINX front container currently does not handle IPv6 resolver addresses correctly, this PR fixes this.

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
