### PR TITLE
Discuss reverting "STARTTLS is a bad idea" 

### DIFF
--- a/core/admin/mailu/ui/templates/client.html
+++ b/core/admin/mailu/ui/templates/client.html
@@ -17,7 +17,7 @@
     </tr>
     <tr>
       <th>{% trans %}TCP port{% endtrans %}</th>
-      <td>{{ "143" if config["TLS_FLAVOR"] == "notls" else "993 (TLS)" }}</td>
+      <td>{{ "143" if config["TLS_FLAVOR"] == "notls" else "993 (TLS) or 143 (STARTTLS)" }}</td>
     </tr>
     <tr>
       <th>{% trans %}Server name{% endtrans %}</th>
@@ -42,7 +42,7 @@
     </tr>
     <tr>
       <th>{% trans %}TCP port{% endtrans %}</th>
-      <td>{{ "25" if config["TLS_FLAVOR"] == "notls" else "465 (TLS)" }}</td>
+      <td>{{ "25" if config["TLS_FLAVOR"] == "notls" else "465 (TLS) or 587 (STARTTLS)" }}</td>
     </tr>
     <tr>
       <th>{% trans %}Server name{% endtrans %}</th>


### PR DESCRIPTION
This reverts commit 0bccb5045c1f2ccd2f8ac13fc7e03faa43049912, which was incorporated directly in `main` without much (public? ) discussion that I've seen.

https://en.wikipedia.org/wiki/Opportunistic_TLS

The point is to enforce TLS in all cases, why still providing the StartTLS endpoints at all then?