### PR TITLE
Disable libhardened-malloc for non x86.

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -8,14 +8,13 @@ ENV TZ=Etc/UTC LANG=C.UTF-8
 
 ARG MAILU_UID=1000
 ARG MAILU_GID=1000
-ARG TARGETPLATFORM
 
 RUN set -euxo pipefail \
   ; addgroup -Sg ${MAILU_GID} mailu \
   ; adduser -Sg ${MAILU_UID} -G mailu -h /app -g "mailu app" -s /bin/bash mailu \
   ; apk add --no-cache bash ca-certificates curl python3 tzdata \
   ; machine="$(uname -m)" \
-  ; ! [[ "${TARGETPLATFORM}" != linux/arm/v7 && \( "${machine}" == x86_64 || "${machine}" == armv8* || "${machine}" == aarch64 \) ]] \
+  ; ! [[ "${machine}" == x86_64 ]] \
     || apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hardened-malloc
 
 ENV LD_PRELOAD=/usr/lib/libhardened_malloc.so


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Support is going to be a nightmare if RPI4 is not working; We can always reintroduce it later.

### Related issue(s)
- closes #2541 
