### PR TITLE
The MESSAGE_SIZE_LIMIT is now used for the clamav configuration

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -37,7 +37,7 @@ The ``POSTMASTER`` is the local part of the postmaster email address. It is
 recommended to setup a generic value and later configure a mail alias for that
 address.
 
-The ``WILDCARD_SENDERS`` setting is a comma delimited list of user email addresses 
+The ``WILDCARD_SENDERS`` setting is a comma delimited list of user email addresses
 that are allowed to send emails from any existing address (spoofing the sender).
 
 The ``AUTH_RATELIMIT_IP`` (default: 60/hour) holds a security setting for fighting
@@ -66,9 +66,9 @@ The ``TLS_FLAVOR`` sets how Mailu handles TLS connections. Setting this value to
 Mail settings
 -------------
 
-The ``MESSAGE_SIZE_LIMIT`` is the maximum size of a single email. It should not
-be too low to avoid dropping legitimate emails and should not be too high to
-avoid filling the disks with large junk emails.
+The ``MESSAGE_SIZE_LIMIT`` (default: 50000000 (50MB)) is the maximum size of a
+single email in bytes. It should not be too low to avoid dropping legitimate emails
+and should not be too high to avoid filling the disks with large junk emails.
 
 The ``MESSAGE_RATELIMIT`` (default: 200/day) is the maximum number of messages
 a single user can send. ``MESSAGE_RATELIMIT_EXEMPTION`` contains a comma delimited
@@ -130,9 +130,9 @@ Web settings
 - ``WEB_WEBMAIL`` contains the path to the Web email client.
 
 - ``WEBROOT_REDIRECT`` redirects all non-found queries to the set path.
-  An empty ``WEBROOT_REDIRECT`` value disables redirecting and enables 
+  An empty ``WEBROOT_REDIRECT`` value disables redirecting and enables
   classic behavior of a 404 result when not found.
-  Alternatively, ``WEBROOT_REDIRECT`` can be set to ``none`` if you 
+  Alternatively, ``WEBROOT_REDIRECT`` can be set to ``none`` if you
   are using an Nginx override for ``location /``.
 
 All three options need a leading slash (``/``) to work.
@@ -145,11 +145,11 @@ Both ``SITENAME`` and ``WEBSITE`` are customization options for the panel menu
 in the admin interface, while ``SITENAME`` is a customization option for
 every Web interface.
 
-- ``LOGO_BACKGROUND`` sets a custom background colour for the brand logo 
+- ``LOGO_BACKGROUND`` sets a custom background colour for the brand logo
   in the topleft of the main admin interface.
   For a list of colour codes refer to this page of `w3schools`_.
 
-- ``LOGO_URL`` sets a URL for a custom logo. This logo replaces the Mailu 
+- ``LOGO_URL`` sets a URL for a custom logo. This logo replaces the Mailu
   logo in the topleft of the main admin interface.
 
 .. _`w3schools`: https://www.w3schools.com/cssref/css_colors.asp
@@ -168,12 +168,12 @@ To have the account created automatically, you just need to define a few environ
 - ``INITIAL_ADMIN_DOMAIN``: the domain appendix: Most probably identical to the ``DOMAIN`` variable.
 - ``INITIAL_ADMIN_PW``: the admin password.
 - ``INITIAL_ADMIN_MODE``: use one of the options below for configuring how the admin account must be created:
-  
+
   - ``create``: (default) creates a new admin account and raises an exception when it already exists.
   - ``ifmissing``: creates a new admin account when the admin account does not exist.
   - ``update``: creates a new admin account when it does not exist, or update the password of an existing admin account.
 
-Note: It is recommended to set ``INITIAL_ADMIN_MODE`` to either ``update`` or ``ifmissing``. Leaving it with the 
+Note: It is recommended to set ``INITIAL_ADMIN_MODE`` to either ``update`` or ``ifmissing``. Leaving it with the
 default value will cause an error when the system is restarted.
 
 An example:
