### PR TITLE
Add env variable to set sieve_vacation_to_header_ignore_envelope

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -173,6 +173,9 @@ plugin {
   # Include the recipient in vacation replies so that DKIM applies
   sieve_vacation_send_from_recipient = yes
 
+  # Use To: header from original message becaus envelope has a SRS address
+  sieve_vacation_to_header_ignore_envelope = yes
+
   # extract spam score from headers
   sieve_spamtest_status_type = strlen
   sieve_spamtest_status_header = X-Spam-Level

--- a/towncrier/newsfragments/2640.bugfix
+++ b/towncrier/newsfragments/2640.bugfix
@@ -1,0 +1,1 @@
+Uses the correct From address (instead of an SRS alias) in the sieve/vacation module


### PR DESCRIPTION
When used with SRS the vacation plugin creates a reply with SRS in the To: header which does not look nice for the recipient. Setting sieve_vacation_to_header_ignore_envelope will use the headers from the original source message instead of potentially rewritten ones.

Without this option auto-replies are sent with a To header with SRS, e.g `SRS0=uetG=43=sender.com=user@autoresponder.com`
With this option they are sent with just `user@sender.com`

This option is for whatever reason not part of the [pigeonhole docs](https://doc.dovecot.org/configuration_manual/sieve/extensions/vacation/) but it is documented here: https://github.com/dovecot/pigeonhole/blob/34431d7a67474c00d5b0554f5d45b867509f4a7a/NEWS#L338

## What type of PR?

enhancement

## What does this PR do?
This PR adds an environment variable to the set the `sieve_vacation_to_header_ignore_envelope` configuration

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly

