### PR TITLE
Rework the anti-spoofing rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Main features include:
 - **User features**, aliases, auto-reply, auto-forward, fetched accounts
 - **Admin features**, global admins, announcements, per-domain delegation, quotas
 - **Security**, enforced TLS, DANE, MTA-STS, Letsencrypt!, outgoing DKIM, anti-virus scanner
-- **Antispam**, auto-learn, greylisting, DMARC and SPF
+- **Antispam**, auto-learn, greylisting, DMARC and SPF, anti-spoofing
 - **Freedom**, all FOSS components, no tracker included
 
 ![Domains](docs/assets/screenshots/domains.png)

--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -158,21 +158,6 @@ def postfix_sender_rate(sender):
     user = models.User.get(sender) or flask.abort(404)
     return flask.abort(404) if user.sender_limiter.hit() else flask.jsonify("450 4.2.1 You are sending too many emails too fast.")
 
-@internal.route("/postfix/sender/access/<path:sender>")
-def postfix_sender_access(sender):
-    """ Simply reject any sender that pretends to be from a local domain
-    """
-    if '@' in sender:
-        if sender.startswith('<') and sender.endswith('>'):
-            sender = sender[1:-1]
-        try:
-            localpart, domain_name = models.Email.resolve_domain(sender)
-            if models.Domain.query.get(domain_name):
-                return flask.jsonify("REJECT")
-        except sqlalchemy.exc.StatementError:
-            pass
-    return flask.abort(404)
-
 # idna encode domain part of each address in list of addresses
 def idna_encode(addresses):
     return [

--- a/core/admin/mailu/internal/views/rspamd.py
+++ b/core/admin/mailu/internal/views/rspamd.py
@@ -28,5 +28,4 @@ def rspamd_dkim_key(domain_name):
 
 @internal.route("/rspamd/local_domains", methods=['GET'])
 def rspamd_local_domains():
-    domains = set(models.Domain.query.all() + models.Alternative.query.all())
-    return '\n'.join(map(str,domains))
+    return '\n'.join(domain[0] for domain in models.Domain.query.with_entities(models.Domain.name).all() + models.Alternative.query.with_entities(models.Alternative.name).all())

--- a/core/admin/mailu/internal/views/rspamd.py
+++ b/core/admin/mailu/internal/views/rspamd.py
@@ -29,4 +29,4 @@ def rspamd_dkim_key(domain_name):
 @internal.route("/rspamd/local_domains", methods=['GET'])
 def rspamd_local_domains():
     domains = set(models.Domain.query.all() + models.Alternative.query.all())
-    return '\n'.join(domains)
+    return '\n'.join(map(str,domains))

--- a/core/admin/mailu/internal/views/rspamd.py
+++ b/core/admin/mailu/internal/views/rspamd.py
@@ -25,3 +25,8 @@ def rspamd_dkim_key(domain_name):
                 }
             )
     return flask.jsonify({'data': {'selectors': selectors}})
+
+@internal.route("/rspamd/local_domains", methods=['GET'])
+def rspamd_local_domains():
+    domains = set(models.Domain.query.all() + models.Alternative.query.all())
+    return '\n'.join(domains)

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -110,7 +110,6 @@ check_ratelimit = check_sasl_access ${podop}senderrate
 
 smtpd_client_restrictions =
   permit_mynetworks,
-  check_sender_access ${podop}senderaccess,
   reject_non_fqdn_sender,
   reject_unknown_sender_domain,
   reject_unknown_recipient_domain,

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -27,7 +27,6 @@ def start_podop():
         ("mailbox", "url", url + "mailbox/§"),
         ("recipientmap", "url", url + "recipient/map/§"),
         ("sendermap", "url", url + "sender/map/§"),
