### PR TITLE
Fix broken SMTP container logging after restart

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -91,6 +91,10 @@ if "RELAYUSER" in os.environ:
 
 # Configure and start local rsyslog server
 conf.jinja("/conf/rsyslog.conf", os.environ, "/etc/rsyslog.conf")
+try:
+    os.unlink("/var/run/rsyslogd.pid")
+except FileNotFoundError:
+    pass
 os.system("/usr/sbin/rsyslogd -niNONE &")
 # Configure logrotate and start crond
 if os.environ["POSTFIX_LOG_FILE"] != "":

--- a/towncrier/newsfragments/2490.bugfix
+++ b/towncrier/newsfragments/2490.bugfix
@@ -1,0 +1,1 @@
+Fix broken logging after SMTP container restart


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
Fixes logging for SMTP container if the container is restarted via `docker-compose stop` or host restart

### Related issue(s)
closes #2490 

## Prerequisites
- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