@@ -190,18 +190,18 @@ Depending on your particular deployment you most probably will want to change th
 Advanced settings
 -----------------
 
-The ``CREDENTIAL_ROUNDS`` (default: 12) setting is the number of rounds used by the 
-password hashing scheme. The number of rounds can be reduced in case faster 
-authentication is needed or increased when additional protection is desired. 
-Keep in mind that this is a mitigation against offline attacks on password hashes, 
+The ``CREDENTIAL_ROUNDS`` (default: 12) setting is the number of rounds used by the
+password hashing scheme. The number of rounds can be reduced in case faster
+authentication is needed or increased when additional protection is desired.
+Keep in mind that this is a mitigation against offline attacks on password hashes,
 aiming to prevent credential stuffing (due to password re-use) on other systems.
 
-The ``SESSION_COOKIE_SECURE`` (default: True) setting controls the secure flag on 
-the cookies of the administrative interface. It should only be turned off if you 
+The ``SESSION_COOKIE_SECURE`` (default: True) setting controls the secure flag on
+the cookies of the administrative interface. It should only be turned off if you
 intend to access it over plain HTTP.
 
-``SESSION_TIMEOUT`` (default: 3600) is the maximum amount of time in seconds between 
-requests before a session is invalidated. ``PERMANENT_SESSION_LIFETIME`` (default: 108000) 
+``SESSION_TIMEOUT`` (default: 3600) is the maximum amount of time in seconds between
+requests before a session is invalidated. ``PERMANENT_SESSION_LIFETIME`` (default: 108000)
 is the maximum amount of time in seconds a session can be kept alive for if it hasn't timed-out.
 
 The ``LOG_LEVEL`` setting is used by the python start-up scripts as a logging threshold.
@@ -211,19 +211,19 @@ See the `python docs`_ for more information.
 
 .. _`python docs`: https://docs.python.org/3.6/library/logging.html#logging-levels
 
-The ``LETSENCRYPT_SHORTCHAIN`` (default: False) setting controls whether we send the 
-ISRG Root X1 certificate in TLS handshakes. This is required for `android handsets older than 7.1.1` 
+The ``LETSENCRYPT_SHORTCHAIN`` (default: False) setting controls whether we send the
+ISRG Root X1 certificate in TLS handshakes. This is required for `android handsets older than 7.1.1`
 but slows down the performance of modern devices.
 
 .. _`android handsets older than 7.1.1`: https://community.letsencrypt.org/t/production-chain-changes/150739
 
 .. _reverse_proxy_headers:
 
-The ``REAL_IP_HEADER`` (default: unset) and ``REAL_IP_FROM`` (default: unset) settings 
-controls whether HTTP headers such as ``X-Forwarded-For`` or ``X-Real-IP`` should be trusted. 
-The former should be the name of the HTTP header to extract the client IP address from and the 
-later a comma separated list of IP addresses designating which proxies to trust. 
-If you are using Mailu behind a reverse proxy, you should set both. Setting the former without 
+The ``REAL_IP_HEADER`` (default: unset) and ``REAL_IP_FROM`` (default: unset) settings
+controls whether HTTP headers such as ``X-Forwarded-For`` or ``X-Real-IP`` should be trusted.
+The former should be the name of the HTTP header to extract the client IP address from and the
+later a comma separated list of IP addresses designating which proxies to trust.
+If you are using Mailu behind a reverse proxy, you should set both. Setting the former without
 the later introduces a security vulnerability allowing a potential attacker to spoof his source address.
 
 The ``TZ`` sets the timezone Mailu will use. The timezone naming convention usually uses a ``Region/City`` format. See `TZ database name`_  for a list of valid timezones This defaults to ``Etc/UTC``. Warning: if you are observing different timestamps in your log files you should change your hosts timezone to UTC instead of changing TZ to your local timezone. Using UTC allows easy log correlation with remote MTAs.