-        ("senderaccess", "url", url + "sender/access/§"),
         ("senderlogin", "url", url + "sender/login/§"),
         ("senderrate", "url", url + "sender/rate/§")
     ])

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -1,17 +1,17 @@
 rules {
   ANTISPOOF_NOAUTH {
     action = "reject";
-    expression = "(IS_LOCAL_DOMAIN_E & MISSING_FROM) | (IS_LOCAL_DOMAIN_H & (R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA))";
+    expression = "-MAILLIST & ((IS_LOCAL_DOMAIN_E & MISSING_FROM) | (IS_LOCAL_DOMAIN_H & (R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA)))";
     message = "Rejected (anti-spoofing: noauth). Please setup DMARC with DKIM or SPF if you want to send emails from your domain from other servers.";
   }
   ANTISPOOF_DMARC_ENFORCE_LOCAL {
     action = "reject";
-    expression = "(IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE | DMARC_NA)";
+    expression = "-MAILLIST & (IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE | DMARC_NA)";
     message = "Rejected (anti-spoofing: DMARC compliance is enforced for local domains, regardless of the policy setting)";
   }
   ANTISPOOF_AUTH_FAILED {
     action = "reject";
-    expression = "BLACKLIST_ANTISPOOF";
+    expression = "-MAILLIST & BLACKLIST_ANTISPOOF";
     message = "Rejected (anti-spoofing: auth-failed)";
   }
 }

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -1,7 +1,17 @@
 rules {
-  ANTISPOOF {
+  ANTISPOOF_NOAUTH {
     action = "reject";
-    expression = "((R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA)|BLACKLIST_ANTISPOOF) & IS_LOCAL_DOMAIN";
-    message = "Rejected (anti-spoofing)";
+    expression = "(IS_LOCAL_DOMAIN_E & MISSING_FROM) | (IS_LOCAL_DOMAIN_H & (R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA))";
+    message = "Rejected (anti-spoofing noauth)";
+  }
+  ANTISPOOF_DMARC_ENFORCE_LOCAL {
+    action = "reject";
+    expression = "((IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE)";
+    message = "Rejected (anti-spoofing DMARC-enforce for local domains)";
+  }
+  ANTISPOOF_AUTH_FAILED {
+    action = "reject";
+    expression = "BLACKLIST_ANTISPOOF";
+    message = "Rejected (anti-spoofing auth-failed)";
   }
 }

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -6,7 +6,7 @@ rules {
   }
   ANTISPOOF_DMARC_ENFORCE_LOCAL {
     action = "reject";
-    expression = "((IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE | DMARC_NA)";
+    expression = "(IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE | DMARC_NA)";
     message = "Rejected (anti-spoofing: DMARC compliance is enforced for local domains, regardless of the policy setting)";
   }
   ANTISPOOF_AUTH_FAILED {

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -1,17 +1,17 @@
 rules {
   ANTISPOOF_NOAUTH {
     action = "reject";
-    expression = "-MAILLIST & ((IS_LOCAL_DOMAIN_E & MISSING_FROM) | (IS_LOCAL_DOMAIN_H & (R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA)))";
+    expression = "!MAILLIST & ((IS_LOCAL_DOMAIN_E & MISSING_FROM) | (IS_LOCAL_DOMAIN_H & (R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA)))";
     message = "Rejected (anti-spoofing: noauth). Please setup DMARC with DKIM or SPF if you want to send emails from your domain from other servers.";
   }
   ANTISPOOF_DMARC_ENFORCE_LOCAL {
     action = "reject";
-    expression = "-MAILLIST & (IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE | DMARC_NA)";
+    expression = "!MAILLIST & (IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE | DMARC_NA)";
     message = "Rejected (anti-spoofing: DMARC compliance is enforced for local domains, regardless of the policy setting)";
   }
   ANTISPOOF_AUTH_FAILED {
     action = "reject";
-    expression = "-MAILLIST & BLACKLIST_ANTISPOOF";
+    expression = "!MAILLIST & BLACKLIST_ANTISPOOF";
     message = "Rejected (anti-spoofing: auth-failed)";
   }
 }

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -1,7 +1,7 @@
 rules {
-  WHITELIST_EXCEPTION {
+  ANTISPOOF {
     action = "reject";
-    expression = "(AUTH_NA|BLACKLIST_ANTISPOOF) & IS_LOCAL_DOMAIN";
+    expression = "((R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA)|BLACKLIST_ANTISPOOF) & IS_LOCAL_DOMAIN";
     message = "Rejected (anti-spoofing)";
   }
 }

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -1,0 +1,7 @@
+rules {
+  WHITELIST_EXCEPTION {
+    action = "reject";
+    expression = "(AUTH_NA|BLACKLIST_ANTISPOOF) & IS_LOCAL_DOMAIN";
+    message = "Rejected (anti-spoofing)";
+  }
+}

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -2,16 +2,16 @@ rules {
   ANTISPOOF_NOAUTH {
     action = "reject";
     expression = "(IS_LOCAL_DOMAIN_E & MISSING_FROM) | (IS_LOCAL_DOMAIN_H & (R_DKIM_NA & R_SPF_NA & DMARC_NA & ARC_NA))";
-    message = "Rejected (anti-spoofing noauth)";
+    message = "Rejected (anti-spoofing: noauth). Please setup DMARC with DKIM or SPF if you want to send emails from your domain from other servers.";
   }
   ANTISPOOF_DMARC_ENFORCE_LOCAL {
     action = "reject";
     expression = "((IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE)";
-    message = "Rejected (anti-spoofing DMARC-enforce for local domains)";
+    message = "Rejected (anti-spoofing: DMARC is enforced for local domains)";
   }
   ANTISPOOF_AUTH_FAILED {
     action = "reject";
     expression = "BLACKLIST_ANTISPOOF";
-    message = "Rejected (anti-spoofing auth-failed)";
+    message = "Rejected (anti-spoofing: auth-failed)";
   }
 }

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -6,8 +6,8 @@ rules {
   }
   ANTISPOOF_DMARC_ENFORCE_LOCAL {
     action = "reject";
-    expression = "((IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE)";
-    message = "Rejected (anti-spoofing: DMARC is enforced for local domains)";
+    expression = "((IS_LOCAL_DOMAIN_H | IS_LOCAL_DOMAIN_E) & (DMARC_POLICY_SOFTFAIL | DMARC_POLICY_REJECT | DMARC_POLICY_QUARANTINE | DMARC_NA)";
+    message = "Rejected (anti-spoofing: DMARC compliance is enforced for local domains, regardless of the policy setting)";
   }
   ANTISPOOF_AUTH_FAILED {
     action = "reject";

--- a/core/rspamd/conf/multimap.conf
+++ b/core/rspamd/conf/multimap.conf
@@ -1,11 +1,15 @@
 IS_LOCAL_DOMAIN_H {
   type = "selector"
   selector = "from('mime'):domain";
-  map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+  map = [
+"http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains",
+"fallback+file:///dev/null"];
 }
 
 IS_LOCAL_DOMAIN_E {
   type = "selector"
   selector = "from('smtp'):domain";
-  map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+  map = [
+"http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains",
+"fallback+file:///dev/null"];
 }

--- a/core/rspamd/conf/multimap.conf
+++ b/core/rspamd/conf/multimap.conf
@@ -1,15 +1,11 @@
 IS_LOCAL_DOMAIN_H {
   type = "selector"
   selector = "from('mime'):domain";
-  map = [
-"http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains",
-"fallback+file:///dev/null"];
+  map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
 }
 
 IS_LOCAL_DOMAIN_E {
   type = "selector"
   selector = "from('smtp'):domain";
-  map = [
-"http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains",
-"fallback+file:///dev/null"];
+  map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
 }

--- a/core/rspamd/conf/multimap.conf
+++ b/core/rspamd/conf/multimap.conf
@@ -1,0 +1,5 @@
+IS_LOCAL_DOMAIN {
+  type = "from";
+  filter = "email:domain";
+  map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+}

--- a/core/rspamd/conf/multimap.conf
+++ b/core/rspamd/conf/multimap.conf
@@ -1,5 +1,11 @@
-IS_LOCAL_DOMAIN {
-  type = "from";
-  filter = "email:domain";
+IS_LOCAL_DOMAIN_H {
+  type = "selector"
+  selector = "from('mime'):domain";
+  map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+}
+
+IS_LOCAL_DOMAIN_E {
+  type = "selector"
+  selector = "from('smtp'):domain";
   map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
 }

--- a/core/rspamd/conf/whitelist.conf
+++ b/core/rspamd/conf/whitelist.conf
@@ -2,7 +2,7 @@ rules {
         BLACKLIST_ANTISPOOF = {
             valid_dmarc = true;
             blacklist = true;
-            domains = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+            domains = ["http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains", "fallback+file:///dev/null"];
 	    score = 0.0;
         }
 }

--- a/core/rspamd/conf/whitelist.conf
+++ b/core/rspamd/conf/whitelist.conf
@@ -1,0 +1,8 @@
+rules {
+        BLACKLIST_ANTISPOOF = {
+            valid_dmarc = true;
+            blacklist = true;
+            domains = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+            score = 15.0;
+        }
+}

--- a/core/rspamd/conf/whitelist.conf
+++ b/core/rspamd/conf/whitelist.conf
@@ -3,6 +3,6 @@ rules {
             valid_dmarc = true;
             blacklist = true;
             domains = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
-	    score = 99.0;
+	    score = 0.0;
         }
 }

--- a/core/rspamd/conf/whitelist.conf
+++ b/core/rspamd/conf/whitelist.conf
@@ -3,6 +3,6 @@ rules {
             valid_dmarc = true;
             blacklist = true;
             domains = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
-            score = 15.0;
+	    score = 99.0;
         }
 }

--- a/core/rspamd/conf/whitelist.conf
+++ b/core/rspamd/conf/whitelist.conf
@@ -2,7 +2,7 @@ rules {
         BLACKLIST_ANTISPOOF = {
             valid_dmarc = true;
             blacklist = true;
-            domains = ["http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains", "fallback+file:///dev/null"];
+            domains = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
 	    score = 0.0;
         }
 }

--- a/core/rspamd/start.py
+++ b/core/rspamd/start.py
@@ -3,7 +3,9 @@
 import os
 import glob
 import logging as log
+import requests
 import sys
+import time
 from socrate import system, conf
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
@@ -18,6 +20,17 @@ if os.environ.get("ANTIVIRUS") == 'clamav':
 
 for rspamd_file in glob.glob("/conf/*"):
     conf.jinja(rspamd_file, os.environ, os.path.join("/etc/rspamd/local.d", os.path.basename(rspamd_file)))
+
+# Admin may not be up just yet
+healthcheck = f'http://{os.environ["ADMIN_ADDRESS"]}/internal/rspamd/local_domains'
+while True:
+    time.sleep(1)
+    try:
+        if requests.get(healthcheck,timeout=2).ok:
+            break
+    except:
+        pass
+    print("Admin is not up just yet, retrying in 1 second")
 
 # Run rspamd
 os.execv("/usr/sbin/rspamd", ["rspamd", "-i", "-f"])

--- a/core/rspamd/start.py
+++ b/core/rspamd/start.py
@@ -30,7 +30,7 @@ while True:
             break
     except:
         pass
-    print("Admin is not up just yet, retrying in 1 second")
+    log.warning("Admin is not up just yet, retrying in 1 second")
 
 # Run rspamd
 os.execv("/usr/sbin/rspamd", ["rspamd", "-i", "-f"])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,8 +28,8 @@ Main features include:
 - **Web access**, multiple Webmails and administration interface
 - **User features**, aliases, auto-reply, auto-forward, fetched accounts
 - **Admin features**, global admins, announcements, per-domain delegation, quotas
-- **Security**, enforced TLS, Letsencrypt!, outgoing DKIM, anti-virus scanner
-- **Antispam**, auto-learn, greylisting, DMARC and SPF
+- **Security**, enforced TLS, DANE, MTA-STS, Letsencrypt!, outgoing DKIM, anti-virus scanner
+- **Antispam**, auto-learn, greylisting, DMARC and SPF, anti-spoofing
 - **Freedom**, all FOSS components, no tracker included
 
 .. image:: assets/screenshots/create.png

--- a/towncrier/newsfragments/2475.feature
+++ b/towncrier/newsfragments/2475.feature
@@ -1,0 +1,1 @@
+Remove the strict anti-spoofing rule. In 2022 we should have other controls (SPF/DKIM) for dealing with authorization and shouldn't assume that Mailu is the only MTA allowed to send emails on behalf of the domains it hosts.

--- a/towncrier/newsfragments/2475.feature
+++ b/towncrier/newsfragments/2475.feature
@@ -1,1 +1,1 @@
-Remove the strict anti-spoofing rule. In 2022 we should have other controls (SPF/DKIM) for dealing with authorization and shouldn't assume that Mailu is the only MTA allowed to send emails on behalf of the domains it hosts.
+Upgrade the anti-spoofing rule. We shouldn't assume that Mailu is the only MTA allowed to send emails on behalf of the domains it hosts... but we should also ensure that both the envelope from and header from are checked.


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

We shouldn't assume that Mailu is the only MTA allowed to send emails on behalf of the domains it hosts.
We should also ensure that it's non-trivial for email-spoofing of hosted domains to happen

Previously we were preventing any spoofing of the envelope from; Now we are preventing spoofing of both the envelope from and the header from unless some form of authentication passes (is a RELAYHOST, SPF, DKIM, ARC)

### Related issue(s)
- close #2475

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
