### PR TITLE
Apply DEFAULT_QUOTA to user creation admin ui page

### DIFF
--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -1,7 +1,6 @@
 from wtforms import validators, fields, widgets
 from wtforms_components import fields as fields_
 from flask_babel import lazy_gettext as _
-from flask import current_app as app
 
 import flask_login
 import flask_wtf
@@ -92,7 +91,7 @@ class UserForm(flask_wtf.FlaskForm):
     pw = fields.PasswordField(_('Password'))
     pw2 = fields.PasswordField(_('Confirm password'), [validators.EqualTo('pw')])
     pwned = fields.HiddenField(label='', default=-1)
-    quota_bytes = fields_.IntegerSliderField(_('Quota'), default=app.config['DEFAULT_QUOTA'])
+    quota_bytes = fields_.IntegerSliderField(_('Quota'), default=10**9)
     enable_imap = fields.BooleanField(_('Allow IMAP access'), default=True)
     enable_pop = fields.BooleanField(_('Allow POP3 access'), default=True)
     allow_spoofing = fields.BooleanField(_('Allow the user to spoof the sender (send email as anyone)'), default=False)

--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -1,6 +1,7 @@
 from wtforms import validators, fields, widgets
 from wtforms_components import fields as fields_
 from flask_babel import lazy_gettext as _
+from flask import current_app as app
 
 import flask_login
 import flask_wtf
@@ -91,7 +92,7 @@ class UserForm(flask_wtf.FlaskForm):
     pw = fields.PasswordField(_('Password'))
     pw2 = fields.PasswordField(_('Confirm password'), [validators.EqualTo('pw')])
     pwned = fields.HiddenField(label='', default=-1)
-    quota_bytes = fields_.IntegerSliderField(_('Quota'), default=10**9)
+    quota_bytes = fields_.IntegerSliderField(_('Quota'), default=app.config['DEFAULT_QUOTA'])
     enable_imap = fields.BooleanField(_('Allow IMAP access'), default=True)
     enable_pop = fields.BooleanField(_('Allow POP3 access'), default=True)
     allow_spoofing = fields.BooleanField(_('Allow the user to spoof the sender (send email as anyone)'), default=False)

--- a/core/admin/mailu/ui/views/users.py
+++ b/core/admin/mailu/ui/views/users.py
@@ -27,6 +27,8 @@ def user_create(domain_name):
     if domain.max_quota_bytes:
         form.quota_bytes.validators = [
             wtforms.validators.NumberRange(max=domain.max_quota_bytes)]
+        if form.quota_bytes.default > domain.max_quota_bytes:
+            form.quota_bytes.default = domain.max_quota_bytes
     if form.validate_on_submit():
         if msg := utils.isBadOrPwned(form):
             flask.flash(msg, "error")

--- a/core/admin/mailu/ui/views/users.py
+++ b/core/admin/mailu/ui/views/users.py
@@ -30,6 +30,7 @@ def user_create(domain_name):
             wtforms.validators.NumberRange(max=domain.max_quota_bytes)]
         if form.quota_bytes.default > domain.max_quota_bytes:
             form.quota_bytes.default = domain.max_quota_bytes
+    form.process()
     if form.validate_on_submit():
         if msg := utils.isBadOrPwned(form):
             flask.flash(msg, "error")

--- a/core/admin/mailu/ui/views/users.py
+++ b/core/admin/mailu/ui/views/users.py
@@ -24,6 +24,7 @@ def user_create(domain_name):
             flask.url_for('.user_list', domain_name=domain.name))
     form = forms.UserForm()
     form.pw.validators = [wtforms.validators.DataRequired()]
+    form.quota_bytes.default = app.config['DEFAULT_QUOTA']
     if domain.max_quota_bytes:
         form.quota_bytes.validators = [
             wtforms.validators.NumberRange(max=domain.max_quota_bytes)]

--- a/core/admin/mailu/ui/views/users.py
+++ b/core/admin/mailu/ui/views/users.py
@@ -30,7 +30,6 @@ def user_create(domain_name):
             wtforms.validators.NumberRange(max=domain.max_quota_bytes)]
         if form.quota_bytes.default > domain.max_quota_bytes:
             form.quota_bytes.default = domain.max_quota_bytes
-    form.process()
     if form.validate_on_submit():
         if msg := utils.isBadOrPwned(form):
             flask.flash(msg, "error")
@@ -48,6 +47,7 @@ def user_create(domain_name):
             flask.flash('User %s created' % user)
             return flask.redirect(
                 flask.url_for('.user_list', domain_name=domain.name))
+    form.process()
     return flask.render_template('user/create.html',
         domain=domain, form=form)
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -133,6 +133,9 @@ the localpart for DMARC rua and ruf email addresses.
 Full-text search is enabled for IMAP is enabled by default. This feature can be disabled
 (e.g. for performance reasons) by setting the optional variable ``FULL_TEXT_SEARCH`` to ``off``.
 
+You can set a global ``DEFAULT_QUOTA`` to be used for mailboxes when the domain has
+no specific quota configured.
+
 .. _web_settings:
 
 Web settings


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

Apply `DEFAULT_QUOTA` settings to user creation admin ui page.

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] ~In case of feature or enhancement: documentation updated accordingly~
- [ ] ~Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.~

I'm sorry for that I'm not good at English to update the documentation. But this is not a completed new feature. `DEFAULT_QUOTA` is an existing configuration. I just completed the behaviors. Although this configuration was never documented.