### PR TITLE
Remove webmail cookies on logout.

### DIFF
--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -57,7 +57,10 @@ def login():
 def logout():
     flask_login.logout_user()
     flask.session.destroy()
-    return flask.redirect(flask.url_for('.login'))
+    response = flask.redirect(flask.url_for('.login'))
+    for cookie in ['roundcube_sessauth', 'roundcube_sessid', 'smsession']:
+        response.set_cookie(cookie, 'empty', expires=0)
+    return response
 
 
 @sso.route('/proxy', methods=['GET'])


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

sometimes at least roundcube webmail is confused when changing users.
this deletes the webmail session cookies to avoid the confusion.
