### PR TITLE
Remove duplicated 'actionstart = ' in fail2ban conf.

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -665,7 +665,7 @@ Using iptables with ipset might reduce the system load in such attacks significa
 
   [Definition]
 
-  actionstart = actionstart = ipset --create f2b-bad-auth iphash
+  actionstart = ipset --create f2b-bad-auth iphash
                 iptables -I DOCKER-USER -m set --match-set f2b-bad-auth src -j DROP
 
   actionstop = iptables -D DOCKER-USER -m set --match-set f2b-bad-auth src -j DROP


### PR DESCRIPTION
In fail2ban example configuration for ipset `option #2`, there is a duplicated string which makes the ipset and fail2ban fail to create the set. 
Fail2ban will never ban any ip due to this error.

## What type of PR?

documentation