### PR TITLE
Update python dependencies as suggested by dependabot

### DIFF
--- a/core/base/requirements-build.txt
+++ b/core/base/requirements-build.txt
@@ -1,3 +1,3 @@
-pip==22.3
-setuptools==65.5.0
-wheel==0.37.1
+pip==22.3.1
+setuptools==65.6.3
+wheel==0.38.4

--- a/core/base/requirements-prod.txt
+++ b/core/base/requirements-prod.txt
@@ -7,16 +7,18 @@ attrs==22.1.0
 Babel==2.11.0
 bcrypt==4.0.1
 blinker==1.5
-certifi==2022.9.24
+certifi==2022.12.7
 cffi==1.15.1
 charset-normalizer==2.1.1
 click==8.1.3
+colorclass==2.2.2
 cryptography==38.0.3
 decorator==5.1.1
 defusedxml==0.7.1
 Deprecated==1.2.13
 dnspython==2.2.1
 dominate==2.7.0
+easygui==0.98.3
 email-validator==1.3.0
 Flask==2.2.2
 Flask-Babel==2.0.0
@@ -40,14 +42,17 @@ Mako==1.2.3
 MarkupSafe==2.1.1
 marshmallow==3.18.0
 marshmallow-sqlalchemy==0.28.1
+msoffcrypto-tool==5.0.0
 multidict==6.0.2
-oletools==0.60.1
 mysql-connector-python==8.0.29
+olefile==0.46
+oletools==0.60.1
 packaging==21.3
 passlib==1.7.4
+pcodedmp==1.2.6
 podop @ file:///app/libs/podop
 postfix-mta-sts-resolver==1.1.4
-protobuf==3.20.1
+protobuf==3.20.2
 psycopg2-binary==2.9.5
 pycares==4.2.2
 pycparser==2.21
@@ -56,7 +61,6 @@ pyOpenSSL==22.1.0
 pyparsing==2.4.7
 python-dateutil==2.8.2
 python-magic==0.4.27
-python-dateutil==2.8.2
 pytz==2022.6
 PyYAML==6.0
 Radicale==3.1.8


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Update dependencies to silence dependabot (vulnerabilities are probably not exploitable)
Only the certifi upgrade could be backported.
