### PR TITLE
Implement ITERATE in podop

### DIFF
--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -5,6 +5,7 @@ from flask import current_app as app
 import flask
 import socket
 import os
+import sqlalchemy.exc
 
 @internal.route("/dovecot/passdb/<path:user_email>")
 def dovecot_passdb_dict(user_email):
@@ -29,7 +30,7 @@ def dovecot_userdb_dict_list():
 def dovecot_userdb_dict(user_email):
     try:
         quota = models.User.query.filter(models.User.email==user_email).with_entities(models.User.quota_bytes).one_or_none() or flask.abort(404)
-    except ValueError:
+    except sqlalchemy.exc.StatementError as exc:
         flask.abort(404)
     return flask.jsonify({
         "quota_rule": f"*:bytes={quota[0]}"

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -19,6 +19,11 @@ def dovecot_passdb_dict(user_email):
         "allow_nets": ",".join(allow_nets)
     })
 
+@internal.route("/dovecot/userdb/")
+def dovecot_userdb_dict_list():
+    return flask.jsonify([
+        user[0] for user in models.User.query.filter(models.User.enabled.is_(True)).with_entities(models.User.email).all()
+    ])
 
 @internal.route("/dovecot/userdb/<path:user_email>")
 def dovecot_userdb_dict(user_email):

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -27,9 +27,9 @@ def dovecot_userdb_dict_list():
 
 @internal.route("/dovecot/userdb/<path:user_email>")
 def dovecot_userdb_dict(user_email):
-    user = models.User.query.get(user_email) or flask.abort(404)
+    quota = models.User.query.filter(models.User.email==email).with_entities(models.User.quota_bytes).one_or_none() or flask.abort(404)
     return flask.jsonify({
-        "quota_rule": "*:bytes={}".format(user.quota_bytes)
+        "quota_rule": "*:bytes="+quota[0])
     })
 
 

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -27,7 +27,10 @@ def dovecot_userdb_dict_list():
 
 @internal.route("/dovecot/userdb/<path:user_email>")
 def dovecot_userdb_dict(user_email):
-    quota = models.User.query.filter(models.User.email==user_email).with_entities(models.User.quota_bytes).one_or_none() or flask.abort(404)
+    try:
+        quota = models.User.query.filter(models.User.email==user_email).with_entities(models.User.quota_bytes).one_or_none() or flask.abort(404)
+    except ValueError:
+        flask.abort(404)
     return flask.jsonify({
         "quota_rule": f"*:bytes={quota[0]}"
     })

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -29,7 +29,7 @@ def dovecot_userdb_dict_list():
 def dovecot_userdb_dict(user_email):
     quota = models.User.query.filter(models.User.email==email).with_entities(models.User.quota_bytes).one_or_none() or flask.abort(404)
     return flask.jsonify({
-        "quota_rule": "*:bytes="+quota[0])
+        "quota_rule": "*:bytes="+quota[0]
     })
 
 

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -27,7 +27,7 @@ def dovecot_userdb_dict_list():
 
 @internal.route("/dovecot/userdb/<path:user_email>")
 def dovecot_userdb_dict(user_email):
-    quota = models.User.query.filter(models.User.email==email).with_entities(models.User.quota_bytes).one_or_none() or flask.abort(404)
+    quota = models.User.query.filter(models.User.email==user_email).with_entities(models.User.quota_bytes).one_or_none() or flask.abort(404)
     return flask.jsonify({
         "quota_rule": "*:bytes="+quota[0]
     })

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -29,7 +29,7 @@ def dovecot_userdb_dict_list():
 def dovecot_userdb_dict(user_email):
     quota = models.User.query.filter(models.User.email==user_email).with_entities(models.User.quota_bytes).one_or_none() or flask.abort(404)
     return flask.jsonify({
-        "quota_rule": "*:bytes="+quota[0]
+        "quota_rule": f"*:bytes={quota[0]}"
     })
 
 

