### PR TITLE
Ensure that Mailu keeps working even if it can't obtain a certificate from LE

### DIFF
--- a/core/nginx/letsencrypt.py
+++ b/core/nginx/letsencrypt.py
@@ -15,6 +15,7 @@ command = [
     "--cert-name", "mailu",
     "--preferred-challenges", "http", "--http-01-port", "8008",
     "--keep-until-expiring",
+    "--allow-subset-of-names",
     "--renew-with-new-domains",
     "--config-dir", "/certs/letsencrypt",
     "--post-hook", "/config.py"
@@ -28,6 +29,7 @@ command2 = [
     "--cert-name", "mailu-ecdsa",
     "--preferred-challenges", "http", "--http-01-port", "8008",
     "--keep-until-expiring",
+    "--allow-subset-of-names",
     "--key-type", "ecdsa",
     "--renew-with-new-domains",
     "--config-dir", "/certs/letsencrypt",

--- a/towncrier/newsfragments/2467.bugfix
+++ b/towncrier/newsfragments/2467.bugfix
@@ -1,0 +1,1 @@
+Ensure that Mailu keeps working even if it can't obtain a certificate from letsencrypt for one of the HOSTNAMES


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Ensure that Mailu keeps working even if it can't obtain a certificate from letsencrypt for one of the HOSTNAMES

Without this TLS configuration would fail and Mailu would operate without TLS completely.

I haven't tested it but thought this used to work previously... maybe certbot has changed something

### Related issue(s)
- closes #2467

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
