### PR TITLE
Fix: Don't update updated_at on quota_bytes_used change

### DIFF
--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -33,7 +33,7 @@ def dovecot_quota(ns, user_email):
     user = models.User.query.get(user_email) or flask.abort(404)
     if ns == "storage":
         user.quota_bytes_used = flask.request.get_json()
-        user.flag_updated_at_as_modified()
+        user.dont_change_updated_at()
         models.db.session.commit()
     return flask.jsonify(None)
 

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -33,6 +33,7 @@ def dovecot_quota(ns, user_email):
     user = models.User.query.get(user_email) or flask.abort(404)
     if ns == "storage":
         user.quota_bytes_used = flask.request.get_json()
+        user.flag_updated_at_as_modified()
         models.db.session.commit()
     return flask.jsonify(None)
 

--- a/core/admin/mailu/internal/views/fetch.py
+++ b/core/admin/mailu/internal/views/fetch.py
@@ -27,6 +27,7 @@ def fetch_done(fetch_id):
     fetch = models.Fetch.query.get(fetch_id) or flask.abort(404)
     fetch.last_check = datetime.datetime.now()
     fetch.error_message = str(flask.request.get_json())
+    fetch.dont_change_updated_at()
     models.db.session.add(fetch)
     models.db.session.commit()
     return ""

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -155,6 +155,10 @@ class Base(db.Model):
             self.__hashed = id(self) if primary is None else hash(primary)
         return self.__hashed
 
+    def flag_updated_at_as_modified(self):
+        """ Mark updated_at as modified, but keep the old date when updating the model"""
+        flag_modified(self, 'updated_at')
+
 
 # Many-to-many association table for domain managers
 managers = db.Table('manager', Base.metadata,
@@ -983,13 +987,3 @@ class MailuConfig:
     alias = MailuCollection(Alias)
     relay = MailuCollection(Relay)
     config = MailuCollection(Config)
-
-
-@db.event.listens_for(User, 'before_update')
-def receive_before_update(mapper, connection, target):
-    """ Mark updated_at as modified, but keep the old date when updating the quota_bytes_used
-    """
-    insp = db.inspect(target)
-    quota_bytes_used_changed, _, _ = insp.attrs.quota_bytes_used.history
-    if quota_bytes_used_changed:
-        flag_modified(target, 'updated_at')

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -155,7 +155,7 @@ class Base(db.Model):
             self.__hashed = id(self) if primary is None else hash(primary)
         return self.__hashed
 
-    def flag_updated_at_as_modified(self):
+    def dont_change_updated_at(self):
         """ Mark updated_at as modified, but keep the old date when updating the model"""
         flag_modified(self, 'updated_at')
 

--- a/towncrier/newsfragments/1363.bugfix
+++ b/towncrier/newsfragments/1363.bugfix
@@ -1,0 +1,1 @@
+Do not update the updated_at field of the User model when quota_bytes_used is updated


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

This PR makes sure that the `updated_at` field is not updated when `quota_bytes_used` is updated. All other updates to the `User` model still updates the `updated_at` field. 

This is done by explicitly using an method in the `Base` class triggering [`flag_modified`][url-flag-modified].

### Related issue(s)
- closes #1363

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.

<!-- LINKS-->
[url-flag-modified]: https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.attributes.flag_modified
