### PR TITLE
Close #1483: remove postfix's /queue/pid/master.pid

### DIFF
--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -14,6 +14,8 @@ from socrate import system, conf
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 
+os.system("flock -n /queue/pid/master.pid rm /queue/pid/master.pid")
+
 def start_podop():
     os.setuid(getpwnam('postfix').pw_uid)
     os.makedirs('/dev/shm/postfix',mode=0o700, exist_ok=True)

--- a/towncrier/newsfragments/1483.bugfix
+++ b/towncrier/newsfragments/1483.bugfix
@@ -1,0 +1,1 @@
+Remove postfix's master.pid on startup if there is no other instance running


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Remove postfix's /queue/pid/master.pid on startup if there is no other instance running.

### Related issue(s)
- closes #1483

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
