### PR TITLE
IMAP folder names may contain characters outside of \w: [a-zA-Z0-9]

### DIFF
--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -47,7 +47,7 @@ class MultipleFoldersVerify(object):
         self.message = message
 
     def __call__(self, form, field):
-        pattern = re.compile(r'^\w+(\s*,\s*\w+)*$')
+        pattern = re.compile(r'^[^,]+(,[^,]+)*$')
         if not pattern.match(field.data.replace(" ", "")):
             raise validators.ValidationError(self.message)
 


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

IMAP folder names may contain characters outside of \w: [a-zA-Z0-9]. Typically it may be subfolders...

I have also simplified the regexp since we strip spaces the line below.

This is used for "external accounts"/fetchmail.

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
