### PR TITLE
Fix nginx config

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -91,7 +91,7 @@ http {
       client_max_body_size {{ MESSAGE_SIZE_LIMIT|int + 8388608 }};
 
       # Listen on HTTP only in kubernetes or behind reverse proxy
-      {% if KUBERNETES_INGRESS == 'true' or TLS_FLAVOR in [ 'mail-letsencrypt', 'notls', 'mail' ] %}
+      {% if KUBERNETES_INGRESS or TLS_FLAVOR in [ 'mail-letsencrypt', 'notls', 'mail' ] %}
       listen 80;
 {% if SUBNET6 %}
       listen [::]:80;
@@ -166,7 +166,7 @@ http {
       include /overrides/*.conf;
 
       # Actual logic
-      {% if ADMIN == 'true' or WEBMAIL != 'none' %}
+      {% if ADMIN or WEBMAIL != 'none' %}
       location ~ ^/(sso|static)/ {
         include /etc/nginx/proxy.conf;
         proxy_pass http://$admin;
@@ -219,7 +219,7 @@ http {
         return 302 /sso/login;
       }
       {% endif %}
-      {% if ADMIN == 'true' %}
+      {% if ADMIN %}
        location {{ WEB_ADMIN }} {
          include /etc/nginx/proxy.conf;
          proxy_pass http://$admin;


### PR DESCRIPTION
Forgot to adapt some IF statements. All config is normalized now for front.

So true/false now matches the boolean value True/False. Instead if {% IF X == 'true' %} we should now use {% IF X %}

## What type of PR?

bug-fix

## What does this PR do?
Fixes a bug in the nginx config. This bug prevents the /admin endpoint from being exposed.

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ n/a] In case of feature or enhancement: documentation updated accordingly
- [ n/a] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
