### PR TITLE
Feature: sender relay

### DIFF
--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -180,3 +180,46 @@ def idna_encode(addresses):
         for (localpart, domain) in
         (address.rsplit("@", 1) for address in addresses)
     ]
+
+@internal.route("/postfix/sender/relay/host/<path:sender>")
+def postfix_sender_relay_host(sender):
+    """ Look for sender dependent relay hosts
+    """
+    if '@' in sender:
+        if sender.startswith('<') and sender.endswith('>'):
+            sender = sender[1:-1]
+        try:
+            if user_relay := models.UserRelay.query.filter_by(relay_mail=sender).first():
+                return flask.jsonify(f'{user_relay.host}:{user_relay.port}')
+        except sqlalchemy.exc.StatementError:
+            pass
+    return flask.abort(404)
+
+@internal.route("/postfix/sender/relay/auth/<path:sender>")
+def postfix_sender_relay_auth(sender):
+    """ Get authentication for relay mail addresses
+    """
+    if '@' in sender:
+        if sender.startswith('<') and sender.endswith('>'):
+            sender = sender[1:-1]
+        try:
+            if user_relay := models.UserRelay.query.filter_by(relay_mail=sender).first():
+                return flask.jsonify(f'{user_relay.username}:{user_relay.password}')
+        except sqlalchemy.exc.StatementError:
+            pass
+    return flask.abort(404)
+
+@internal.route("/postfix/sender/relay/login/<path:sender>")
+def postfix_sender_relay_login(sender):
+    """ Return users who are allowed to send mail for user dependent
+        relay addresses
+    """
+    if '@' in sender:
+        if sender.startswith('<') and sender.endswith('>'):
+            sender = sender[1:-1]
+        try:
+            if user_relay := models.UserRelay.query.filter_by(relay_mail=sender).first():
+                return flask.jsonify(f'{user_relay.user_email}')
+        except sqlalchemy.exc.StatementError:
+            pass
+    return flask.abort(404)

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -776,6 +776,32 @@ class Fetch(Base):
         )
 
 
