### PR TITLE
drop privs better

### DIFF
--- a/core/admin/start.py
+++ b/core/admin/start.py
@@ -2,15 +2,12 @@
 
 import os
 import logging as log
-from pwd import getpwnam
 import sys
 from socrate import system
 
 os.system("chown mailu:mailu -R /dkim")
 os.system("find /data | grep -v /fetchmail | xargs -n1 chown mailu:mailu")
-mailu_id = getpwnam('mailu')
-os.setgid(mailu_id.pw_gid)
-os.setuid(mailu_id.pw_uid)
+system.drop_privs_to('mailu')
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "INFO"))
 system.set_env(['SECRET'])

--- a/core/base/libs/socrate/socrate/system.py
+++ b/core/base/libs/socrate/socrate/system.py
@@ -1,6 +1,7 @@
 import hmac
 import logging as log
 import os
+from pwd import getpwnam
 import socket
 import tenacity
 
@@ -45,3 +46,10 @@ def set_env(required_secrets=[]):
 def clean_env():
     """ remove all secret keys """
     [os.environ.pop(key, None) for key in os.environ.keys() if key.endswith("_KEY")]
+
+def drop_privs_to(username='mailu'):
+    pwnam = getpwnam(username)
+    os.setgroups([])
+    os.setgid(pwnam.pw_gid)
+    os.setuid(pwnam.pw_uid)
+    os.environ['HOME'] = pwnam.pw_dir

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -5,7 +5,6 @@ import glob
 import multiprocessing
 import logging as log
 import sys
-from pwd import getpwnam
 
 from podop import run_server
 from socrate import system, conf
@@ -14,9 +13,7 @@ log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
 system.set_env()
 
 def start_podop():
-    id_mail = getpwnam('mail')
-    os.setgid(id_mail.pw_gid)
-    os.setuid(id_mail.pw_uid)
+    system.drop_privs_to('mail')
     url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/dovecot/§"
     run_server(0, "dovecot", "/tmp/podop.socket", [
 		("quota", "url", url ),

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -9,7 +9,6 @@ import sys
 import re
 
 from podop import run_server
-from pwd import getpwnam
 from socrate import system, conf
 
 log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", "WARNING"))
@@ -18,7 +17,7 @@ system.set_env()
 os.system("flock -n /queue/pid/master.pid rm /queue/pid/master.pid")
 
 def start_podop():
-    os.setuid(getpwnam('postfix').pw_uid)
+    system.drop_privs_to('postfix')
     os.makedirs('/dev/shm/postfix',mode=0o700, exist_ok=True)
     url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/postfix/"
     # TODO: Remove verbosity setting from Podop?
@@ -36,7 +35,7 @@ def start_podop():
 
 def start_mta_sts_daemon():
     os.chmod("/root/", 0o755) # read access to /root/.netrc required
-    os.setuid(getpwnam('postfix').pw_uid)
+    system.drop_privs_to('postfix')
     from postfix_mta_sts_resolver import daemon
     daemon.main()
 

--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -97,8 +97,7 @@ if __name__ == "__main__":
     os.chown("/data/fetchids", id_fetchmail.pw_uid, id_fetchmail.pw_gid)
     os.chown("/data/", id_fetchmail.pw_uid, id_fetchmail.pw_gid)
     os.chmod("/data/fetchids", 0o700)
-    os.setgid(id_fetchmail.pw_gid)
-    os.setuid(id_fetchmail.pw_uid)
+    system.drop_privs_to('fetchmail')
     config = system.set_env()
     while True:
         delay = int(os.environ.get('FETCHMAIL_DELAY', 60))


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Without this we may see the following:
```
Initializing database
PHP Deprecated:  Return type of zipdownload_mbox_filter::filter($in, $out, &$consumed, $closing) should either be compatible with php_user_filter::filter($in, $out, &$consumed, bool $closing): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/roundcube/plugins/zipdownload/zipdownload.php on line 405
PHP Fatal error:  [snuffleupagus][0.0.0.0][readonly_exec][drop] Attempted execution of a writable file (/var/www/roundcube/plugins/mailu/mailu.php) in /var/www/roundcube/program/lib/Roundcube/rcube_plugin_api.php on line 204
Fatal error: Please check the Roundcube error log and/or server error logs for more information.
```

This has been confirmed to fix it.

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
