### PR TITLE
Set snappymail autologout time according to SESSION_TIMEOUT

### DIFF
--- a/webmails/snappymail/defaults/application.ini
+++ b/webmails/snappymail/defaults/application.ini
@@ -20,6 +20,7 @@ allow_sync = On
 
 [defaults]
 contacts_autosave = On
+autologout = {{ (((PERMANENT_SESSION_LIFETIME | default(10800)) | int)/60) | int }}
 
 [cache]
 enable = On


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
Set the autologout variable in snappymail according with systemwide session configuration so that autologout does not trigger too early or too late, which confuses and unnerves users.

!!!!! Please note that I currently (due to very limited time resources) cannot test on snappymail yet, so this is a "blind" flight PR !!!!!
I know it’s a bit insolent to open PRs with untested code, deferring the testing work to somebody else, but that’s the best I can do ATM. Sorry!

### Related issue(s)
- closes #2680 
- 1.9 backport siebling: #

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.

 