### PR TITLE
Upgrade to snuffleupagus 0.9.0

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -60,7 +60,7 @@ ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
 COPY requirements-${MAILU_DEPS}.txt ./
 COPY libs/ libs/
 
-ARG SNUFFLEUPAGUS_VERSION=0.8.3
+ARG SNUFFLEUPAGUS_VERSION=0.9.0
 ENV SNUFFLEUPAGUS_URL https://github.com/jvoisin/snuffleupagus/archive/refs/tags/v$SNUFFLEUPAGUS_VERSION.tar.gz
 
 RUN set -euxo pipefail \

--- a/towncrier/newsfragments/2618.misc
+++ b/towncrier/newsfragments/2618.misc
@@ -1,0 +1,1 @@
+Upgrade to snuffleupagus 0.9.0

--- a/webmails/snuffleupagus.rules
+++ b/webmails/snuffleupagus.rules
@@ -130,5 +130,4 @@ sp.cookie.name("roundcube_sessid").samesite("strict");
 sp.ini_protection.policy_silent_fail();
 
 # roundcube uses unserialize() everywhere.
-# This should do the job until https://github.com/jvoisin/snuffleupagus/issues/438 is implemented.
-sp.disable_function.function("unserialize").param("data").value_r("[cCoO]:\d+:[\"{]").drop();
+sp.unserialize_noclass.enable();


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Upgrade to snuffleupagus 0.9.0. This has a better way to deal with unserialize() and a better compatibility with PHP8.2

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
