### PR TITLE
Switch from docker.io to ghcr.io for deploying images

### DIFF
--- a/.github/workflows/arm.yml
+++ b/.github/workflows/arm.yml
@@ -7,20 +7,10 @@ on:
 
 concurrency: ci-arm-${{ github.ref }}
 
-###############################################
-# REQUIRED secrets
-# ${{ secrets.Docker_Login }}
-#    Username of docker login for pushing the images to repo env.DOCKER_ORG and env.DOCKER_ORG_TESTS
-# ${{ secrets.Docker_Password }}
-#    Password of docker login for pushing the images to repo env.DOCKER_ORG and env.DOCKER_ORG_TESTS
-# Add the above secrets to your github repo to determine where the images will be pushed.
-################################################
 # REQUIRED global variables
-# DOCKER_ORG, docker org used for pushing release images (branch x.y and master)
-# DOCKER_ORG_TEST, docker org used for pushing images for testing (branch testing).
+# DOCKER_ORG, docker org used for pushing images.
 env:
-  DOCKER_ORG: mailu
-  DOCKER_ORG_TEST: mailuci
+  DOCKER_ORG: ghcr.io/mailu
 
 jobs:
 # This job calculates all global job variables that are required by all the subsequent jobs.

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -1,3 +1,11 @@
+###############################################
+# REQUIRED secrets
+# ${{ secrets.Docker_Login }}
+#    Username of docker login for logging in docker for pulling images (higher pull rate limit)
+# ${{ secrets.Docker_Password }}
+#    Password of docker login for logging in docker for pulling images (higher pull rate limit)
+################################################
+
 name: build-test-deploy
 on:
   workflow_call:
@@ -16,7 +24,7 @@ on:
         required: true
         type: string
       docker_org:
-        description: 'The docker organisation where the images are pushed to.'
+        description: 'The docker organisation where the images are pushed to. E.g. ghcr.io/mailu'
         required: true
         type: string
       branch:
@@ -24,7 +32,7 @@ on:
         required: true
         type: string
       deploy:
-        description: Deploy to docker hub. Happens for all branches but staging. Use string true or false.
+        description: Deploy to container registry. Happens for all branches but staging. Use string true or false.
         default: true
         required: false
         type: string
@@ -50,7 +58,7 @@ on:
         required: true
         type: string
       docker_org:
-        description: 'The docker organisation where the images are pushed to.'
+        description: 'The docker organisation where the images are pushed to. E.g. ghcr.io/mailu'
         required: true
         type: string
       branch:
@@ -58,7 +66,7 @@ on:
         required: true
         type: string
       deploy:
-        description: Deploy to docker hub. Happens for all branches but staging. Use string true or false.
+        description: Deploy to container registry. Happens for all branches but staging. Use string true or false.
         default: true
         required: false
         type: string
@@ -250,8 +258,8 @@ jobs:
       - name: Build all docker images
         env:
           DOCKER_ORG: ghcr.io/${{ steps.string.outputs.lowercase }}
-          MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}-build
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}-build
         uses: docker/bake-action@v2
         with:
           files: ${{env.HCL_FILE}}
@@ -313,8 +321,8 @@ jobs:
       - name: Build all docker images
         env:
           DOCKER_ORG: ghcr.io/${{ steps.string.outputs.lowercase }}
-          MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}-build
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}-build
         uses: docker/bake-action@v2
         with:
           files: ${{env.HCL_FILE}}
@@ -381,8 +389,8 @@ jobs:
         run: python tests/compose/test.py ${{ matrix.target }} ${{ matrix.time }}
         env:
           DOCKER_ORG: ghcr.io/${{ steps.string.outputs.lowercase }}
-          MAILU_VERSION: ${{ env.MAILU_VERSION }}
-          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
+          MAILU_VERSION: ${{ env.MAILU_VERSION }}-build
+          PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}-build
 
   deploy:
     name: Deploy images
@@ -409,17 +417,18 @@ jobs:
       - uses: crazy-max/ghaction-github-runtime@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.Docker_Login }}
-          password: ${{ secrets.Docker_Password }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Helper to convert docker org to lowercase
         id: string
         uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ github.repository_owner }}