@@ -339,13 +339,13 @@ Mail log settings
 
 By default, all services log directly to stdout/stderr. Logs can be collected by any docker log processing solution.
 
-Postfix writes the logs to a syslog server which logs to stdout. This is used to filter 
-out messages from the healthcheck. In some situations, a separate mail log is required 
-(e.g. for legal reasons). The syslog server can be configured to write log files to a volume. 
+Postfix writes the logs to a syslog server which logs to stdout. This is used to filter
+out messages from the healthcheck. In some situations, a separate mail log is required
+(e.g. for legal reasons). The syslog server can be configured to write log files to a volume.
 It can be configured with the following option:
 
 - ``POSTFIX_LOG_FILE``: The file to log the mail log to. When enabled, the syslog server will also log to stdout.
 
-When ``POSTFIX_LOG_FILE`` is enabled, the logrotate program will automatically rotate the 
-logs every week and keep 52 logs. To override the logrotate configuration, create the file logrotate.conf 
+When ``POSTFIX_LOG_FILE`` is enabled, the logrotate program will automatically rotate the
+logs every week and keep 52 logs. To override the logrotate configuration, create the file logrotate.conf
 with the desired configuration in the :ref:`Postfix overrides folder<override-label>`.

--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -13,7 +13,9 @@ RUN apk add --no-cache \
 # Image specific layers under this line
 RUN apk add --no-cache clamav rsyslog wget clamav-libunrar
 
-COPY conf /etc/clamav
+RUN pip3 install socrate==0.2.0
+
+COPY conf /conf
 COPY start.py /start.py
 COPY health.sh /health.sh
 

--- a/optional/clamav/conf/clamd.conf
+++ b/optional/clamav/conf/clamd.conf
@@ -41,8 +41,8 @@ ScanArchive yes
 # Scan
 ###############
 
-MaxScanSize 150M
-MaxFileSize 30M
+MaxScanSize {{ ((MESSAGE_SIZE_LIMIT|int(50000000,  10) / 1000000) * 3)|int }}M
+MaxFileSize {{ ((MESSAGE_SIZE_LIMIT|int(50000000,  10) / 1000000) + 5)|int }}M
 MaxRecursion 10
 MaxFiles 15000
 MaxEmbeddedPE 10M

--- a/optional/clamav/start.py
+++ b/optional/clamav/start.py
@@ -3,9 +3,15 @@
 import os
 import logging as log
 import sys
+import glob
+from socrate import conf
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 logger=log.getLogger(__name__)
+
+# Parse configuration files
+for clamav_file in glob.glob("/conf/*.conf"):
+    conf.jinja(clamav_file, os.environ, os.path.join("/etc/clamav", os.path.basename(clamav_file)))
 
 # Bootstrap the database if clamav is running for the first time
 if not os.path.isfile("/data/main.cvd"):

--- a/towncrier/newsfragments/1646.bugfix
+++ b/towncrier/newsfragments/1646.bugfix
@@ -1,0 +1,2 @@
+The MESSAGE_SIZE_LIMIT is also used for the clamav configuration (MaxScanSize, MaxFileSize).
+This resolves the situation where MESSAGE_SIZE_LIMIT was set higher than the hard-coded values in the clamav configuration.


### PR DESCRIPTION


## What type of PR?

bug-fix

## What does this PR do?
The MESSAGE_SIZE_LIMIT is now used for the clamav configuration (MaxScanSize, MaxFileSize).

This resolves the situation where MESSAGE_SIZE_LIMIT was set higher than the hard-coded values in the clamav configuration.

For MaxScanSize we used a hardcoded value that was 3 times higher than the default value. I kept this in place.
I have set MaxFileSize a little bit higher than MESSAGE_SIZE_LIMIT. This makes sure emails can always be scanned (assuming they don't have too large archives as attachments).

### Related issue(s)
- closes #1646

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
