### PR TITLE
Quote SMTP SIZE to avoid splitting keyword and parameter in EHLO response

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -288,7 +288,7 @@ mail {
     {% endif %}
 
     # Advertise real capabilities of backends (postfix/dovecot)
-    smtp_capabilities PIPELINING SIZE {{ MESSAGE_SIZE_LIMIT }} ETRN ENHANCEDSTATUSCODES 8BITMIME DSN;
+    smtp_capabilities PIPELINING "SIZE {{ MESSAGE_SIZE_LIMIT }}" ETRN ENHANCEDSTATUSCODES 8BITMIME DSN;
     pop3_capabilities TOP UIDL RESP-CODES PIPELINING AUTH-RESP-CODE USER;
     imap_capabilities IMAP4 IMAP4rev1 UIDPLUS SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+;
 

--- a/towncrier/newsfragments/2485.bugfix
+++ b/towncrier/newsfragments/2485.bugfix
@@ -1,0 +1,1 @@
+Quote SMTP SIZE to avoid splitting keyword and parameter in EHLO response


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fixes a syntax issue in the nginx front EHLO response. As currently configured, the SIZE parameter and value are treated as separate keywords and as a result are returned on separate lines in an EHLO response:

```
...
250-SIZE
250-50000000
...
```

By adding quotes, nginx will return the correct response on a single line:

```
...
250-SIZE 50000000
...
```

### Related issue(s)

closes #2485

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
