### PR TITLE
Re-enable the built-in nginx resolver for traffic going through the mail plugin

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -277,6 +277,7 @@ mail {
     server_name {{ HOSTNAMES.split(",")[0] }};
     auth_http http://127.0.0.1:8000/auth/email;
     proxy_pass_error_message on;
+    resolver {{ RESOLVER }} valid=30s;
     error_log /dev/stderr info;
 
     {% if TLS and not TLS_ERROR %}

--- a/towncrier/newsfragments/2368.bugfix
+++ b/towncrier/newsfragments/2368.bugfix
@@ -1,0 +1,3 @@
+Re-enable the built-in nginx resolver for traffic going through the mail plugin.
+This is required for passing rDNS/ptr information to postfix.
+Without this rspamd will flag all messages with DHFILTER_HOSTNAME_UNKNOWN due to the missing rDNS/ptr info.


### PR DESCRIPTION
## What type of PR?

Bug-fix

## What does this PR do?
Re-enable the built-in nginx resolver for traffic going through the mail plugin
This is required for passing rDNS/ptr information to postfix.
The mail proxy uses the resolver info for passing XCLIENT info.
See http://nginx.org/en/docs/mail/ngx_mail_proxy_module.html#xclient
Without this info rspamd will flag all messages with DHFILTER_HOSTNAME_UNKNOWN due to the missing rDNS/ptr info.

Yes this re-introduces these `cannot resolve` error  messages. If we really want to get rid of these, then we can consider logging to a rsyslog daemon where we filter out these messages.

### Related issue(s)
- Auto close an issue like: closes #2368

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [n/a] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
