### PR TITLE
Fix small typo in config-import example template

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -302,7 +302,7 @@ This is a complete YAML template with all additional parameters that can be defi
           ip: 192.168.1.1
           password: '$5$rounds=1$...'
 
-  aliases:
+  alias:
     - email: email@example.com
       comment: ''
       destination:


### PR DESCRIPTION
## What type of PR?

documentation fix

## What does this PR do?
Fixes a small typo in the full yaml template example  for the config-import. The entry ``alias:`` was incorrectly displayed as ``aliases:``.

### Related issue(s)
- closes #2387 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ n/a ] In case of feature or enhancement: documentation updated accordingly
- [ n/a ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
