### PR TITLE
fix missing casting to int for SESSION_KEY_BITS

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -165,6 +165,7 @@ class ConfigManager:
             self.config['SESSION_COOKIE_SECURE'] = self.config['TLS_FLAVOR'] != 'notls'
         self.config['SESSION_PERMANENT'] = True
         self.config['SESSION_TIMEOUT'] = int(self.config['SESSION_TIMEOUT'])
+        self.config['SESSION_KEY_BITS'] = int(self.config['SESSION_KEY_BITS'])
         self.config['PERMANENT_SESSION_LIFETIME'] = int(self.config['PERMANENT_SESSION_LIFETIME'])
         self.config['AUTH_RATELIMIT_IP_V4_MASK'] = int(self.config['AUTH_RATELIMIT_IP_V4_MASK'])
         self.config['AUTH_RATELIMIT_IP_V6_MASK'] = int(self.config['AUTH_RATELIMIT_IP_V6_MASK'])


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

This PR adds a missing env var casting for the `SESSION_KEY_BITS` variable.
When trying to provide a different value via env var, the value is passed as a string and then compared to a int.
The following check then throws a cast error: https://github.com/Mailu/Mailu/blob/50c7fa882e0a2cea57cecdd4b9c89bba13362f5a/core/admin/mailu/utils.py#L309-L312

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.
