### PR TITLE
deprecate swarm in 1.9

### DIFF
--- a/docs/swarm/master/README.md
+++ b/docs/swarm/master/README.md
@@ -2,6 +2,8 @@
 
 ## Some warnings
 
+**Please note that next version of Mailu will not support swarm deployments anymore.**
+
 ### How Docker swarm works
 
 Docker swarm enables replication and fail-over scenarios. As a feature, if a node dies or goes away, Docker will re-schedule it's containers on the remaining nodes.

--- a/setup/templates/steps/flavor.html
+++ b/setup/templates/steps/flavor.html
@@ -8,6 +8,6 @@ maintained by specific contributors.</p>
 
 <div class="radio">
   {{ macros.radio("flavor", "compose", "Compose", "simply using Docker Compose manager", flavor) }}
-  {{ macros.radio("flavor", "stack", "Stack", "using stack deployments in a Swarm cluster", flavor) }}
+  {{ macros.radio("flavor", "stack", "Stack (DEPRECATED)", "using stack deployments in a Swarm cluster. Please note that next version of Mailu will not offer this flavor.", flavor) }}
 </div>
 {% endcall %}


### PR DESCRIPTION
This makes it clear that Swam shouldn't be used for new deployments.

I will send another PR against master to get rid of it completely.