### PR TITLE
Forwarding emails option in user settings did not support 1 letter do…

### DIFF
--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -37,7 +37,7 @@ class MultipleEmailAddressesVerify(object):
         self.message = message
 
     def __call__(self, form, field):
-        pattern = re.compile(r'^([_a-z0-9\-]+)(\.[_a-z0-9\-]+)*@([a-z0-9\-]{2,}\.)*([a-z]{2,})(,([_a-z0-9\-]+)(\.[_a-z0-9\-]+)*@([a-z0-9\-]{2,}\.)*([a-z]{2,}))*$')
+        pattern = re.compile(r'^([_a-z0-9\-]+)(\.[_a-z0-9\-]+)*@([a-z0-9\-]{1,}\.)*([a-z]{1,})(,([_a-z0-9\-]+)(\.[_a-z0-9\-]+)*@([a-z0-9\-]{1,}\.)*([a-z]{2,}))*$')
         if not pattern.match(field.data.replace(" ", "")):
             raise validators.ValidationError(self.message)
 

--- a/towncrier/newsfragments/2402.bugfix
+++ b/towncrier/newsfragments/2402.bugfix
@@ -1,0 +1,1 @@
+Forwarding emails user setting did not support 1 letter domains.


### PR DESCRIPTION
…mains.

## What type of PR?

Bug-fix

## What does this PR do?

Forwarding emails option in user setting did not support 1 letter domains. The regex for checking the validity of  multiple email addresses string has been modified to allow 1 letter domains and to allow 1 letter local part.

### Related issue(s)
- closes #2402 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [n/a] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
