### PR TITLE
autodetect SUBNET

### DIFF
--- a/core/admin/start.py
+++ b/core/admin/start.py
@@ -8,7 +8,6 @@ from socrate import system
 os.system("chown mailu:mailu -R /dkim")
 os.system("find /data | grep -v /fetchmail | xargs -n1 chown mailu:mailu")
 system.drop_privs_to('mailu')
-
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "INFO"))
 system.set_env(['SECRET'])
 

--- a/core/base/libs/socrate/socrate/system.py
+++ b/core/base/libs/socrate/socrate/system.py
@@ -1,9 +1,12 @@
+import dns.resolver
 import hmac
 import logging as log
 import os
 from pwd import getpwnam
 import socket
+import sys
 import tenacity
+from textwrap import wrap
 
 @tenacity.retry(stop=tenacity.stop_after_attempt(100),
                 wait=tenacity.wait_random(min=2, max=5))
@@ -38,10 +41,23 @@ def set_env(required_secrets=[]):
     for secret in required_secrets:
         os.environ[f'{secret}_KEY'] = hmac.new(bytearray(secret_key, 'utf-8'), bytearray(secret, 'utf-8'), 'sha256').hexdigest()
 
-    return {
+    if not os.environ.get('SUBNET'):
+        os.environ['SUBNET'] = get_network_v4()
+
+    to_return={
             key: _coerce_value(os.environ.get(key, value))
             for key, value in os.environ.items()
            }
+
+    try:
+        ip_resolver = dns.resolver.query("resolver")[0].address
+        log.info(f'Setting DNS to {ip_resolver}')
+        with open('/etc/resolv.conf','w') as f:
+            f.write(f'nameserver {ip_resolver}\noptions ndots:0\n')
+    except:
+        pass
+
+    return to_return
 
 def clean_env():
     """ remove all secret keys """
@@ -53,3 +69,53 @@ def drop_privs_to(username='mailu'):
     os.setgid(pwnam.pw_gid)
     os.setuid(pwnam.pw_uid)
     os.environ['HOME'] = pwnam.pw_dir
+
+def get_network_v4():
+	dflgw = None
+	routes = []
+	for line in open('/proc/net/route', 'r'):
+		r = line.strip().split()
+		try:
+			route = [r[0]] + [int(c, 16) for c in r[1:]]
+		except ValueError:
+			pass
+		else:
+			if route[1] != 0:
+				routes.append(route)
+			elif dflgw is None:
+				dflgw = (route[0], route[2])
+
+	if dflgw is None:
+		return None
+
+	intf, ip = dflgw
+	for route in routes:
+		if route[0] == intf and route[1] == ip&route[7]:
+			net = route[1]
+			mask = bin(route[7]).count("1")
+			return f'{net&0xff}.{net>>8&0xff}.{net>>16&0xff}.{net>>24&0xff}/{mask}'
+
+def get_network_v6():
+	dflgw = None
+	routes = []
+	for line in open('/proc/net/ipv6_route', 'r'):
+		r = line.strip().split()
+		try:
+			route = [r[-1]] + [int(c, 16) for c in r[:-1]]
+		except ValueError:
+			pass
+		else:
+			if route[1] != 0 and route[2] != 0:
+				routes.append(route)
+			elif dflgw is None and route[9] == 3:
+				dflgw = (route[0], route[5])
+
+	if dflgw is None:
+		return None
+
+	intf, ip = dflgw
+	for route in routes:
+		if route[0] == intf and route[1] == ip&((2**route[2]-1)^0xffffffffffffffffffffffffffffffff):
+			prefix = ':'.join(wrap(f'{route[1]:032x}', 4))
+			mask = route[2]
+			return f'{prefix}/{mask}'

--- a/core/base/libs/socrate/socrate/system.py
+++ b/core/base/libs/socrate/socrate/system.py
@@ -47,7 +47,7 @@ def set_env(required_secrets=[]):
         with open('/etc/resolv.conf','w') as f:
             f.write(f'nameserver {ip_resolver}\noptions ndots:0\n')
     except:
-        pass
+        log.info('The unbound container cannot be found or is not enabled. Falling back to the default DNS resolver')
 
     if not os.environ.get('SUBNET'):
         os.environ['SUBNET'] = get_network_v4()

--- a/core/base/libs/socrate/socrate/system.py
+++ b/core/base/libs/socrate/socrate/system.py
@@ -41,14 +41,6 @@ def set_env(required_secrets=[]):
     for secret in required_secrets:
         os.environ[f'{secret}_KEY'] = hmac.new(bytearray(secret_key, 'utf-8'), bytearray(secret, 'utf-8'), 'sha256').hexdigest()
 
-    if not os.environ.get('SUBNET'):
-        os.environ['SUBNET'] = get_network_v4()
-
-    to_return={
-            key: _coerce_value(os.environ.get(key, value))
-            for key, value in os.environ.items()
-           }
-
     try:
         ip_resolver = dns.resolver.query("resolver")[0].address
         log.info(f'Setting DNS to {ip_resolver}')
@@ -57,7 +49,13 @@ def set_env(required_secrets=[]):
     except:
         pass
 
-    return to_return
+    if not os.environ.get('SUBNET'):
+        os.environ['SUBNET'] = get_network_v4()
+
+    return {
+            key: _coerce_value(os.environ.get(key, value))
+            for key, value in os.environ.items()
+           }
 
 def clean_env():
     """ remove all secret keys """

--- a/optional/unbound/start.py
+++ b/optional/unbound/start.py
@@ -6,7 +6,18 @@ import sys
 from socrate import conf, system
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
-system.set_env()
+
+with open( '/etc/resolv.conf', 'r' ) as resolv:
+    for line in resolv.readlines():
+        if line.startswith('nameserver '):
+            os.environ['DOCKER_RESOLVER'] = line.split(' ')[1].rstrip()
+            break
+
+container_names=[]
+for key in os.environ:
+    if key.endswith('_ADDRESS'):
+        container_names.append(os.environ[key])
+os.environ['CONTAINERS'] = ','.join(container_names)
 
 conf.jinja("/unbound.conf", os.environ, "/etc/unbound/unbound.conf")
 

--- a/optional/unbound/start.py
+++ b/optional/unbound/start.py
@@ -14,10 +14,14 @@ with open( '/etc/resolv.conf', 'r' ) as resolv:
             env['DOCKER_RESOLVER'] = line.split(' ')[1].rstrip()
             break
 
-env['CONTAINERS'] = [value for key, value in env.items() if key.endswith('_ADDRESS')]
-
 if not env.get('SUBNET'):
     env['SUBNET'] = system.get_network_v4()
+
+env['CONTAINERS'] = [value for key, value in env.items() if key.endswith('_ADDRESS')]
+
+if 'DOCKER_RESOLVER' not in env:
+    env['CONTAINERS'] = []
+    log.error("Can't determine docker resolver from /etc/resolv.conf")
 
 conf.jinja("/unbound.conf", env, "/etc/unbound/unbound.conf")
 

--- a/optional/unbound/unbound.conf
+++ b/optional/unbound/unbound.conf
@@ -1,7 +1,9 @@
 server:
   verbosity: 1
   interface: 0.0.0.0
-{{- '  interface: ::0' if SUBNET6 }}
+{%- if SUBNET6 %}
+  interface: ::0
+{%- endif %}
   logfile: ""
   do-ip4: yes
   do-ip6: {{ 'yes' if SUBNET6 else 'no' }}

--- a/optional/unbound/unbound.conf
+++ b/optional/unbound/unbound.conf
@@ -8,6 +8,7 @@ server:
   do-udp: yes
   do-tcp: yes
   do-daemonize: no
+  do-not-query-localhost: no
   access-control: {{ SUBNET }} allow
 {%- if SUBNET6 %}
   access-control: {{ SUBNET6 }} allow
@@ -19,4 +20,13 @@ server:
   hide-identity: yes
   hide-version: yes
   cache-min-ttl: 300
+{%- for container in CONTAINERS.split(',') %}
+  domain-insecure: "{{ container }}."
+{%- endfor %}
 
+{% for container in CONTAINERS.split(',') %}
+forward-zone:
+  name: "{{ container }}."
+  forward-addr: {{ DOCKER_RESOLVER }}
+  forward-no-cache: yes
+{% endfor %}

--- a/optional/unbound/unbound.conf
+++ b/optional/unbound/unbound.conf
@@ -20,11 +20,11 @@ server:
   hide-identity: yes
   hide-version: yes
   cache-min-ttl: 300
-{%- for container in CONTAINERS.split(',') %}
+{%- for container in CONTAINERS %}
   domain-insecure: "{{ container }}."
 {%- endfor %}
 
-{% for container in CONTAINERS.split(',') %}
+{% for container in CONTAINERS %}
 forward-zone:
   name: "{{ container }}."
   forward-addr: {{ DOCKER_RESOLVER }}

--- a/optional/unbound/unbound.conf
+++ b/optional/unbound/unbound.conf
@@ -21,7 +21,6 @@ server:
   root-hints: "/etc/unbound/root.hints"
   hide-identity: yes
   hide-version: yes
-  cache-min-ttl: 300
 {%- for container in CONTAINERS %}
   domain-insecure: "{{ container }}."
 {%- endfor %}

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -13,12 +13,6 @@ services:
     restart: always
     volumes:
       - "{{ root }}/redis:/data"
-    {% if resolver_enabled %}
-    depends_on:
-      - resolver
-    dns:
-      - {{ dns }}
-    {% endif %}
 
   # Core services
   front:
@@ -42,16 +36,11 @@ services:
     {% if resolver_enabled %}
     depends_on:
       - resolver
-    dns:
-      - {{ dns }}
 
   resolver:
     image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}unbound:${MAILU_VERSION:-{{ version }}}
     env_file: {{ env }}
     restart: always
-    networks:
-      default:
-        ipv4_address: {{ dns }}
     {% endif %}
 
   admin:
@@ -69,8 +58,6 @@ services:
       - redis
     {% if resolver_enabled %}
       - resolver
-    dns:
-      - {{ dns }}
     {% endif %}
 
   imap:
@@ -84,8 +71,6 @@ services:
       - front
     {% if resolver_enabled %}
       - resolver
-    dns:
-      - {{ dns }}
     {% endif %}
 
   smtp:
@@ -99,8 +84,6 @@ services:
       - front
     {% if resolver_enabled %}
       - resolver
-    dns:
-      - {{ dns }}
     {% endif %}
 
 {% if oletools_enabled %}
@@ -142,8 +125,6 @@ services:
     {% endif %}
     {% if resolver_enabled %}
       - resolver
-    dns:
-      - {{ dns }}
     {% endif %}
 
   # Optional services
@@ -157,8 +138,6 @@ services:
     {% if resolver_enabled %}
     depends_on:
       - resolver
-    dns:
-      - {{ dns }}
     {% endif %}
   {% endif %}
 
@@ -172,8 +151,6 @@ services:
     {% if resolver_enabled %}
     depends_on:
       - resolver
-    dns:
-      - {{ dns }}
     {% endif %}
   {% endif %}
 
