### PR TITLE
Use the new notation: arm64/v8 instead of arm64

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -76,7 +76,7 @@ jobs:
       - derive-variables
     uses: ./.github/workflows/build_test_deploy.yml
     with:
-      architecture: 'linux/arm64,linux/arm/v7'
+      architecture: 'linux/arm64/v8,linux/arm/v7'
       mailu_version: ${{needs.derive-variables.outputs.MAILU_VERSION}}-arm
       pinned_mailu_version: ${{needs.derive-variables.outputs.PINNED_MAILU_VERSION}}-arm
       docker_org: ${{needs.derive-variables.outputs.DOCKER_ORG}}

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -470,6 +470,7 @@ jobs:
           docker buildx imagetools create \
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:${{ env.MAILU_VERSION }} \
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:$pinned_mailu_version \
+            --tag ${{ inputs.docker_org }}/${{ matrix.target }}:latest \
             ghcr.io/${{ steps.string.outputs.lowercase }}/${{ matrix.target }}:${{ env.MAILU_VERSION }}
 
 #This job creates a tagged release. A tag is created for the pinned version x.y.z. The GH release refers to this tag.

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -426,6 +426,7 @@ jobs:
           docker buildx imagetools create \
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:${{ env.MAILU_VERSION }} \
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:$pinned_mailu_version \
+            --tag ${{ inputs.docker_org }}/${{ matrix.target }}:latest \
             ghcr.io/${{ steps.string.outputs.lowercase }}/${{ matrix.target }}:${{ env.MAILU_VERSION }}
 
   deploy-arm:


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

With a modern version of docker compose, on arm64 you get:
```
docker-compose pull 
[+] Running 0/8
 ⠼ admin Pulling                                                                                                                                                                        1.4s
 ⠿ smtp Error                                                                                                                                                                           1.4s
 ⠿ imap Error                                                                                                                                                                           1.4s
 ⠿ webmail Error                                                                                                                                                                        1.4s
 ⠿ antispam Error                                                                                                                                                                       1.4s
 ⠼ redis Pulling                                                                                                                                                                        1.4s
 ⠼ front Pulling                                                                                                                                                                        1.4s
 ⠿ resolver Error                                                                                                                                                                       1.4s
no matching manifest for linux/arm64/v8 in the manifest list entries
```

This may fix it.

It's discussed at https://stackoverflow.com/questions/70819028/relation-between-linux-arm64-and-linux-arm64-v8-are-these-aliases-for-each-othe