### PR TITLE
Fix ipv6 subnet for xclient_hosts

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -121,7 +121,7 @@ smtpd_relay_restrictions =
 
 unverified_recipient_reject_reason = Address lookup failure
 
-smtpd_authorized_xclient_hosts={{ SUBNET}},{{ SUBNET6 }}
+smtpd_authorized_xclient_hosts={{ SUBNET}}{% if SUBNET6 %},[{{ SUBNET6 }}]{% endif %}
 
 ###############
 # Milter


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

this puts the ipv6 prefix into square brackets in the xclient_hosts configuration.
strictly speaking putting the square brackets also around the netmask is not correct, but it's okay for postfix
this will be cleaned when all configuration variables and normalizations are moved to the base container.
