### PR TITLE
Switch to mode=min for GHA cache for docker buildx 

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -135,7 +135,7 @@ jobs:
           push: false
           set: |
             *.cache-from=type=gha,scope=build-${{ matrix.target }}
-            *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=max
+            *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=min
             *.platform=${{ inputs.architecture }}
 
 # This job runs all the tests.

--- a/webmails/roundcube/Dockerfile
+++ b/webmails/roundcube/Dockerfile
@@ -1,4 +1,3 @@
-# NOTE: only add qemu-arm-static if building for arm
 FROM php:8.0-apache
 
 ARG VERSION


### PR DESCRIPTION
Switch to mode=min for GHA cache for docker buildx to prevent rate limiting in GHA workflow.
It has hardly any influence on build times. 
See https://github.com/Diman0/Mailu_Fork/actions/runs/2893811188
It is still ~12 minutes.

For example search for SHA256 in the logs of https://github.com/Mailu/Mailu/runs/7923068540?check_suite_focus=true:
- 304 hits!
- With 6 tests that is 1824 cache hits

Search for SHA256 in the logs  of https://github.com/Diman0/Mailu_Fork/runs/7929824199?check_suite_focus=true
- 186 hits
- With 6 tests that is 1116 cache hits

That is better. I hope this will prevent rate limiting issues.

## What type of PR?

enhancement

## What does this PR do?

### Related issue(s)
None

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [n/a] In case of feature or enhancement: documentation updated accordingly
- [n/a] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
