### PR TITLE
Fix out of office replies

### DIFF
--- a/core/rspamd/conf/options.inc
+++ b/core/rspamd/conf/options.inc
@@ -1,3 +1,3 @@
 {% if RELAYNETS %}
-local_networks = [{{ RELAYNETS }}];
+local_networks = [{{ RELAYNETS }},{{ SUBNET }}{% if SUBNET6 %}, {{ SUBNET6 }}{% endif %}];
 {% endif %}

--- a/core/rspamd/conf/options.inc
+++ b/core/rspamd/conf/options.inc
@@ -1,3 +1,1 @@
-{% if RELAYNETS %}
-local_networks = [{{ RELAYNETS }},{{ SUBNET }}{% if SUBNET6 %}, {{ SUBNET6 }}{% endif %}];
-{% endif %}
+local_networks = [{{ SUBNET }}{% if SUBNET6 %}, {{ SUBNET6 }}{% endif %}{% if RELAYNETS %}, {{ RELAYNETS }}{% endif %}];

--- a/towncrier/newsfragments/2635.bugfix
+++ b/towncrier/newsfragments/2635.bugfix
@@ -1,0 +1,1 @@
+Fix sieve/out of office replies by adding SUBNET to rspamd's local_networks


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix sieve/out of office replies by adding SUBNET to rspamd's local_networks.

Webmails are now on a different subnet.

### Related issue(s)


## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
