### PR TITLE
Tell roundcube that sieve scripts should be utf8 encoded

### DIFF
--- a/towncrier/newsfragments/2650.bugfix
+++ b/towncrier/newsfragments/2650.bugfix
@@ -1,0 +1,1 @@
+Tell roundcube to use UTF8 instead of 'UTF7-IMAP' when creating sieve scripts.

--- a/webmails/roundcube/config/config.inc.php
+++ b/webmails/roundcube/config/config.inc.php
@@ -25,6 +25,7 @@ $config['smtp_pass'] = '%p';
 
 // Sieve script management
 $config['managesieve_host'] = '{{ FRONT_ADDRESS or "front" }}:14190';
+$config['managesieve_mbox_encoding'] = 'UTF8';
 
 // roundcube customization
 $config['product_name'] = 'Mailu Webmail';


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Tell roundcube that sieve scripts should be utf8 encoded.

### Related issue(s)
- Close #2258

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
