### PR TITLE
Remove the misleading text in mailu.env that zstd and lz4 are supported

### DIFF
--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -96,7 +96,7 @@ WELCOME_SUBJECT={{ welcome_subject or 'Welcome to your new email account' }}
 WELCOME_BODY={{ welcome_body or 'Welcome to your new email account, if you can read this, then it is configured properly!' }}
 
 # Maildir Compression
-# choose compression-method, default: none (value: gz, bz2, lz4, zstd)
+# choose compression-method, default: none (value: gz, bz2)
 COMPRESSION={{ compression }}
 # change compression-level, default: 6 (value: 1-9)
 COMPRESSION_LEVEL={{ compression_level }}

--- a/towncrier/newsfragments/2139.bugfix
+++ b/towncrier/newsfragments/2139.bugfix
@@ -1,0 +1,5 @@
+Remove the misleading text in mailu.env that zstd and lz4 are supported for dovecot mail compression.
+Zstd and lz4 are not supported. The reason is that the alpine project does not compile this
+into the dovecot package.
+Users who want this funcionality, can kindly request the alpine project to compile dovecot
+with lz4&zstd support.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
Remove the misleading text in mailu.env that zstd and lz4 are supported  for dovecot mail compression.
Zstd and lz4 are not supported. The reason is that the alpine project does not compile this into the dovecot package.
Users who want this functionality, can kindly request the alpine project to compile dovecot with lz4&zstd support.

### Related issue(s)
- closes #2139

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [n/a] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
