### PR TITLE
Fix the CI

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -45,7 +45,7 @@ RUN set -euxo pipefail \
     { \
       machine="$(uname -m)" \
     ; deps="build-base gcc libffi-dev python3-dev" \
-    ; [[ "${machine}" == armv7 ]] && \
+    ; [[ "${machine}" != x86_64 ]] && \
         deps="${deps} cargo git libressl-dev mariadb-connector-c-dev postgresql-dev" \
     ; apk add --virtual .build-deps ${deps} \
     ; [[ "${machine}" == armv7 ]] && \


### PR DESCRIPTION
We should install the dependencies everywhere where we may have to rebuild the wheels.

If other people use other arch and want their builds to go faster we can whitelist them too after they have confirmed it works.