-      - name: Push image to Docker
+      - name: Push image to Github (ghcr.io)
         shell: bash
         run: |
           if [ '${{ env.MAILU_VERSION }}' == 'master' ]; then pinned_mailu_version='master'; else pinned_mailu_version=${{ env.PINNED_MAILU_VERSION}}; fi;
@@ -427,7 +436,7 @@ jobs:
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:${{ env.MAILU_VERSION }} \
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:$pinned_mailu_version \
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:latest \
-            ghcr.io/${{ steps.string.outputs.lowercase }}/${{ matrix.target }}:${{ env.MAILU_VERSION }}
+            ghcr.io/${{ steps.string.outputs.lowercase }}/${{ matrix.target }}:${{ env.MAILU_VERSION }}-build
 
   deploy-arm:
     name: Deploy images for arm
@@ -454,17 +463,18 @@ jobs:
       - uses: crazy-max/ghaction-github-runtime@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Login to Docker Hub
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.Docker_Login }}
-          password: ${{ secrets.Docker_Password }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Helper to convert docker org to lowercase
         id: string
         uses: ASzc/change-string-case-action@v5
         with:
           string: ${{ github.repository_owner }}
-      - name: Push image to Docker
+      - name: Push image to Github (ghcr.io)
         shell: bash
         run: |
           if [ '${{ env.MAILU_VERSION }}' == 'master-arm' ]; then pinned_mailu_version='master-arm'; else pinned_mailu_version=${{ env.PINNED_MAILU_VERSION}}; fi;
@@ -472,7 +482,7 @@ jobs:
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:${{ env.MAILU_VERSION }} \
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:$pinned_mailu_version \
             --tag ${{ inputs.docker_org }}/${{ matrix.target }}:latest \
-            ghcr.io/${{ steps.string.outputs.lowercase }}/${{ matrix.target }}:${{ env.MAILU_VERSION }}
+            ghcr.io/${{ steps.string.outputs.lowercase }}/${{ matrix.target }}:${{ env.MAILU_VERSION }}-build
 
 #This job creates a tagged release. A tag is created for the pinned version x.y.z. The GH release refers to this tag.
   tag-release:

--- a/.github/workflows/x64.yml
+++ b/.github/workflows/x64.yml
@@ -9,20 +9,10 @@ on:
 
 concurrency: ci-x64-${{ github.ref }}
 
-###############################################
-# REQUIRED secrets
-# ${{ secrets.Docker_Login }}
-#    Username of docker login for pushing the images to repo env.DOCKER_ORG and env.DOCKER_ORG_TESTS
-# ${{ secrets.Docker_Password }}
-#    Password of docker login for pushing the images to repo env.DOCKER_ORG and env.DOCKER_ORG_TESTS
-# Add the above secrets to your github repo to determine where the images will be pushed.
-################################################
 # REQUIRED global variables
-# DOCKER_ORG, docker org used for pushing release images (branch x.y and master)
-# DOCKER_ORG_TEST, docker org used for pushing images for testing (branch testing).
+# DOCKER_ORG, docker org used for pushing images.
 env:
-  DOCKER_ORG: mailu
-  DOCKER_ORG_TEST: mailuci
+  DOCKER_ORG: ghcr.io/mailu
 
 jobs:
 # This job calculates all global job variables that are required by all the subsequent jobs.
@@ -55,7 +45,7 @@ jobs:
         run: |
           echo "MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
           echo "PINNED_MAILU_VERSION=pr-${COMMIT_MESSAGE//[!0-9]/}" >> $GITHUB_ENV
-          echo "DOCKER_ORG_DERIVED=${{ env.DOCKER_ORG_TEST }}" >> $GITHUB_ENV
+          echo "DOCKER_ORG_DERIVED=${{ env.DOCKER_ORG }}" >> $GITHUB_ENV
           echo "DEPLOY=true" >> $GITHUB_ENV
           echo "RELEASE=false" >> $GITHUB_ENV
       - name: Derive MAILU_VERSION and DEPLOY/RELEASE for other branches than testing

--- a/docs/contributors/environment.rst
+++ b/docs/contributors/environment.rst
@@ -116,7 +116,7 @@ After cloning the git repository to your workstation, you can build the images:
 
 The ``build.hcl`` file has three variables:
 
-#. ``$DOCKER_ORG``: First part of the image tag. Defaults to *mailu* and needs to be changed
+#. ``$DOCKER_ORG``: First part of the image tag. Defaults to *ghcr.io/mailu* and needs to be changed
    only  when pushing to your own Docker hub account.
 #. ``$MAILU_VERSION``: Last part of the image tag. Defaults to *local* to differentiate from pulled
    images.
@@ -206,14 +206,14 @@ Test images
 
 All PR's automatically get build by a Github Action workflow, controlled by `bors-ng`_.
 Some primitive auto testing is done.
-The resulting images get uploaded to Docker hub, under the
-tag name ``mailuci/<name>:pr-<no>``.
+The resulting images get uploaded to the Github container registry, under the
+tag name ``ghcr.io/mailu/<name>:pr-<no>``.
 
 For example, to test PR #500 against master, reviewers can use:
 
 .. code-block:: bash
 
-  export DOCKER_ORG="mailuci"
+  export DOCKER_ORG="ghcr.io/mailu"
   export MAILU_VERSION="pr-500"
   docker compose pull
   docker compose up -d

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -22,7 +22,7 @@ services:
 
   # Core services
   front:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}nginx:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}nginx:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
     logging:
@@ -49,7 +49,7 @@ services:
       - {{ dns }}
 
   resolver:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}unbound:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}unbound:${MAILU_VERSION:-{{ version }}}
     env_file: {{ env }}
     restart: always
     networks:
@@ -58,7 +58,7 @@ services:
     {% endif %}
 
   admin:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}admin:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}admin:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
     {% if not admin_enabled %}
@@ -77,7 +77,7 @@ services:
     {% endif %}
 
   imap:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}dovecot:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}dovecot:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
     volumes:
@@ -92,7 +92,7 @@ services:
     {% endif %}
 
   smtp:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}postfix:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}postfix:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
     volumes:
@@ -108,7 +108,7 @@ services:
 
 {% if oletools_enabled %}
   oletools:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}oletools:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}oletools:${MAILU_VERSION:-{{ version }}}
     hostname: oletools
     restart: always
     networks:
@@ -122,7 +122,7 @@ services:
 {% endif %}
 
   antispam:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}rspamd:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}rspamd:${MAILU_VERSION:-{{ version }}}
     hostname: antispam
     restart: always
     env_file: {{ env }}
@@ -152,7 +152,7 @@ services:
   # Optional services
   {% if antivirus_enabled %}
   antivirus:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}clamav:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}clamav:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
     volumes:
@@ -167,7 +167,7 @@ services:
 
   {% if webdav_enabled %}
   webdav:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}radicale:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}radicale:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
     volumes:
@@ -178,7 +178,7 @@ services:
 
   {% if fetchmail_enabled %}
   fetchmail:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}fetchmail:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}fetchmail:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
     volumes:
@@ -197,7 +197,7 @@ services:
   # Webmail
   {% if webmail_type != 'none' %}
   webmail:
-    image: ${DOCKER_ORG:-mailu}/${DOCKER_PREFIX:-}webmail:${MAILU_VERSION:-{{ version }}}
+    image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}webmail:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
     volumes:

--- a/towncrier/newsfragments/2704.misc
+++ b/towncrier/newsfragments/2704.misc
@@ -1,0 +1,10 @@
+Switch the container registry used for deploying images from docker.io
+to ghcr.io (github).
+
+To start using ghcr.io, regenerate your docker-compose.yml file via setup.mailu.io.
+
+For Mailu 1.9 users:
+1. docker-compose down.
+2. create the file .env in the same folder as docker-compose.yml with the following contents:
+DOCKER_ORG=ghcr.io/mailu
+3. docker-compose up -d


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?
As we all know, docker has announced that they will stop with free docker organisations. The Mailu project used this. In about a month, the mailu docker org stops to exist and all images will be deleted.

This PR modifies the CI/CD workflow (github actions) to use ghcr.io as the container registry for deployed images. The images are first build with `-build` appended to the tag. These images are also used in the test step. Only in the deploy phase, are the final tags added (as it should be). This makes sure new images are only available after the deployment step.

The setup utility is updated to use `ghcr.io/mailu` as the docker_org.

All references to the docker org `mailu` have been replaced with `ghcr.io/mailu` in the documentation.

I confirmed via my Mailu_Fork repo that the github workflow works fine. 
https://github.com/Diman0/Mailu_Fork/actions/runs/4440118095

### Related issue(s)
- closes #2704 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