+class UserRelay(Base):
+    """ A Relayed account is a remote POP/IMAP account bound to a local
+    account. The bound account is allowed to send from this mail address
+    and the mails are relayed through the server and account.
+    """
+
+    __tablename__ = 'user_relay'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_email = db.Column(db.String(255), db.ForeignKey(User.email),
+        nullable=False)
+    relay_mail = db.Column(db.String(255), nullable=False, unique=True)
+    user = db.relationship(User,
+        backref=db.backref('user_relays', cascade='all, delete-orphan'))
+    host = db.Column(db.String(255), nullable=False)
+    port = db.Column(db.Integer, nullable=False)
+    tls = db.Column(db.Boolean, nullable=False)
+    username = db.Column(db.String(255), nullable=False)
+    password = db.Column(db.String(255), nullable=False)
+
+    def __repr__(self):
+        return (
+            f'<UserRelay #{self.id}: //{self.username}@{self.host}:{self.port}>'
+        )
+
+
 class MailuConfig:
     """ Class which joins whole Mailu config for dumping
         and loading

--- a/core/admin/mailu/schemas.py
+++ b/core/admin/mailu/schemas.py
@@ -1157,6 +1157,20 @@ class FetchSchema(BaseSchema):
 
 
 @mapped
+class UserRelaySchema(BaseSchema):
+    """ Marshmallow schema for Fetch model """
+    class Meta:
+        """ Schema config """
+        model = models.UserRelay
+        load_instance = True
+
+        sibling = True
+        hide_by_context = {
+            ('secrets',): {'password'},
+        }
+
+
+@mapped
 class UserSchema(BaseSchema):
     """ Marshmallow schema for User model """
     class Meta:
@@ -1179,7 +1193,7 @@ class UserSchema(BaseSchema):
     email = fields.String(required=True)
     tokens = fields.Nested(TokenSchema, many=True)
     fetches = fields.Nested(FetchSchema, many=True)
-
+    user_relays = fields.Nested(UserRelaySchema, many=True)
     password = PasswordField(required=True, metadata={'model': models.User})
     hash_password = fields.Boolean(load_only=True, missing=False)
 

--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -168,6 +168,16 @@ class FetchForm(flask_wtf.FlaskForm):
     submit = fields.SubmitField(_('Submit'))
 
 
+class UserRelayForm(flask_wtf.FlaskForm):
+    relay_mail = fields.StringField(_('Relay mail address'), [validators.Email()])
+    host = fields.StringField(_('Hostname or IP'), [validators.DataRequired()])
+    port = fields.IntegerField(_('TCP port'), [validators.DataRequired(), validators.NumberRange(min=0, max=65535)])
+    tls = fields.BooleanField(_('Enable TLS'))
+    username = fields.StringField(_('Username'), [validators.DataRequired()])
+    password = fields.PasswordField(_('Password'))
+    submit = fields.SubmitField(_('Submit'))
+
+
 class AnnouncementForm(flask_wtf.FlaskForm):
     announcement_subject = fields.StringField(_('Announcement subject'),
         [validators.DataRequired()])

--- a/core/admin/mailu/ui/templates/sidebar.html
+++ b/core/admin/mailu/ui/templates/sidebar.html
@@ -38,6 +38,12 @@
         </a>
       </li>
       <li class="nav-item" role="none">
+        <a href="{{ url_for('.user_relay_list') }}" class="nav-link" role="menuitem">
+          <i class="nav-icon fas fa-download"></i>
+          <p>{% trans %}Relay accounts{% endtrans %}</p>
+        </a>
+      </li>
+      <li class="nav-item" role="none">
         <a href="{{ url_for('.token_list') }}" class="nav-link" role="menuitem">
           <i class="nav-icon fas fa-ticket-alt"></i>
           <p>{% trans %}Authentication tokens{% endtrans %}</p>

--- a/core/admin/mailu/ui/templates/user_relay/create.html
+++ b/core/admin/mailu/ui/templates/user_relay/create.html
@@ -1,0 +1,23 @@
+{%- extends "base.html" %}
+
+{%- block title %}
+{% trans %}Add a relay account{% endtrans %}
+{%- endblock %}
+
+{%- block subtitle %}
+{{ user }}
+{%- endblock %}
+
+{%- block content %}
+{%- call macros.card() %}
+<form class="form" method="post" role="form">
+  {{ form.hidden_tag() }}
+  {{ macros.form_field(form.relay_mail) }}
+  {{ macros.form_fields((form.host, form.port)) }}
+  {{ macros.form_field(form.tls) }}
+  {{ macros.form_field(form.username) }}
+  {{ macros.form_field(form.password) }}
+  {{ macros.form_field(form.submit) }}
+</form>
+{%- endcall %}
+{%- endblock %}

--- a/core/admin/mailu/ui/templates/user_relay/create.html
+++ b/core/admin/mailu/ui/templates/user_relay/create.html
@@ -17,6 +17,14 @@
   {{ macros.form_field(form.tls) }}
   {{ macros.form_field(form.username) }}
   {{ macros.form_field(form.password) }}
+  <p>{% trans %}When pressing the submit button an actual login
+    to the relay server ist tried. Please be patiant as antispam
+    rules can defer the login.{% endtrans %}
+  </p>
+  <p>{% trans %}If the error "SSL: WRONG_VERSION_NUMBER" is shown
+    and TLS is activated check the port. The default port for 
+    encryptet mail transport is 465.{% endtrans %}
+  </p>
   {{ macros.form_field(form.submit) }}
 </form>
 {%- endcall %}

--- a/core/admin/mailu/ui/templates/user_relay/edit.html
+++ b/core/admin/mailu/ui/templates/user_relay/edit.html
@@ -1,0 +1,9 @@
+{%- extends "user_relay/create.html" %}
+
+{%- block title %}
+{% trans %}Update a relay account{% endtrans %}
+{%- endblock %}
+
+{%- block subtitle %}
+{{ user }}
+{%- endblock %}

--- a/core/admin/mailu/ui/templates/user_relay/list.html
+++ b/core/admin/mailu/ui/templates/user_relay/list.html
@@ -1,0 +1,45 @@
+{%- extends "base.html" %}
+
+{%- block title %}
+{% trans %}Relay accounts{% endtrans %}
+{%- endblock %}
+
+{%- block subtitle %}
+{{ user }}
+{%- endblock %}
+
+{%- block main_action %}
+<a class="btn btn-primary float-right" href="{{ url_for('.user_relay_create', user_email=user.email) }}">{% trans %}Add an account{% endtrans %}</a>
+{%- endblock %}
+
+{%- block content %}
+{%- call macros.table() %}
+<thead>
+  <tr>
+    <th>{% trans %}Actions{% endtrans %}</th>
+    <th>{% trans %}Relay Mail{% endtrans %}</th>
+    <th>{% trans %}Endpoint{% endtrans %}</th>
+    <th>{% trans %}TLS{% endtrans %}</th>
+    <th>{% trans %}Username{% endtrans %}</th>
+    <th>{% trans %}Created{% endtrans %}</th>
+    <th>{% trans %}Last edit{% endtrans %}</th>
+  </tr>
+</thead>
+<tbody>
+  {%- for relay in user.user_relays %}
+  <tr>
+    <td>
+      <a href="{{ url_for('.user_relay_edit', user_relay_id=relay.id) }}" title="{% trans %}Edit{% endtrans %}"><i class="fa fa-pencil-alt"></i></a>&nbsp;
+      <a href="{{ url_for('.user_relay_delete', user_relay_id=relay.id) }}" title="{% trans %}Delete{% endtrans %}"><i class="fa fa-trash"></i></a>
+    </td>
+    <td>{{ relay.relay_mail }}</td>
+    <td>{{ relay.host }}:{{ relay.port }}</td>
+    <td>{{ relay.tls }}</td>
+    <td>{{ relay.username }}</td>
+    <td>{{ relay.created_at | format_date }}</td>
+    <td>{{ relay.updated_at | format_date }}</td>
+  </tr>
+  {%- endfor %}
+</tbody>
+{%- endcall %}
+{%- endblock %}

--- a/core/admin/mailu/ui/views/__init__.py
+++ b/core/admin/mailu/ui/views/__init__.py
@@ -1,4 +1,4 @@
 __all__ = [
     'admins', 'aliases', 'alternatives', 'base', 'domains', 'fetches',
-    'managers', 'users', 'relays', 'tokens', 'languages'
+    'user_relays', 'managers', 'users', 'relays', 'tokens', 'languages'
 ]

--- a/core/admin/mailu/ui/views/user_relays.py
+++ b/core/admin/mailu/ui/views/user_relays.py
@@ -1,0 +1,74 @@
+from mailu import models
+from mailu.ui import ui, forms, access
+
+import smtplib
+
+import flask
+import flask_login
+import wtforms
+
+
+@ui.route('/user_relay/list', methods=['GET', 'POST'], defaults={'user_email': None})
+@ui.route('/user_relay/list/<path:user_email>', methods=['GET'])
+@access.owner(models.User, 'user_email')
+def user_relay_list(user_email):
+    user_email = user_email or flask_login.current_user.email
+    user = models.User.query.get(user_email) or flask.abort(404)
+    return flask.render_template('user_relay/list.html', user=user)
+
+
+@ui.route('/user_relay/create', methods=['GET', 'POST'], defaults={'user_email': None})
+@ui.route('/user_relay/create/<path:user_email>', methods=['GET', 'POST'])
+@access.owner(models.User, 'user_email')
+def user_relay_create(user_email):
+    user_email = user_email or flask_login.current_user.email
+    user = models.User.query.get(user_email) or flask.abort(404)
+    form = forms.UserRelayForm()
+    form.password.validators = [wtforms.validators.DataRequired()]
+    if form.validate_on_submit():
+        conflicting_relay = models.UserRelay.query.filter_by(relay_mail=form.relay_mail.data).first()
+        if conflicting_relay:
+            flask.flash('Relay mail %s is already used' % form.relay_mail.data, 'error')
+        else:
+            user_relay = models.UserRelay(user=user)
+            form.populate_obj(user_relay)
+            models.db.session.add(user_relay)
+            models.db.session.commit()
+            flask.flash('User relay configuration created')
+            return flask.redirect(
+                flask.url_for('.user_relay_list', user_email=user.email))
+    return flask.render_template('user_relay/create.html', form=form)
+
+
+@ui.route('/user_relay/edit/<user_relay_id>', methods=['GET', 'POST'])
+@access.owner(models.UserRelay, 'user_relay_id')
+def user_relay_edit(user_relay_id):
+    user_relay = models.UserRelay.query.get(user_relay_id) or flask.abort(404)
+    form = forms.UserRelayForm(obj=user_relay)
+    if form.validate_on_submit():
+        conflicting_relay = models.UserRelay.query.filter_by(relay_mail=form.relay_mail.data).first()
+        if conflicting_relay and user_relay_id != str(conflicting_relay.id):
+            flask.flash('Relay mail %s is already used' % form.relay_mail.data, 'error')
+        else:
+            if not form.password.data:
+                form.password.data = user_relay.password
+            form.populate_obj(user_relay)
+            models.db.session.commit()
+            flask.flash('User relay configuration updated')
+            return flask.redirect(
+                flask.url_for('.user_relay_list', user_email=user_relay.user.email))
+    return flask.render_template('user_relay/edit.html',
+        form=form, user_relay=user_relay)
+
+
+@ui.route('/user_relay/delete/<user_relay_id>', methods=['GET', 'POST'])
+@access.confirmation_required("delete a user relay account")
+@access.owner(models.UserRelay, 'user_relay_id')
+def user_relay_delete(user_relay_id):
+    user_relay = models.UserRelay.query.get(user_relay_id) or flask.abort(404)
+    user = user_relay.user
+    models.db.session.delete(user_relay)
+    models.db.session.commit()
+    flask.flash('User relay configuration delete')
+    return flask.redirect(
+        flask.url_for('.user_relay_list', user_email=user.email))

--- a/core/admin/migrations/versions/a30bcdbb3631_.py
+++ b/core/admin/migrations/versions/a30bcdbb3631_.py
@@ -1,0 +1,37 @@
+""" Add table for user relay
+
+Revision ID: a30bcdbb3631
+Revises: 8f9ea78776f4
+Create Date: 2022-07-12 21:06:53.749360
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'a30bcdbb3631'
+down_revision = '8f9ea78776f4'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_table('user_relay',
+    sa.Column('created_at', sa.Date(), nullable=False),
+    sa.Column('updated_at', sa.Date(), nullable=True),
+    sa.Column('comment', sa.String(length=255), nullable=True),
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('user_email', sa.String(length=255), nullable=False),
+    sa.Column('relay_mail', sa.String(length=255), nullable=False),
+    sa.Column('host', sa.String(length=255), nullable=False),
+    sa.Column('port', sa.Integer(), nullable=False),
+    sa.Column('tls', sa.Boolean(), nullable=False),
+    sa.Column('username', sa.String(length=255), nullable=False),
+    sa.Column('password', sa.String(length=255), nullable=False),
+    sa.ForeignKeyConstraint(['user_email'], ['user.email'], name=op.f('user_relay_user_email_fkey')),
+    sa.PrimaryKeyConstraint('id', name=op.f('user_relay_pkey')),
+    sa.UniqueConstraint('relay_mail')
+    )
+
+
+def downgrade():
+    op.drop_table('user_relay')

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -25,14 +25,14 @@ podop = socketmap:unix:/tmp/podop.socket:
 # Only accept virtual emails
 mydestination =
 