--- a/core/base/libs/podop/podop/dovecot.py
+++ b/core/base/libs/podop/podop/dovecot.py
@@ -114,7 +114,7 @@ class DictProtocol(asyncio.Protocol):
             result = await self.dict.iter(key)
             logging.debug("Found {} entries: {}".format(len(result), result))
             for i,k in enumerate(result):
-                if max_rows > 0 and max_rows >= i:
+                if max_rows > 0 and i >= max_rows:
                     break
                 rows.append(self.process_lookup((path.decode("utf8")+k).encode("utf8"), user, is_iter=True))
             await asyncio.gather(*rows)

--- a/core/base/libs/podop/podop/dovecot.py
+++ b/core/base/libs/podop/podop/dovecot.py
@@ -95,7 +95,7 @@ class DictProtocol(asyncio.Protocol):
             else:
                 response = json.dumps(result).encode("ascii")
             logging.debug("Replying {}".format(key))
-            return await (self.reply(b"O", (key_type+'/'+key).encode("utf8"), response, end=True) if is_iter else self.reply(b"O", response))
+            return await (self.reply(b"O", (key_type+'/'+key).encode("utf8"), response) if is_iter else self.reply(b"O", response))
         except KeyError:
             return await self.reply(b"N")
 
@@ -156,7 +156,7 @@ class DictProtocol(asyncio.Protocol):
         del self.transactions_user[transaction_id]
         return await self.reply(b"O", transaction_id)
 
-    async def reply(self, command, *args, end=True):
+    async def reply(self, command, *args):
         logging.debug("Replying {} with {}".format(command, args))
         async with self.transport_lock:
             self.transport.write(command)

--- a/core/base/libs/podop/podop/dovecot.py
+++ b/core/base/libs/podop/podop/dovecot.py
@@ -95,7 +95,6 @@ class DictProtocol(asyncio.Protocol):
                 response = result
             else:
                 response = json.dumps(result).encode("ascii")
-            logging.debug("Replying {}".format(key))
             return await (self.reply(b"O", orig_key, response) if is_iter else self.reply(b"O", response))
         except KeyError:
             return await self.reply(b"N")

--- a/core/base/libs/podop/podop/dovecot.py
+++ b/core/base/libs/podop/podop/dovecot.py
@@ -123,9 +123,9 @@ class DictProtocol(asyncio.Protocol):
         except KeyError:
             return await self.reply(b"F")
         except Exception as e:
-            logging.error(f"Got {e}, cancelling remaining tasks")
             for task in rows:
                 task.cancel()
+            raise e
 
     def process_begin(self, transaction_id, user=None):
         """ Process a dict begin message

--- a/core/base/libs/podop/podop/dovecot.py
+++ b/core/base/libs/podop/podop/dovecot.py
@@ -156,8 +156,8 @@ class DictProtocol(asyncio.Protocol):
         return await self.reply(b"O", transaction_id)
 
     async def reply(self, command, *args):
-        logging.debug("Replying {} with {}".format(command, args))
         async with self.transport_lock:
+            logging.debug("Replying {} with {}".format(command, args))
             self.transport.write(command)
             self.transport.write(b"\t".join(map(tabescape, args)))
             if end:

--- a/core/dovecot/conf/auth.conf
+++ b/core/dovecot/conf/auth.conf
@@ -1,5 +1,6 @@
 uri = proxy:/tmp/podop.socket:auth
 iterate_disable = yes
+iterate_prefix = 'userdb/'
 default_pass_scheme = plain
 password_key = passdb/%u
 user_key = userdb/%u

--- a/towncrier/newsfragments/2498.feature
+++ b/towncrier/newsfragments/2498.feature
@@ -1,0 +1,1 @@
+Implement the required glue to make "doveadm -A" work


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

This makes ``doveadm -A`` work.

The easiest way to try it out is:
```
doveadm dict iter proxy:/tmp/podop.socket:auth shared/userdb

or 

doveadm user '*'
```

The protocol is described at https://doc.dovecot.org/developer_manual/design/dict_protocol/
The current version of dovecot is not using flags... so there's little gain in implementing them.

### Related issue(s)
- close #2499

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
