### PR TITLE
fix roundcube/sieve

### DIFF
--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -7,10 +7,11 @@ LABEL version=$VERSION
 
 COPY snappymail/pubkey.asc /tmp/snappymail.asc
 COPY roundcube/pubkey.asc /tmp/roundcube.asc
+COPY roundcube/roundcube.diff /tmp/roundcube.diff
 
 RUN set -euxo pipefail \
   ; apk add --no-cache \
-    nginx gpg gpg-agent \
+    nginx gpg gpg-agent patch \
     php81 php81-fpm php81-mbstring php81-zip php81-xml php81-simplexml php81-pecl-apcu \
     php81-dom php81-curl php81-exif gd php81-gd php81-iconv php81-intl php81-openssl php81-ctype \
     php81-pdo_sqlite php81-pdo_mysql php81-pdo_pgsql php81-pdo php81-sodium libsodium php81-tidy php81-pecl-uuid \
@@ -42,7 +43,8 @@ RUN set -euxo pipefail \
   ; rm -rf CHANGELOG.md SECURITY.md INSTALL LICENSE README.md UPGRADING composer.json-dist installer composer.* \
   ; ln -sf index.php /var/www/roundcube/public_html/sso.php \
   ; rm -rf plugins/{autologon,example_addressbook,http_authentication,krb_authentication,new_user_identity,password,redundant_attachments,squirrelmail_usercopy,userinfo,virtuser_file,virtuser_query} \
-  ; sed -i '/suhosin.session.encrypt/d;/mbstring\.func_overload/d' program/lib/Roundcube/bootstrap.php
+  ; patch -p0 < /tmp/roundcube.diff \
+  ; rm /tmp/roundcube.diff
 
 COPY roundcube/config/config.inc.php /conf/
 COPY roundcube/login/mailu.php /var/www/roundcube/plugins/mailu/

--- a/webmails/roundcube/roundcube.diff
+++ b/webmails/roundcube/roundcube.diff
@@ -1,0 +1,47 @@
+--- plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
++++ plugins/managesieve/lib/Roundcube/rcube_sieve_engine.php
+@@ -529,28 +529,13 @@
+         // get request size limits (#1488648)
+         $max_post = max([
+                 ini_get('max_input_vars'),
+-                ini_get('suhosin.request.max_vars'),
+-                ini_get('suhosin.post.max_vars'),
+         ]);
+-        $max_depth = max([
+-                ini_get('suhosin.request.max_array_depth'),
+-                ini_get('suhosin.post.max_array_depth'),
+-        ]);
+ 
+         // check request size limit
+         if ($max_post && count($_POST, COUNT_RECURSIVE) >= $max_post) {
+             rcube::raise_error([
+                     'code' => 500, 'file' => __FILE__, 'line' => __LINE__,
+                     'message' => "Request size limit exceeded (one of max_input_vars/suhosin.request.max_vars/suhosin.post.max_vars)"
+-                ], true, false
+-            );
+-            $this->rc->output->show_message('managesieve.filtersaveerror', 'error');
+-        }
+-        // check request depth limits
+-        else if ($max_depth && count($_POST['_header']) > $max_depth) {
+-            rcube::raise_error([
+-                    'code' => 500, 'file' => __FILE__, 'line' => __LINE__,
+-                    'message' => "Request size limit exceeded (one of suhosin.request.max_array_depth/suhosin.post.max_array_depth)"
+                 ], true, false
+             );
+             $this->rc->output->show_message('managesieve.filtersaveerror', 'error');
+--- program/lib/Roundcube/bootstrap.php
++++ program/lib/Roundcube/bootstrap.php
+@@ -32,13 +32,11 @@
+     // Some users are not using Installer, so we'll check some
+     // critical PHP settings here. Only these, which doesn't provide
+     // an error/warning in the logs later. See (#1486307).
+-    'mbstring.func_overload' => 0,
+ ];
+ 
+ // check these additional ini settings if not called via CLI
+ if (php_sapi_name() != 'cli') {
+     $config += [
+-        'suhosin.session.encrypt' => false,
+         'file_uploads'            => true,
+         'session.auto_start'      => false,
+         'zlib.output_compression' => false,


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Without this snuffleupagus is throwing a tantrum on ini_get(), when saving a sieve filter from roundcube.

```
[17-Dec-2022 13:44:08] WARNING: [pool php] child 21853 said into stderr: "NOTICE: PHP message: PHP Fatal error:  [snuffleupagus][0.0.0.0][disabled_function][drop] Ab
orted execution on call of the function 'ini_get', because its argument '$option' content (suhosin.request.max_vars) matched a rule in /var/www/roundcube/plugins/man
agesieve/lib/Roundcube/rcube_sieve_engine.php on line 532"
```

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
