### PR TITLE
Enable HAPROXY protocol on SUBNET

### DIFF
--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -17,7 +17,7 @@ def dovecot_passdb_dict(user_email):
     return flask.jsonify({
         "password": None,
         "nopassword": "Y",
-        "allow_nets": ",".join(allow_nets)
+        "allow_real_nets": ",".join(allow_nets)
     })
 
 @internal.route("/dovecot/userdb/")

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -11,6 +11,8 @@ default_internal_user = dovecot
 default_login_user = mail
 default_internal_group = dovecot
 
+haproxy_trusted_networks = {{ SUBNET }} {{ SUBNET6 }}
+
 ###############
 # Mailboxes
 ###############
@@ -109,6 +111,7 @@ protocol pop3 {
 service imap-login {
   inet_listener imap {
     port = 143
+    haproxy = yes
   }
 }
 

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -338,6 +338,7 @@ mail {
       starttls only;
       {% endif %}
       protocol imap;
+      proxy_protocol on;
       imap_auth plain;
       auth_http_header Auth-Port 143;
     }
@@ -349,6 +350,7 @@ mail {
       starttls only;
       {% endif %}
       protocol pop3;
+      proxy_protocol on;
       pop3_auth plain;
       auth_http_header Auth-Port 110;
     }
@@ -377,6 +379,7 @@ mail {
       listen 993 ssl;
       listen [::]:993 ssl;
       protocol imap;
+      proxy_protocol on;
       imap_auth plain;
       auth_http_header Auth-Port 993;
     }
@@ -385,6 +388,7 @@ mail {
       listen 995 ssl;
       listen [::]:995 ssl;
       protocol pop3;
+      proxy_protocol on;
       pop3_auth plain;
       auth_http_header Auth-Port 995;
     }

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -292,6 +292,9 @@ mail {
     pop3_capabilities TOP UIDL RESP-CODES PIPELINING AUTH-RESP-CODE USER;
     imap_capabilities IMAP4 IMAP4rev1 UIDPLUS SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+;
 
+    # ensure we talk HAPROXY protocol to the backends
+    proxy_protocol on;
+
     # Default SMTP server for the webmail (no encryption, but authentication)
     server {
       listen 10025;
@@ -338,7 +341,6 @@ mail {
       starttls only;
       {% endif %}
       protocol imap;
-      proxy_protocol on;
       imap_auth plain;
       auth_http_header Auth-Port 143;
     }
@@ -350,7 +352,6 @@ mail {
       starttls only;
       {% endif %}
       protocol pop3;
-      proxy_protocol on;
       pop3_auth plain;
       auth_http_header Auth-Port 110;
     }
@@ -379,7 +380,6 @@ mail {
       listen 993 ssl;
       listen [::]:993 ssl;
       protocol imap;
-      proxy_protocol on;
       imap_auth plain;
       auth_http_header Auth-Port 993;
     }
@@ -388,7 +388,6 @@ mail {
       listen 995 ssl;
       listen [::]:995 ssl;
       protocol pop3;
-      proxy_protocol on;
       pop3_auth plain;
       auth_http_header Auth-Port 995;
     }

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -15,7 +15,7 @@ COPY start.py /
 RUN echo $VERSION >/version
 
 EXPOSE 25/tcp 10025/tcp
-HEALTHCHECK --start-period=350s CMD echo QUIT|nc localhost 25|grep "220 .* ESMTP Postfix"
+HEALTHCHECK --start-period=350s CMD /usr/sbin/postfix status
 
 VOLUME ["/queue"]
 

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -23,6 +23,7 @@ alias_maps =
 podop = socketmap:unix:/tmp/podop.socket:
 
 postscreen_upstream_proxy_protocol = haproxy
+compatibility_level=3.6
 
 # Only accept virtual emails
 mydestination =

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -22,6 +22,8 @@ alias_maps =
 # Podop configuration
 podop = socketmap:unix:/tmp/podop.socket:
 
+postscreen_upstream_proxy_protocol = haproxy
+
 # Only accept virtual emails
 mydestination =
 
@@ -37,9 +39,8 @@ smtp_sasl_tls_security_options = noanonymous
 # Recipient delimiter for extended addresses
 recipient_delimiter = {{ RECIPIENT_DELIMITER }}
 
-# Only the front server is allowed to perform xclient
-# In kubernetes and Docker swarm, such address cannot be determined using the hostname. Allow for the whole Mailu subnet instead.
-smtpd_authorized_xclient_hosts={{ SUBNET }}
+# We need to allow everything to do xclient and rely on front to filter-out "bad" requests
+smtpd_authorized_xclient_hosts=0.0.0.0/0 [::0]/0
 
 ###############
 # TLS

--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -2,10 +2,10 @@
 #               (yes)   (yes)   (yes)   (never) (100)
 
 # Exposed SMTP service
-smtp      inet  n       -       n       -       -       smtpd
+smtp      inet  n       -       n       -       1       postscreen
 
 # Internal SMTP service
-10025     inet  n       -       n       -       -       smtpd
+10025     inet  n       -       n       -       1       postscreen
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_discard_ehlo_keywords=pipelining
   -o smtpd_client_restrictions=$check_ratelimit,reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit
@@ -44,6 +44,7 @@ verify    unix  -       -       n       -       1       verify
 flush     unix  n       -       n       1000?   0       flush
 proxymap  unix  -       -       n       -       -       proxymap
 smtp      unix  -       -       n       -       -       smtp
+smtpd     pass  -       -       n       -       -       smtpd
 relay     unix  -       -       n       -       -       smtp
 error     unix  -       -       n       -       -       error
 retry     unix  -       -       n       -       -       error
@@ -52,4 +53,3 @@ lmtp      unix  -       -       n       -       -       lmtp
 anvil     unix  -       -       n       -       1       anvil
 scache    unix  -       -       n       -       1       scache
 postlog   unix-dgram n  -       n       -       1       postlogd
-

--- a/core/postfix/conf/rsyslog.conf
+++ b/core/postfix/conf/rsyslog.conf
@@ -31,6 +31,8 @@ module(load="imuxsock")
 # Discard messages from local test requests
 :msg, contains, "connect from localhost[127.0.0.1]"  ~
 :msg, contains, "connect from localhost[::1]"  ~
+:msg, contains, "haproxy read: short protocol header: QUIT"  ~
+:msg, contains, "discarding EHLO keywords: PIPELINING"  ~
 
 {% if POSTFIX_LOG_FILE %}
 # Log mail logs to file

--- a/core/postfix/conf/rsyslog.conf
+++ b/core/postfix/conf/rsyslog.conf
@@ -31,8 +31,6 @@ module(load="imuxsock")
 # Discard messages from local test requests
 :msg, contains, "connect from localhost[127.0.0.1]"  ~
 :msg, contains, "connect from localhost[::1]"  ~
-:msg, contains, "haproxy read: short protocol header: QUIT"  ~
-:msg, contains, "discarding EHLO keywords: PIPELINING"  ~
 
 {% if POSTFIX_LOG_FILE %}
 # Log mail logs to file

--- a/towncrier/newsfragments/2603.bugfix
+++ b/towncrier/newsfragments/2603.bugfix
@@ -1,0 +1,1 @@
+Speak HAPROXY protocol in between front and smtp and front and imap. This ensures the backend is aware of the real client IP and whether TLS was used.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

- Enable HAPROXY in between front and imap: With this we avoid running into the limitations of  ``mail_max_userip_connections`` and the logfiles reflect the real IP.
- Enable HAPROXY in between front and smtp: with this postfix and rspamd are aware of whether TLS was used or not on the last hop. In practice this won't work as nginx doesn't send PROTO yet.
- Discard redundant log messages from postfix

With all of this, not only are the logs easier to understand but ``doveadm who`` also works as one would expect.

### Related issue(s)
- closes #894
- #1328
- closes #1364
- #1705

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
