### PR TITLE
Enhance network segregation

### DIFF
--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -22,7 +22,7 @@ RUN set -euxo pipefail \
 
 RUN echo $VERSION >/version
 
-EXPOSE 80/tcp
+#EXPOSE 80/tcp
 HEALTHCHECK CMD curl -skfLo /dev/null http://localhost/sso/login?next=ui.index
 
 VOLUME ["/data","/dkim"]

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -135,10 +135,16 @@ service lmtp {
 service managesieve-login {
   inet_listener sieve {
     port = 4190
+    haproxy = yes
   }
 }
 
+protocol sieve {
+  ssl = no
+}
+
 service managesieve {
+  process_limit = 1024
 }
 
 plugin {

--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -17,7 +17,8 @@ ARG VERSION
 LABEL version=$VERSION
 
 RUN set -euxo pipefail \
-  ; apk add --no-cache certbot nginx nginx-mod-mail openssl
+  ; apk add --no-cache certbot nginx nginx-mod-http-brotli nginx-mod-stream nginx-mod-mail openssl \
+  ; rm /etc/nginx/conf.d/stream.conf
 
 COPY conf/ /conf/
 COPY --from=static /static/ /static/
@@ -25,7 +26,7 @@ COPY *.py /
 
 RUN echo $VERSION >/version
 
-EXPOSE 80/tcp 443/tcp 110/tcp 143/tcp 465/tcp 587/tcp 993/tcp 995/tcp 25/tcp 10025/tcp 10143/tcp
+EXPOSE 80/tcp 443/tcp 110/tcp 143/tcp 465/tcp 587/tcp 993/tcp 995/tcp 25/tcp 14190/tcp 10025/tcp 10143/tcp
 HEALTHCHECK --start-period=60s CMD curl -skfLo /dev/null http://localhost/health
 
 VOLUME ["/certs", "/overrides"]

--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -26,7 +26,8 @@ COPY *.py /
 
 RUN echo $VERSION >/version
 
-EXPOSE 80/tcp 443/tcp 110/tcp 143/tcp 465/tcp 587/tcp 993/tcp 995/tcp 25/tcp 14190/tcp 10025/tcp 10143/tcp
+EXPOSE 80/tcp 443/tcp 110/tcp 143/tcp 465/tcp 587/tcp 993/tcp 995/tcp 25/tcp
+# EXPOSE 10025/tcp 10143/tcp 14190/tcp
 HEALTHCHECK --start-period=60s CMD curl -skfLo /dev/null http://localhost/health
 
 VOLUME ["/certs", "/overrides"]

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -1,9 +1,11 @@
 # Basic configuration
 user nginx;
 worker_processes auto;
+pcre_jit on;
 error_log /dev/stderr notice;
 pid /var/run/nginx.pid;
 load_module "modules/ngx_mail_module.so";
+load_module "modules/ngx_stream_module.so";
 
 events {
     worker_connections 1024;
@@ -273,6 +275,25 @@ http {
     }
 
     include /etc/nginx/conf.d/*.conf;
+}
+
+stream {
+    log_format main '$remote_addr [$time_local] '
+    		'$protocol $status $bytes_sent $bytes_received '
+    		'$session_time "$upstream_addr" '
+    		'"$upstream_bytes_sent" "$upstream_bytes_received" "$upstream_connect_time"';
+    access_log /dev/stdout main;
+
+    # managesieve
+    server {
+      listen 14190;
+      resolver {{ RESOLVER }} valid=30s;
+
+      proxy_connect_timeout 1s;
+      proxy_timeout 1m;
+      proxy_protocol on;
+      proxy_pass {{ IMAP_ADDRESS }}:4190;
+    }
 }
 
 mail {

--- a/core/oletools/Dockerfile
+++ b/core/oletools/Dockerfile
@@ -14,7 +14,7 @@ RUN set -euxo pipefail \
 RUN echo $VERSION >/version
 
 HEALTHCHECK --start-period=60s CMD echo PING|nc -q1 127.0.0.1 11343|grep "PONG"
-EXPOSE 11343/tcp
+#EXPOSE 11343/tcp
 
 USER nobody:nobody
 

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -14,7 +14,7 @@ COPY start.py /
 
 RUN echo $VERSION >/version
 
-EXPOSE 25/tcp 10025/tcp
+#EXPOSE 25/tcp 10025/tcp
 HEALTHCHECK --start-period=350s CMD /usr/sbin/postfix status
 
 VOLUME ["/queue"]

--- a/core/rspamd/Dockerfile
+++ b/core/rspamd/Dockerfile
@@ -15,7 +15,7 @@ COPY start.py /
 
 RUN echo $VERSION >/version
 
-EXPOSE 11332/tcp 11334/tcp 11335/tcp
+#EXPOSE 11332/tcp 11334/tcp 11335/tcp
 HEALTHCHECK --start-period=350s CMD curl -skfLo /dev/null http://localhost:11334/
 
 VOLUME ["/var/lib/rspamd"]

--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -14,7 +14,7 @@ COPY start.py /
 
 RUN echo $VERSION >/version
 
-EXPOSE 3310/tcp
+#EXPOSE 3310/tcp
 HEALTHCHECK --start-period=350s CMD echo PING|nc localhost 3310|grep "PONG"
 
 VOLUME ["/data"]

--- a/optional/radicale/Dockerfile
+++ b/optional/radicale/Dockerfile
@@ -10,7 +10,7 @@ COPY radicale.conf /
 
 RUN echo $VERSION >/version
 
-EXPOSE 5232/tcp
+#EXPOSE 5232/tcp
 HEALTHCHECK CMD curl -f -L http://localhost:5232/ || exit 1
 
 VOLUME ["/data"]

--- a/optional/unbound/Dockerfile
+++ b/optional/unbound/Dockerfile
@@ -18,7 +18,7 @@ COPY start.py /
 
 RUN echo $VERSION >/version
 
-EXPOSE 53/udp 53/tcp
+#EXPOSE 53/udp 53/tcp
 HEALTHCHECK CMD dig @127.0.0.1 || exit 1
 
 CMD /start.py

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -36,6 +36,9 @@ services:
       - "{{ bind6 }}:{{ port }}:{{ port }}"
     {% endif %}
     {% endfor %}
+    networks:
+      - default
+      - webmail
     volumes:
       - "{{ root }}/certs:/certs"
       - "{{ root }}/overrides/nginx:/overrides:ro"
@@ -169,12 +172,8 @@ services:
     env_file: {{ env }}
     volumes:
       - "{{ root }}/dav:/data"
-    {% if resolver_enabled %}
-    depends_on:
-      - resolver
-    dns:
-      - {{ dns }}
-    {% endif %}
+    networks:
+      - radicale
   {% endif %}
 
   {% if fetchmail_enabled %}
@@ -204,13 +203,10 @@ services:
     volumes:
       - "{{ root }}/webmail:/data"
       - "{{ root }}/overrides/{{ webmail_type }}:/overrides:ro"
+    networks:
+      - webmail
     depends_on:
-      - imap
-    {% if resolver_enabled %}
-      - resolver
-    dns:
-      - {{ dns }}
-    {% endif %}
+      - front
   {% endif %}
 
 networks:
@@ -226,6 +222,14 @@ networks:
         {% if ipv6_enabled %}
         - subnet: {{ subnet6 }}
         {% endif %}
+{% if webdav_enabled %}
+  radicale:
+    driver: bridge
+{% endif %}
+{% if webmail_type != 'none' %}
+  webmail:
+    driver: bridge
+{% endif %}
 {% if oletools_enabled %}
   noinet:
     driver: bridge

--- a/towncrier/newsfragments/2613.feature
+++ b/towncrier/newsfragments/2613.feature
@@ -1,0 +1,1 @@
+Isolate radicale and webmail on their own network. This ensures they don't have privileged access to any of the other containers.

--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -86,7 +86,7 @@ COPY php-webmail.conf /etc/php81/php-fpm.d/
 COPY nginx-webmail.conf /conf/
 COPY snuffleupagus.rules /etc/snuffleupagus.rules.tpl
 
-EXPOSE 80/tcp
+# EXPOSE 80/tcp
 VOLUME /data
 VOLUME /overrides
 

--- a/webmails/roundcube/config/config.inc.php
+++ b/webmails/roundcube/config/config.inc.php
@@ -28,7 +28,7 @@ $config['default_host']  = '{{ FRONT_ADDRESS or "front" }}';
 $config['default_port'] = '10143';
 
 // Sieve script management
-$config['managesieve_host'] = '{{ IMAP_ADDRESS or "imap" }}';
+$config['managesieve_host'] = '{{ FRONT_ADDRESS or "front" }}:14190';
 
 // We access the IMAP and SMTP servers locally with internal names, SSL
 // will obviously fail but this sounds better than allowing insecure login

--- a/webmails/snappymail/defaults/default.json
+++ b/webmails/snappymail/defaults/default.json
@@ -32,8 +32,8 @@
         "usePhpMail": false
     },
     "Sieve": {
-        "host": "{{ IMAP_ADDRESS }}",
-        "port": 4190,
+        "host": "{{ FRONT_ADDRESS }}",
+        "port": 14190,
         "secure": 0,
         "shortLogin": false,
         "ssl": {

--- a/webmails/snuffleupagus.rules
+++ b/webmails/snuffleupagus.rules
@@ -98,7 +98,7 @@ sp.disable_function.function("is_callable").param("value").value("eval").drop();
 sp.disable_function.function("is_callable").param("value").value("exec").drop();
 sp.disable_function.function("is_callable").param("value").value("system").drop();
 sp.disable_function.function("is_callable").param("value").value("shell_exec").drop();
-sp.disable_function.function("is_callable").filename_r("^/var/www/snappymail/snappymail/v/\d+\.\d+\.\d+/app/libraries/snappymail/pgp/gpg\.php$").param("value").value("proc_open").allow();
+sp.disable_function.function("is_callable").filename_r("^/var/www/snappymail/snappymail/v/[0-9]+\.[0-9]+\.[0-9]+/app/libraries/snappymail/pgp/gpg\.php$").param("value").value("proc_open").allow();
 sp.disable_function.function("is_callable").param("value").value("proc_open").drop();
 sp.disable_function.function("is_callable").param("value").value("passthru").drop();
 


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

- put radicale and webmail on their own network: this is done for security: that way they have no privileged access anywhere (no access to redis, no access to XCLIENT, ...)
- remove the EXPOSE statements from the dockerfiles. These ports are for internal comms and are not meant to be exposed in any way to the outside world.

### Related issue(s)
- #2611

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