-# Relayhost if any is configured
+# Relayhost if any is configured and sender dependent relay
 relayhost = {{ RELAYHOST }}
-{% if RELAYUSER %}
 smtp_sasl_auth_enable = yes
-smtp_sasl_password_maps = lmdb:/etc/postfix/sasl_passwd
+smtp_sasl_password_maps = ${podop}senderrelayauth{% if RELAYUSER %}, lmdb:/etc/postfix/sasl_passwd{% endif %}
 smtp_sasl_security_options = noanonymous, noplaintext
 smtp_sasl_tls_security_options = noanonymous
-{% endif %}
+smtp_sender_dependent_authentication = yes
+sender_dependent_relayhost_maps = ${podop}senderrelayhostmap
 
 # Recipient delimiter for extended addresses
 recipient_delimiter = {{ RECIPIENT_DELIMITER }}
@@ -100,8 +100,10 @@ lmtp_host_lookup = native
 # Delay all rejects until all information can be logged
 smtpd_delay_reject = yes
 
-# Allowed senders are: the user or one of the alias destinations
-smtpd_sender_login_maps = ${podop}senderlogin
+# Allowed senders are: the user or one of the alias destinations and user
+# dependent relay addresses. These relay adresses are disjoint from senderlogin
+# addresses --> no unionmap needed at this point
+smtpd_sender_login_maps = ${podop}senderlogin, ${podop}senderrelaylogin
 
 # Restrictions for incoming SMTP, other restrictions are applied in master.cf
 smtpd_helo_required = yes

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -29,7 +29,10 @@ def start_podop():
         ("sendermap", "url", url + "sender/map/§"),
         ("senderaccess", "url", url + "sender/access/§"),
         ("senderlogin", "url", url + "sender/login/§"),
