### PR TITLE
Fix build.hcl / CI.yml regarding labels

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -142,6 +142,8 @@ jobs:
           DOCKER_ORG: ghcr.io/${{ steps.string.outputs.lowercase }}
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
           PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
+          LABEL_VERSION: ${{ env.MAILU_VERSION }}
+          PINNED_LABEL_VERSION: ${{ env.PINNED_MAILU_VERSION }}
         uses: docker/bake-action@v2
         with:
           files: ${{env.HCL_FILE}}
@@ -198,6 +200,8 @@ jobs:
           DOCKER_ORG: ghcr.io/${{ steps.string.outputs.lowercase }}
           MAILU_VERSION: ${{ env.MAILU_VERSION }}
           PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}
+          LABEL_VERSION: ${{ env.MAILU_VERSION }}
+          PINNED_LABEL_VERSION: ${{ env.PINNED_MAILU_VERSION }}
         uses: docker/bake-action@v2
         with:
           files: ${{env.HCL_FILE}}
@@ -260,6 +264,8 @@ jobs:
           DOCKER_ORG: ghcr.io/${{ steps.string.outputs.lowercase }}
           MAILU_VERSION: ${{ env.MAILU_VERSION }}-build
           PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}-build
+          LABEL_VERSION: ${{ env.MAILU_VERSION }}
+          PINNED_LABEL_VERSION: ${{ env.PINNED_MAILU_VERSION }}
         uses: docker/bake-action@v2
         with:
           files: ${{env.HCL_FILE}}
@@ -323,6 +329,8 @@ jobs:
           DOCKER_ORG: ghcr.io/${{ steps.string.outputs.lowercase }}
           MAILU_VERSION: ${{ env.MAILU_VERSION }}-build
           PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}-build
+          LABEL_VERSION: ${{ env.MAILU_VERSION }}
+          PINNED_LABEL_VERSION: ${{ env.PINNED_MAILU_VERSION }}
         uses: docker/bake-action@v2
         with:
           files: ${{env.HCL_FILE}}

--- a/tests/build.hcl
+++ b/tests/build.hcl
@@ -20,6 +20,12 @@ variable "PINNED_MAILU_VERSION" {
 variable "MAILU_VERSION" {
   default = "local"
 }
+variable "LABEL_VERSION" {
+  default = "local"
+}
+variable "PINNED_LABEL_VERSION" {
+  default = "local"
+}
 
 #-----------------------------------------------------------------------------------------
 # Grouping of targets to build. All these images are built when using:
@@ -54,7 +60,7 @@ target "defaults" {
   platforms = [ "linux/amd64"]
   dockerfile = "Dockerfile"
   args = {
-    VERSION = "${PINNED_MAILU_VERSION}"
+    VERSION = "${PINNED_LABEL_VERSION}"
   }
 }
 
@@ -99,8 +105,8 @@ target "docs" {
   context = "docs/"
   tags = tag("docs")
   args = {
-    version = "${MAILU_VERSION}"
-    pinned_version = "${PINNED_MAILU_VERSION}"
+    version = "${LABEL_VERSION}"
+    pinned_version = "${PINNED_LABEL_VERSION}"
   }
 }
 


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
The version label and versions passed to the docs image were based on the tag. Now we first build the images with -build appended to the tag, we cannot use the tag as version label anymore. 

E.g. the docs image now has the version master-build. This causes any requests to https://mailu.io/master to fail now. Due to the label master-build, it expects https://mailu.io/master-build

Two new env vars are introduced to pass the version to the build.hcl file. This will be used to set the VERSION label in the image, and pass as build arguments to the docs image. 

