### PR TITLE
Mirror alpine image to ghcr.io/mailu docker org to prevent docker pull rate limit

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,42 @@
+# Used for creating mirror images of images currently on docker.io.
+# The main reason is to circumvent the docker pull rate-limit
+# Currently this is used for:
+# Alpine (used in Dockerfile for base image)
+
+name: mirror-images
+on:
+  workflow_dispatch:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Mirror (copy) the image every day at 03:00h
+    # m h  dom mon dow
+    - cron:  '0 3 * * *'
+
+jobs:
+# mirror alpine image
+  mirror-image-alpine:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        #list of tags to mirror, update this to sync a different alpine tag
+        tag: ["3.17.2"]
+    steps:
+      - name: Helper to convert docker org to lowercase
+        id: string
+        uses: ASzc/change-string-case-action@v5
+        with:
+          string: ${{ github.repository_owner }}
+      - name: Mirror images
+        shell: bash
+        env:
+          DOCKER_ORG: ghcr.io/${{ steps.string.outputs.lowercase }}
+          TAG: ${{ matrix.tag }}
+        run: |
+          set -euxo pipefail \
+          ; echo "${{ github.token }}" | docker login --username "${{ github.repository_owner }}" --password-stdin ghcr.io \
+          ; curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >regctl \
+          ; chmod 755 regctl \
+          ; ./regctl image copy docker.io/alpine:"$TAG" "$DOCKER_ORG"/alpine:"$TAG" \
+          ; rm regctl \
+          ; docker logout ghcr.io

--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -1,7 +1,15 @@
 # syntax=docker/dockerfile-upstream:1.4.3
 
 # base system image (intermediate)
-ARG DISTRO=alpine:3.17.2
+# Note when updating tag, also update it in .github/workflows/mirror.yml.
+# Then run that workflow at least once to pull & mirror the new alpine image. Or do it manually via:
+# echo "$MY_GH_PAT" | docker login --username "my_gh_user_name" --password-stdin ghcr.io
+# curl -L https://github.com/regclient/regclient/releases/latest/download/regctl-linux-amd64 >regctl
+# chmod 755 regctl
+# ./regctl image copy docker.io/alpine:3.17.2 ghcr.io/mailu/alpine:3.17.2
+# rm regctl
+# docker logout ghcr.io
+ARG DISTRO=ghcr.io/mailu/alpine:3.17.2
 FROM $DISTRO as system
 
 ENV TZ=Etc/UTC LANG=C.UTF-8


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?
Mirror alpine image to ghcr.io/mailu docker org to prevent docker pull rate limit. Use mirrored ghcr.io/mailu/alpine image as base image.

The new github action will mirror/copy the image every day at 03:00h. It can also be run manually to immediately sync the image.

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
