### PR TITLE
Fix error in reverse proxy example for how to include nginx override.

### DIFF
--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -243,25 +243,10 @@ Refer to the Traefik documentation for more details.
 Override Mailu configuration
 ----------------------------
 
-If you do not have the resources for running a separate reverse proxy, you could override Mailu reverse proxy configuration by using a Docker volume.
-Simply store your configuration file (Nginx format), in ``/mailu/overrides/nginx.conf`` for instance.
-All *.conf files will be included in the main server block of Mailu in nginx which listens on port 80/443.
+If you do not have the resources for running a separate reverse proxy, you could override Mailu reverse proxy configuration by using :ref:`an override<override-label>`.
+Simply store your configuration file (Nginx format), in ``/mailu/overrides/nginx.conf``.
+All ``*.conf`` files will be included in the main server block of Mailu in nginx which listens on port 80/443.
 Add location blocks for any services that must be proxied.
-
-Then modify your ``docker-compose.yml`` file and change the ``front`` section to add a mount:
-
-.. code-block:: nginx
-
-  front:
-    build: nginx
-    image: mailu/nginx:$VERSION
-    restart: always
-    env_file: .env
-    ports:
-      [...]
-    volumes:
-      - "$ROOT/certs:/certs"
-      - "$ROOT/overrides/nginx:/overrides"
 
 You can also download the example configuration files:
 

--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -244,7 +244,9 @@ Override Mailu configuration
 ----------------------------
 
 If you do not have the resources for running a separate reverse proxy, you could override Mailu reverse proxy configuration by using a Docker volume.
-Simply store your configuration file (Nginx format), in ``/mailu/nginx.conf`` for instance.
+Simply store your configuration file (Nginx format), in ``/mailu/overrides/nginx.conf`` for instance.
+All *.conf files will be included in the main server block of Mailu in nginx which listens on port 80/443.
+Add location blocks for any services that must be proxied.
 
 Then modify your ``docker-compose.yml`` file and change the ``front`` section to add a mount:
 
@@ -259,7 +261,7 @@ Then modify your ``docker-compose.yml`` file and change the ``front`` section to
       [...]
     volumes:
       - "$ROOT/certs:/certs"
-      - "$ROOT/nginx.conf:/etc/nginx/nginx.conf"
+      - "$ROOT/overrides/nginx:/overrides"
 
 You can also download the example configuration files:
 


### PR DESCRIPTION

## What type of PR?

documentation

## What does this PR do?
The reverse proxy documentation contained an error in an example section. The nginx override file is incorrectly overridden in the sample. Also clarified how the file is included and that you should define location blocks (because it is included in the main mailu server block).

### Related issue(s)
- closes #2232 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [n/a] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
