### PR TITLE
Fix the armv7 build (again)!

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -15,8 +15,8 @@ RUN set -euxo pipefail \
   ; adduser -Sg ${MAILU_UID} -G mailu -h /app -g "mailu app" -s /bin/bash mailu \
   ; apk add --no-cache bash ca-certificates curl python3 tzdata \
   ; machine="$(uname -m)" \
-  ; [[ "${TARGETPLATFORM}" != linux/arm/v7 && \( "${machine}" == x86_64 || "${machine}" == armv8* || "${machine}" == aarch64 \) ]] \
-    && apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hardened-malloc
+  ; ! [[ "${TARGETPLATFORM}" != linux/arm/v7 && \( "${machine}" == x86_64 || "${machine}" == armv8* || "${machine}" == aarch64 \) ]] \
+    || apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hardened-malloc
 
 ENV LD_PRELOAD=/usr/lib/libhardened_malloc.so
 ENV CXXFLAGS="-g -O2 -fdebug-prefix-map=/app=. -fstack-protector-strong -Wformat -Werror=format-security -pie -fPIE"


### PR DESCRIPTION
Revert "simplify": ghostwheel42's approach was right
This reverts commit 04f6bd263390265da9357b17b9f77a4fd6a22330.

Without the build still errors-out because of ``set -euxo pipefail``
see https://github.com/Mailu/Mailu/actions/runs/3479399158/jobs/5817902589