### PR TITLE
Fix armv7 build by manually downloading crates.io index

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -32,7 +32,8 @@ RUN set -euxo pipefail \
   ; apk add --no-cache py3-pip \
   ; python3 -m venv ${VIRTUAL_ENV} \
   ; ${VIRTUAL_ENV}/bin/pip install --no-cache-dir -r requirements-build.txt \
-  ; apk del -r py3-pip
+  ; apk del -r py3-pip \
+  ; rm -f /tmp/*.pem
 
 ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 
@@ -42,11 +43,12 @@ COPY libs/ libs/
 RUN set -euxo pipefail \
   ; machine="$(uname -m)"; deps="" \
   ; [[ "${machine}" == arm* || "${machine}" == aarch64 ]] && deps="${deps} build-base gcc libffi-dev python3-dev" \
-  ; [[ "${machine}" == armv7* ]] && deps="${deps} cargo libressl-dev mariadb-connector-c-dev postgresql-dev" \
+  ; [[ "${machine}" == armv7* ]] && deps="${deps} cargo git libressl-dev mariadb-connector-c-dev postgresql-dev" \
   ; [[ "${deps}" ]] && apk add --virtual .build-deps ${deps} \
+  ; [[ "${machine}" == armv7* ]] && mkdir -p /root/.cargo/registry/index && git clone --bare https://github.com/rust-lang/crates.io-index.git /root/.cargo/registry/index/github.com-1285ae84e5963aae \
   ; pip install -r requirements-${MAILU_ENV}.txt \
   ; apk -e info -q .build-deps && apk del -r .build-deps \
-  ; rm -rf /root/.cache /tmp/*.pem
+  ; rm -rf /root/.cargo /root/.cache /tmp/*.pem
 
 
 # base mailu image


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

cargo fails with oom when download crates.io index.
this circumvents the problem by cloning crates.io index manually
