### PR TITLE
Fix build action dependencies

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -41,8 +41,7 @@ COPY requirements-${MAILU_ENV}.txt ./
 COPY libs/ libs/
 
 RUN set -euxo pipefail \
-  ; machine="$(uname -m)"; deps="" \
-  ; [[ "${machine}" == arm* || "${machine}" == aarch64 || "${machine}" == x86_64 ]] && deps="${deps} build-base gcc libffi-dev python3-dev" \
+  ; machine="$(uname -m)"; deps="build-base gcc libffi-dev python3-dev" \
   ; [[ "${machine}" == armv7* ]] && deps="${deps} cargo git libressl-dev mariadb-connector-c-dev postgresql-dev" \
   ; [[ "${deps}" ]] && apk add --virtual .build-deps ${deps} \
   ; [[ "${machine}" == armv7* ]] && mkdir -p /root/.cargo/registry/index && git clone --bare https://github.com/rust-lang/crates.io-index.git /root/.cargo/registry/index/github.com-1285ae84e5963aae \

--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -42,7 +42,7 @@ COPY libs/ libs/
 
 RUN set -euxo pipefail \
   ; machine="$(uname -m)"; deps="" \
-  ; [[ "${machine}" == arm* || "${machine}" == aarch64 ]] && deps="${deps} build-base gcc libffi-dev python3-dev" \
+  ; [[ "${machine}" == arm* || "${machine}" == aarch64 || "${machine}" == x86_64 ]] && deps="${deps} build-base gcc libffi-dev python3-dev" \
   ; [[ "${machine}" == armv7* ]] && deps="${deps} cargo git libressl-dev mariadb-connector-c-dev postgresql-dev" \
   ; [[ "${deps}" ]] && apk add --virtual .build-deps ${deps} \
   ; [[ "${machine}" == armv7* ]] && mkdir -p /root/.cargo/registry/index && git clone --bare https://github.com/rust-lang/crates.io-index.git /root/.cargo/registry/index/github.com-1285ae84e5963aae \


### PR DESCRIPTION
## What type of PR?

Bug fix

## What does this PR do?

Adding a missing check for x86_64 to install gcc, etc.  Otherwise the build pipeline will throw an error if not using the cache that it's missing gcc and the other libraries.

### Related issue(s)

N/A

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
