### PR TITLE
Set rainloop autologout time according to SESSION_TIMEOUT

### DIFF
--- a/webmails/rainloop/defaults/application.ini
+++ b/webmails/rainloop/defaults/application.ini
@@ -17,3 +17,6 @@ allow_sync = On
 
 [plugins]
 contacts_autosave = On
+
+[defaults]
+autologout = {{ (((PERMANENT_SESSION_LIFETIME | default(10800)) | int)/60) | int }}


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Set the autologout variable in rainloop according with systemwide session configuration so that autologout does not trigger too early or too late, which confuses and unnerves users.

### Related issue(s)
- closes #2680 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
