### PR TITLE
Reduce the SSL session caches from 50m each to 3m each

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -100,7 +100,7 @@ http {
       include /etc/nginx/tls.conf;
       ssl_stapling on;
       ssl_stapling_verify on;
-      ssl_session_cache shared:SSLHTTP:50m;
+      ssl_session_cache shared:SSLHTTP:3m;
       add_header Strict-Transport-Security 'max-age=31536000';
 
       {% if not TLS_FLAVOR in [ 'mail', 'mail-letsencrypt' ] %}
@@ -284,7 +284,7 @@ mail {
 
     {% if TLS and not TLS_ERROR %}
     include /etc/nginx/tls.conf;
-    ssl_session_cache shared:SSLMAIL:50m;
+    ssl_session_cache shared:SSLMAIL:3m;
     {% endif %}
 
     # Advertise real capabilities of backends (postfix/dovecot)

--- a/core/nginx/conf/tls.conf
+++ b/core/nginx/conf/tls.conf
@@ -6,7 +6,7 @@ ssl_certificate_key {{ TLS[3] }};
 ssl_trusted_certificate /etc/ssl/certs/ca-cert-ISRG_Root_X1.pem;
 {% endif %}
 ssl_session_timeout 1d;
-ssl_session_tickets off;
+ssl_session_tickets off; # this can be removed when we have nginx v1.23.2
 ssl_dhparam /conf/dhparam.pem;
 ssl_protocols TLSv1.2 TLSv1.3;
 ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;

--- a/towncrier/newsfragments/2605.misc
+++ b/towncrier/newsfragments/2605.misc
@@ -1,0 +1,1 @@
+Reduce the SSL session caches from 50m each to 3m each. This should be good for 12k sessions (within 1day) for each cache and will help reduce memory usage.


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Reduce the SSL session caches from 50m each to 3m each. This should be good for 12k sessions (within 1day, see http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache and our ssl_session_timeout) for each cache and will help reduce memory usage.

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
