### PR TITLE
Fix the bug reported by fastlorenzo

### DIFF
--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -62,7 +62,6 @@ def logout():
         response.set_cookie(cookie, 'empty', expires=0)
     return response
 
-
 @sso.route('/proxy', methods=['GET'])
 @sso.route('/proxy/<target>', methods=['GET'])
 def proxy(target='webmail'):
@@ -95,6 +94,8 @@ def proxy(target='webmail'):
         return flask.abort(500, 'Too many users in (domain=%s)' % domain)
     user = models.User(localpart=localpart, domain=domain)
     user.set_password(secrets.token_urlsafe())
+    flask.session.regenerate()
+    flask_login.login_user(user)
     models.db.session.add(user)
     models.db.session.commit()
     user.send_welcome()


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix the bug reported by fastlorenzo: when using proxy-auth, if the user doesn't exist you have to hit the URL twice.

### Related issue(s)


## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