@@ -190,8 +167,6 @@ services:
       - imap
     {% if resolver_enabled %}
       - resolver
-    dns:
-      - {{ dns }}
     {% endif %}
   {% endif %}
 
@@ -208,8 +183,6 @@ services:
       - imap
     {% if resolver_enabled %}
       - resolver
-    dns:
-      - {{ dns }}
     {% endif %}
   {% endif %}
 
@@ -219,15 +192,14 @@ networks:
     enable_ipv6: true
     {% endif %}
     driver: bridge
+    {% if ipv6_enabled %}
     ipam:
       driver: default
       config:
-        - subnet: {{ subnet }}
-        {% if ipv6_enabled %}
         - subnet: {{ subnet6 }}
-        {% endif %}
-{% if oletools_enabled %}
+    {% endif %}
+  {% if oletools_enabled %}
   noinet:
     driver: bridge
     internal: true
-{% endif %}
+  {% endif %}

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -96,12 +96,6 @@ services:
     restart: always
     networks:
       - noinet
-    depends_on:
-    {% if resolver_enabled %}
-      - resolver
-    dns:
-      - {{ dns }}
-    {% endif %}
 {% endif %}
 
   antispam:

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -11,9 +11,8 @@
 # Set to a randomly generated 16 bytes string
 SECRET_KEY={{ secret(16) }}
 
-# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
-SUBNET={{ subnet }}
 {% if ipv6_enabled %}
+# Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)
 SUBNET6={{ subnet6 }}
 {% endif %}
 

--- a/setup/server.py
+++ b/setup/server.py
@@ -7,7 +7,6 @@ import jinja2
 import uuid
 import string
 import random
-import ipaddress
 import hashlib
 import time
 
@@ -90,10 +89,6 @@ def build_app(path):
     def submit():
         data = flask.request.form.copy()
         data['uid'] = str(uuid.uuid4())
-        try:
-            data['dns'] = str(ipaddress.IPv4Network(data['subnet'], strict=False)[-2])
-        except ValueError as err:
-            return "Error while generating files: " + str(err)
         db.set(data['uid'], json.dumps(data))
         return flask.redirect(flask.url_for('.setup', uid=data['uid']))
 

--- a/setup/templates/steps/compose/03_expose.html
+++ b/setup/templates/steps/compose/03_expose.html
@@ -13,16 +13,6 @@ an IPv4 or an IPv6 address if you wish to access Mailu.</p>
 avoid generic all-interfaces addresses like <code>0.0.0.0</code> or <code>::</code>.
 <a href="https://mailu.io/{{ version }}/compose/setup.html#bind-address">How to find these addresses.</a></p>
 
-<div class="form-group">
-  <label>IPv4 listen address</label>
-<!--   Validates IPv4 address -->
-  <input class="form-control" type="text" name="bind4" value="127.0.0.1" 
-  		pattern="^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$">
-  <label>Subnet of the docker network. This should not conflict with any networks to which your system is connected. (Internal and external!)</label>
-  <input class="form-control" type="text" name="subnet" required pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}(\/([0-9]|[1-2][0-9]|3[0-2]))$"
-    value="192.168.203.0/24">
-</div>
-
 <div class="form-check form-check-inline">
   <label class="form-check-label">
     <input class="form-check-input" type="checkbox" name="ipv6_enabled" value="true" id="enable_ipv6">

--- a/tests/compose/filters/docker-compose.yml
+++ b/tests/compose/filters/docker-compose.yml
@@ -85,6 +85,10 @@ services:
       - "/mailu/overrides/rspamd:/etc/rspamd/override.d"
     depends_on:
       - front
+      - redis
+      - oletools
+      - antivirus
+      - resolver
 
   # Optional services
   antivirus:

--- a/towncrier/newsfragments/1341.misc
+++ b/towncrier/newsfragments/1341.misc
@@ -2,3 +2,4 @@ Remove HOST_* variables, use *_ADDRESS everywhere instead. Please note that thos
 Derive a different key for admin/SECRET_KEY; this will invalidate existing sessions
 Ensure that rspamd starts after clamav
 Only display a single HOSTNAME on the client configuration page
+Autodetect SUBNET

--- a/towncrier/newsfragments/1341.misc
+++ b/towncrier/newsfragments/1341.misc
@@ -2,4 +2,4 @@ Remove HOST_* variables, use *_ADDRESS everywhere instead. Please note that thos
 Derive a different key for admin/SECRET_KEY; this will invalidate existing sessions
 Ensure that rspamd starts after clamav
 Only display a single HOSTNAME on the client configuration page
-Autodetect SUBNET
+Autodetect SUBNET; switch to unbound for local name resolution


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

autodetect SUBNET; switch to unbound for name resolution.

The idea here is to reduce the number of tricky questions we ask the user during setup and minimize the opportunities for missconfiguration: "smart defaults". If you get it wrong you turn your instance into an open-relay.

### Related issue(s)
- #2614

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
