### PR TITLE
Update docs to mention .inc.php for roundcube

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -332,7 +332,7 @@ If ``ROUNDCUBE_PLUGINS`` is not set the following plugins are enabled by default
 
 To disable all plugins just set ``ROUNDCUBE_PLUGINS`` to ``mailu``.
 
-To configure a plugin add php files named ``*.inc`` to roundcube's :ref:`override section <override-label>`.
+To configure a plugin add php files named ``*.inc.php`` to roundcube's :ref:`override section <override-label>`.
 
 Mail log settings
 -----------------


### PR DESCRIPTION
My recent patch updated the roundcube overrides to use .inc.php vs .inc (as is done in roundcube and as suggested by roundcube plugin docs). I updated the overrides section in the docs but a page that links to the overrides section still had the old ".inc" file name. This fixes that oversight. Sorry about that.

## What type of PR?

documentation

## What does this PR do?

Updates configuration.rst to also reflect the new extension.

## Prerequisites
This patch neither adds features nor requires a towncrier.