### PR TITLE
Correct the extension of files used for Roundcube overrides

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -267,7 +267,7 @@ correct syntax. The following file names will be taken as override configuration
 - `Dovecot`_ - ``dovecot.conf`` in dovecot sub-directory;
 - `Nginx`_ - All ``*.conf`` files in the ``nginx`` sub-directory;
 - `Rspamd`_ - All files in the ``rspamd`` sub-directory.
-- Roundcube - All ``*.inc`` files in the ``roundcube`` sub directory.
+- `Roundcube`_ - All ``*.inc.php`` files in the ``roundcube`` sub directory.
 
 To override the root location (``/``) in Nginx ``WEBROOT_REDIRECT`` needs to be set to ``none`` in the env file (see :ref:`web settings <web_settings>`).
 
@@ -354,10 +354,11 @@ How do I use webdav (radicale)?
 *issue reference:* `1591`_.
 
 
-.. _`Postfix`: http://www.postfix.org/postconf.5.html
-.. _`Dovecot`: https://doc.dovecot.org/configuration_manual/config_file/config_file_syntax/
-.. _`NGINX`:   https://nginx.org/en/docs/
-.. _`Rspamd`:  https://www.rspamd.com/doc/configuration/index.html
+.. _`Postfix`:   http://www.postfix.org/postconf.5.html
+.. _`Dovecot`:   https://doc.dovecot.org/configuration_manual/config_file/config_file_syntax/
+.. _`NGINX`:     https://nginx.org/en/docs/
+.. _`Rspamd`:    https://www.rspamd.com/doc/configuration/index.html
+.. _`Roundcube`: https://github.com/roundcube/roundcubemail/wiki/Configuration#customize-the-look
 
 .. _`Docker swarm howto`: https://github.com/Mailu/Mailu/tree/master/docs/swarm/master
 .. _`125`: https://github.com/Mailu/Mailu/issues/125

--- a/towncrier/newsfragments/2388.bugfix
+++ b/towncrier/newsfragments/2388.bugfix
@@ -1,0 +1,1 @@
+Roundcube overrides now also include .inc.php files. Only .inc.php should be used moving forward.

--- a/webmails/roundcube/start.py
+++ b/webmails/roundcube/start.py
@@ -60,7 +60,7 @@ else:
 context["PLUGINS"] = ",".join(f"'{p}'" for p in plugins)
 
 # add overrides
-context["INCLUDES"] = sorted(inc for inc in os.listdir("/overrides") if inc.endswith(".inc")) if os.path.isdir("/overrides") else []
+context["INCLUDES"] = sorted(inc for inc in os.listdir("/overrides") if inc.endswith((".inc", ".inc.php"))) if os.path.isdir("/overrides") else []
 
 # calculate variables for config file
 context["SESSION_TIMEOUT_MINUTES"] = max(int(env.get("SESSION_TIMEOUT", "3600")) // 60, 1)


### PR DESCRIPTION
This adds ".inc.php" files to the included overrides while maintaining support for existing ".inc" files previously included via overrides. It also updates the corresponding documentation.

Roundcube itself uses "inc.php" files and these overrides are expected to match that format. Switching to "inc.php" both tells the user that these need to be proper php files and conveys they are used for changing the same settings that Roundcube's inc.php files modify.

## What type of PR?

bug-fix, documentation

## What does this PR do?

- Adds ".inc.php" to the list of include files being built in roundcube's start.py
- Updates override information in the faq section: [How can I override settings?](https://github.com/Mailu/Mailu/blob/master/docs/faq.rst#how-can-i-override-settings)
- Includes changelog recommends using .inc.php moving forward

## Related issue(s)
- This addresses confusion seen in issues like: #2388

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
