### PR TITLE
Rollback to mysql-connector-python==8.0.29

### DIFF
--- a/core/base/requirements-dev.txt
+++ b/core/base/requirements-dev.txt
@@ -23,7 +23,7 @@ itsdangerous
 limits
 marshmallow
 marshmallow-sqlalchemy
-mysql-connector-python
+mysql-connector-python==8.0.29
 passlib
 psycopg2-binary
 Pygments

--- a/core/base/requirements-prod.txt
+++ b/core/base/requirements-prod.txt
@@ -41,7 +41,7 @@ MarkupSafe==2.1.1
 marshmallow==3.18.0
 marshmallow-sqlalchemy==0.28.1
 multidict==6.0.2
-mysql-connector-python==8.0.31
+mysql-connector-python==8.0.29
 packaging==21.3
 passlib==1.7.4
 podop @ file:///app/libs/podop


### PR DESCRIPTION
See #2553

## What type of PR?

bug-fix

## What does this PR do?

Rollback to mysql-connector-python==8.0.29

### Related issue(s)
- closes #2553 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
