### PR TITLE
Prevent signups for accounts where an alias exists

### DIFF
--- a/core/admin/mailu/ui/views/users.py
+++ b/core/admin/mailu/ui/views/users.py
@@ -167,7 +167,7 @@ def user_signup(domain_name=None):
         form = forms.UserSignupFormCaptcha()
 
     if form.validate_on_submit():
-        if domain.has_email(form.localpart.data):
+        if domain.has_email(form.localpart.data) or models.Alias.resolve(form.localpart.data, domain_name):
             flask.flash('Email is already used', 'error')
         else:
             flask.session.regenerate()

--- a/towncrier/newsfragments/2429.feature
+++ b/towncrier/newsfragments/2429.feature
@@ -1,0 +1,1 @@
+Prevent signups with accounts for which an SQL-LIKE alias exists.


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

This prevent signups for accounts where an SQL like alias exists; we already do it for non-SQL like aliases

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