-        ("senderrate", "url", url + "sender/rate/§")
+        ("senderrate", "url", url + "sender/rate/§"),
+        ("senderrelayhostmap", "url", url + "sender/relay/host/§"),
+        ("senderrelayauth", "url", url + "sender/relay/auth/§"),
+        ("senderrelaylogin", "url", url + "sender/relay/login/§")
     ])
 
 def start_mta_sts_daemon():

--- a/docs/webadministration.rst
+++ b/docs/webadministration.rst
@@ -160,6 +160,29 @@ You can add a fetched account by clicking on the `Add an account` button on the 
 Click the submit button to apply settings. With the default polling interval, fetchmail will start polling the email account after 10 minutes.
 
 
+Relay accounts
+----------------
+
+On the `relay accounts` page you can configure email accounts over which email messages will be sent if they use the relay mail address as sending email.
+
+You can add a relay account by clicking on the `Add an account` button on the top right of the page. To add an relay account, the following settings must be configured:
+
+* Relay mail address. The mail address which should be relayed over the server.
+
+* Hostname or IP. The hostname or IP address of the relay email server.
+
+* TCP port. The TCP port the relay email server listens on. Common ports are 465 (SMTPS with TLS), 587 (SMTP with STARTTLS), 25 (Default SMPT port).
+
+* Enable TLS. Tick this setting if the email server requires TLS/SSL instead of STARTTLS.
+
+* Username. The user name for logging in to the relay email server. Normally this is the email address or the email address' local-part (the part before @).
+
+* Password. The password for logging in to the relay email server.
+
+Click the submit button to apply settings. When pressing the submit button an actual login to the relay server ist tried to prevent the use of invalid mail accounts.
+Please be patiant as antispam rules can defer the login.
+
+
 Authentication tokens
 ---------------------
 

--- a/towncrier/newsfragments/2412.feature
+++ b/towncrier/newsfragments/2412.feature
@@ -1,0 +1,1 @@
+Add support for setting up relay accounts for users


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

Supports setting up [sender dependent relayhost maps](https://www.postfix.org/postconf.5.html#sender_dependent_relayhost_maps) for users.

The code adds a menu item for users which allows to add relay host entries for this user. Every added account allows the user to send mails from the relay mail address. The mail is relayed over the relay server with the relay mail login.

When an account is saved, an actual login is tried against the server to prevent the use of invalid mail accounts.

### Related issue(s)

None

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
