### PR TITLE
Hotfix for workflow. For build step do not build from cache.

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -134,8 +134,7 @@ jobs:
           load: false
           push: false
           set: |
-            *.cache-from=type=gha,scope=build-${{ matrix.target }}
-            *.cache-to=type=gha,scope=build-${{ matrix.target }},mode=min
+            *.cache-to=type=gha,scope=build-${{ matrix.target }}-${{ github.ref }},mode=min
             *.platform=${{ inputs.architecture }}
 
 # This job runs all the tests.
@@ -190,20 +189,20 @@ jobs:
           load: true
           push: false
           set: |
-            *.cache-from=type=gha,scope=build-docs
-            *.cache-from=type=gha,scope=build-setup
-            *.cache-from=type=gha,scope=build-admin
-            *.cache-from=type=gha,scope=build-antispam
-            *.cache-from=type=gha,scope=build-front
-            *.cache-from=type=gha,scope=build-imap
-            *.cache-from=type=gha,scope=build-smtp
-            *.cache-from=type=gha,scope=build-snappymail
-            *.cache-from=type=gha,scope=build-roundcube
-            *.cache-from=type=gha,scope=build-antivirus
-            *.cache-from=type=gha,scope=build-fetchmail
-            *.cache-from=type=gha,scope=build-resolver
-            *.cache-from=type=gha,scope=build-traefik-certdumper
-            *.cache-from=type=gha,scope=build-webdav
+            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-front-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}
             *.platform=${{ inputs.architecture }}
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
@@ -255,20 +254,20 @@ jobs:
           files: ${{env.HCL_FILE}}
           push: true
           set: |
-            *.cache-from=type=gha,scope=build-docs
-            *.cache-from=type=gha,scope=build-setup
-            *.cache-from=type=gha,scope=build-admin
-            *.cache-from=type=gha,scope=build-antispam
-            *.cache-from=type=gha,scope=build-front
-            *.cache-from=type=gha,scope=build-imap
-            *.cache-from=type=gha,scope=build-smtp
-            *.cache-from=type=gha,scope=build-snappymail
-            *.cache-from=type=gha,scope=build-roundcube
-            *.cache-from=type=gha,scope=build-antivirus
-            *.cache-from=type=gha,scope=build-fetchmail
-            *.cache-from=type=gha,scope=build-resolver
-            *.cache-from=type=gha,scope=build-traefik-certdumper
-            *.cache-from=type=gha,scope=build-webdav
+            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-front-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}
             *.platform=${{ inputs.architecture }}
 
   deploy-arm:

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -134,7 +134,7 @@ jobs:
           load: false
           push: false
           set: |
-            *.cache-to=type=gha,scope=build-${{ matrix.target }}-${{ github.ref }},mode=min
+            *.cache-to=type=gha,scope=build-${{ matrix.target }}-${{ github.ref }}-${{ github.run_id }},mode=min
             *.platform=${{ inputs.architecture }}
 
 # This job runs all the tests.
@@ -189,20 +189,20 @@ jobs:
           load: true
           push: false
           set: |
-            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-front-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-front-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}-${{ github.run_id }}
             *.platform=${{ inputs.architecture }}
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
@@ -254,20 +254,20 @@ jobs:
           files: ${{env.HCL_FILE}}
           push: true
           set: |
-            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-front-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}
-            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}
+            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-front-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}-${{ github.run_id }}
             *.platform=${{ inputs.architecture }}
 
   deploy-arm:
@@ -306,20 +306,20 @@ jobs:
           files: ${{env.HCL_FILE}}
           push: true
           set: |
-            *.cache-from=type=gha,scope=build-docs
-            *.cache-from=type=gha,scope=build-setup
-            *.cache-from=type=gha,scope=build-admin
-            *.cache-from=type=gha,scope=build-antispam
-            *.cache-from=type=gha,scope=build-front
-            *.cache-from=type=gha,scope=build-imap
-            *.cache-from=type=gha,scope=build-smtp
-            *.cache-from=type=gha,scope=build-snappymail
-            *.cache-from=type=gha,scope=build-roundcube
-            *.cache-from=type=gha,scope=build-antivirus
-            *.cache-from=type=gha,scope=build-fetchmail
-            *.cache-from=type=gha,scope=build-resolver
-            *.cache-from=type=gha,scope=build-traefik-certdumper
-            *.cache-from=type=gha,scope=build-webdav
+            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-front-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}-${{ github.run_id }}
             *.platform=${{ inputs.architecture }}
 
 #This job creates a tagged release. A tag is created for the pinned version x.y.z. The GH release refers to this tag.

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -134,7 +134,7 @@ jobs:
           load: false
           push: false
           set: |
-            *.cache-to=type=gha,scope=build-${{ matrix.target }}-${{ github.ref }}-${{ github.run_id }},mode=min
+            *.cache-to=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-${{ matrix.target }}-build,mode=min
             *.platform=${{ inputs.architecture }}
 
 # This job runs all the tests.
@@ -189,20 +189,20 @@ jobs:
           load: true
           push: false
           set: |
-            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-front-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-docs-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-setup-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-admin-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-antispam-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-front-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-imap-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-smtp-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-snappymail-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-roundcube-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-antivirus-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-fetchmail-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-resolver-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-traefik-certdumper-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-webdav-build
             *.platform=${{ inputs.architecture }}
       - name: Install python packages
         run: python3 -m pip install -r tests/requirements.txt
@@ -254,20 +254,20 @@ jobs:
           files: ${{env.HCL_FILE}}
           push: true
           set: |
-            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-front-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-docs-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-setup-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-admin-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-antispam-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-front-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-imap-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-smtp-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-snappymail-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-roundcube-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-antivirus-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-fetchmail-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-resolver-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-traefik-certdumper-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-webdav-build
             *.platform=${{ inputs.architecture }}
 
   deploy-arm:
@@ -306,20 +306,20 @@ jobs:
           files: ${{env.HCL_FILE}}
           push: true
           set: |
-            *.cache-from=type=gha,scope=build-docs-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-setup-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-admin-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-antispam-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-front-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-imap-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-smtp-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-snappymail-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-roundcube-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-antivirus-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-fetchmail-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-resolver-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-traefik-certdumper-${{ github.ref }}-${{ github.run_id }}
-            *.cache-from=type=gha,scope=build-webdav-${{ github.ref }}-${{ github.run_id }}
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-docs-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-setup-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-admin-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-antispam-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-front-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-imap-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-smtp-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-snappymail-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-roundcube-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-antivirus-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-fetchmail-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-resolver-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-traefik-certdumper-build
+            *.cache-from=type=gha,scope=${{ github.run_id }}-${{ github.ref }}-webdav-build
             *.platform=${{ inputs.architecture }}
 
 #This job creates a tagged release. A tag is created for the pinned version x.y.z. The GH release refers to this tag.


### PR DESCRIPTION
Hotfix for workflow. For build step do not build from cache.
Make sure cache layers are unique by using ${{ github.ref }}

The build job uses the cache-from. This is not required. Due to non-unique cache keys it also resulted the build step building from cache. 
As a precaution the ${{ github.ref }} and ${{ github.run_id }} are appended to the cache key for the build cache layers. This should make sure the cache keys are unique among workflow runs

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
n/a

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [n/a] In case of feature or enhancement: documentation updated accordingly
- [n/a ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
