### PR TITLE
Move runtime environment variables to the end

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -77,7 +77,7 @@ RUN setcap 'cap_net_bind_service=+ep' /app/venv/bin/gunicorn 'cap_net_bind_servi
 
 ENV \
   VIRTUAL_ENV=/app/venv \
-  PATH="${VIRTUAL_ENV}/bin:${PATH}" \
+  PATH="/app/venv/bin:${PATH}" \
   LD_PRELOAD="/usr/lib/libhardened_malloc.so" \
   ADMIN_ADDRESS="admin" \
   FRONT_ADDRESS="front" \

--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -13,26 +13,8 @@ RUN set -euxo pipefail \
   ; addgroup -Sg ${MAILU_GID} mailu \
   ; adduser -Sg ${MAILU_UID} -G mailu -h /app -g "mailu app" -s /bin/bash mailu \
   ; apk add --no-cache bash ca-certificates curl python3 tzdata libcap \
-  ; machine="$(uname -m)" \
-  ; ! [[ "${machine}" == x86_64 ]] \
+  ; ! [[ "$(uname -m)" == x86_64 ]] \
     || apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hardened-malloc==11-r0
-
-ENV \
-  LD_PRELOAD="/usr/lib/libhardened_malloc.so" \
-  CXXFLAGS="-g -O2 -fdebug-prefix-map=/app=. -fstack-protector-strong -Wformat -Werror=format-security -fstack-clash-protection -fexceptions" \
-  CFLAGS="-g -O2 -fdebug-prefix-map=/app=. -fstack-protector-strong -Wformat -Werror=format-security -fstack-clash-protection -fexceptions" \
-  CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2" \
-  LDFLAGS="-Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now" \
-  ADMIN_ADDRESS="admin" \
-  FRONT_ADDRESS="front" \
-  SMTP_ADDRESS="smtp" \
-  IMAP_ADDRESS="imap" \
-  OLETOOLS_ADDRESS="oletools" \
-  REDIS_ADDRESS="redis" \
-  ANTIVIRUS_ADDRESS="antivirus" \
-  ANTISPAM_ADDRESS="antispam" \
-  WEBMAIL_ADDRESS="webmail" \
-  WEBDAV_ADDRESS="webdav"
 
 WORKDIR /app
 
@@ -43,6 +25,7 @@ CMD /bin/bash
 FROM system as build
 
 ARG MAILU_DEPS=prod
+ARG SNUFFLEUPAGUS_VERSION=0.9.0
 
 ENV VIRTUAL_ENV=/app/venv
 
@@ -55,13 +38,16 @@ RUN set -euxo pipefail \
   ; apk del -r py3-pip \
   ; rm -f /tmp/*.pem
 
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-
 COPY requirements-${MAILU_DEPS}.txt ./
 COPY libs/ libs/
 
-ARG SNUFFLEUPAGUS_VERSION=0.9.0
-ENV SNUFFLEUPAGUS_URL https://github.com/jvoisin/snuffleupagus/archive/refs/tags/v$SNUFFLEUPAGUS_VERSION.tar.gz
+ENV \
+  PATH="${VIRTUAL_ENV}/bin:${PATH}" \
+  CXXFLAGS="-g -O2 -fdebug-prefix-map=/app=. -fstack-protector-strong -Wformat -Werror=format-security -fstack-clash-protection -fexceptions" \
+  CFLAGS="-g -O2 -fdebug-prefix-map=/app=. -fstack-protector-strong -Wformat -Werror=format-security -fstack-clash-protection -fexceptions" \
+  CPPFLAGS="-Wdate-time -D_FORTIFY_SOURCE=2" \
+  LDFLAGS="-Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now" \
+  SNUFFLEUPAGUS_URL="https://github.com/jvoisin/snuffleupagus/archive/refs/tags/v${SNUFFLEUPAGUS_VERSION}.tar.gz"
 
 RUN set -euxo pipefail \
   ;  machine="$(uname -m)" \
@@ -73,8 +59,8 @@ RUN set -euxo pipefail \
       mkdir -p /root/.cargo/registry/index && \
       git clone --bare https://github.com/rust-lang/crates.io-index.git /root/.cargo/registry/index/github.com-1285ae84e5963aae \
   ; pip install -r requirements-${MAILU_DEPS}.txt \
-  ; curl -sL  ${SNUFFLEUPAGUS_URL} | tar xz \
-  ; cd snuffleupagus-$SNUFFLEUPAGUS_VERSION \
+  ; curl -sL ${SNUFFLEUPAGUS_URL} | tar xz \
+  ; cd snuffleupagus-${SNUFFLEUPAGUS_VERSION} \
   ; rm -rf src/tests/*php7*/ src/tests/*session*/ src/tests/broken_configuration/ src/tests/*cookie* src/tests/upload_validation/ \
   ; apk add --virtual .build-deps php81-dev php81-cgi php81-simplexml php81-xml pcre-dev build-base php81-pear php81-openssl re2c \
   ; pecl install vld-beta \
@@ -89,5 +75,17 @@ COPY --from=build /app/venv/ /app/venv/
 COPY --chown=root:root --from=build /app/snuffleupagus.so /usr/lib/php81/modules/
 RUN setcap 'cap_net_bind_service=+ep' /app/venv/bin/gunicorn 'cap_net_bind_service=+ep' /usr/bin/python3.10
 
-ENV VIRTUAL_ENV=/app/venv
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+ENV \
+  VIRTUAL_ENV=/app/venv \
+  PATH="${VIRTUAL_ENV}/bin:${PATH}" \
+  LD_PRELOAD="/usr/lib/libhardened_malloc.so" \
+  ADMIN_ADDRESS="admin" \
+  FRONT_ADDRESS="front" \
+  SMTP_ADDRESS="smtp" \
+  IMAP_ADDRESS="imap" \
+  OLETOOLS_ADDRESS="oletools" \
+  REDIS_ADDRESS="redis" \
+  ANTIVIRUS_ADDRESS="antivirus" \
+  ANTISPAM_ADDRESS="antispam" \
+  WEBMAIL_ADDRESS="webmail" \
+  WEBDAV_ADDRESS="webdav"


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

This moves the environment variables used at runtime from the system to the base image.
It's a workaround for a strange build issue observed when building with hardened malloc enabled.

