### PR TITLE
Put ipv6 resolver address in square brackets

### DIFF
--- a/core/nginx/config.py
+++ b/core/nginx/config.py
@@ -12,7 +12,8 @@ log.basicConfig(stream=sys.stderr, level=args.get("LOG_LEVEL", "WARNING"))
 # Get the first DNS server
 with open("/etc/resolv.conf") as handle:
     content = handle.read().split()
-    args["RESOLVER"] = content[content.index("nameserver") + 1]
+    resolver = content[content.index("nameserver") + 1]
+    args["RESOLVER"] = f"[{resolver}]" if ":" in resolver else resolver
 
 args["ADMIN_ADDRESS"] = system.get_host_address_from_environment("ADMIN", "admin")
 args["ANTISPAM_WEBUI_ADDRESS"] = system.get_host_address_from_environment("ANTISPAM_WEBUI", "antispam:11334")


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

NGINX front container currently does not handle IPv6 resolver addresses correctly, this PR fixes this.
Replaces #2382
