### PR TITLE
Fix tag-release step in workflow which prevented github releases from being created automatically

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -416,8 +416,11 @@ jobs:
         id: changelog
         shell: bash
         run: |
+            delimiter="$RANDOM"
             pushd . && cd towncrier/newsfragments && ls -Art | tail -n 1 | cut -d. -f1 | xargs -0I % echo "issue=%" >> $GITHUB_OUTPUT && popd
-            pushd . && cd towncrier/newsfragments && ls -Art | tail -n 1 | xargs cat | xargs -0I % echo "content=%" >> $GITHUB_OUTPUT && popd
+            echo "content<<${delimiter}" >> "${GITHUB_OUTPUT}"
+            pushd . && cd towncrier/newsfragments && ls -Art | tail -n 1 | xargs cat | xargs -0I % echo "%" >> "${GITHUB_OUTPUT}" && popd
+            echo "${delimiter}" >> "${GITHUB_OUTPUT}"
       - name: Construct message for release
         shell: bash
         env:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,5 @@
+.. _mailu_restful_api:
+
 Mailu RESTful API
 =================
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -382,6 +382,7 @@ When ``POSTFIX_LOG_FILE`` is enabled, the logrotate program will automatically r
 logs every week and keep 52 logs. To override the logrotate configuration, create the file logrotate.conf
 with the desired configuration in the :ref:`Postfix overrides folder<override-label>`.
 
+.. _header_authentication:
 
 Header authentication using an external proxy
 ---------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -362,6 +362,8 @@ How do I use webdav (radicale)?
 .. _`575`: https://github.com/Mailu/Mailu/issues/575
 .. _`1591`: https://github.com/Mailu/Mailu/issues/1591
 
+.. _mta-sts:
+
 How do I setup a MTA-STS policy?
 ````````````````````````````````
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -316,10 +316,12 @@ If you use overrides for Rspamd, then please note that overrides are now placed 
 If you use your own map files, change the location to ``/overrides/myMapFile.map`` in the corresponding rspamd conf file.
 
 To use the new autoconfig endpoint and Mailu RESTFul API, you may need to update your reverse proxy config.
-If you use ``TLS_FLAVOR=letsencrypt``, add autoconfig.myhostname.com to the setting ``HOSTNAMES=`` in mailu.env to generate a certifficate for the autoconfig endpoint as well.
+If you use ``TLS_FLAVOR=letsencrypt``, add autoconfig.myhostname.com to the setting ``HOSTNAMES=`` in mailu.env to generate a certificate for the autoconfig endpoint as well.
 After starting your Mailu deployment, please refer to the section `DNS client auto-configuration entries` on the domain details page
 in the web administration interface for the exact name of the autoconfig endpoint (https://test.mailu.io/admin/domain/details/test.mailu.io).
 
+It is also recommended to have a look at :ref:`mta-sts <mta-sts>`.
+When mta-sts is enabled, modern email servers will immediately use TLS for delivering emails to Mailu.
 
 Mailu 1.9 - 2021-12-29
 ----------------------

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -49,7 +49,7 @@ Configuring a new domain or add new users can be fully automated now.
 The current API makes use of a single API token for authentication.
 In a future release this will likely be re-visited.
 
-For more information refer to the `Mailu RESTful API` page.
+For more information refer to the :ref:`Mailu RESTful API <mailu_restful_api>` page.
 
 Header authentication support (use external identity providers)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -57,7 +57,7 @@ Header authentication support (use external identity providers)
 It is now possible to use different authentication systems (such as keycloak, authentik, vouch-proxy) to handle the authentication of Mailu users.
 This can be used to enable Single Sign On from other IDentity Providers via protocols such as OIDC or SAML2.
 
-For more information see `Header authentication using an external proxy` in the configuration reference.
+For more information see :ref:`Header authentication using an external proxy <header_authentication>` in the configuration reference.
 
 Better anti-spoofing protection
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -131,6 +131,20 @@ The override system for Rspamd has been overhauled. While the config files were 
 Now overrides are placed in the location (in the Rspamd/Antispam container) /overrides.
 
 If you use your own map files, change the location to /override/myMapFile.map in the corresponding conf file.
+For example when overriding multimap.conf that use a custom \*.map file:
+
+.. code-block:: bash
+
+  #multimap.conf
+  LOCAL_BL_DOMAIN {
+    type = "from";
+    filter = "email:domain";
+    map = "/override/blacklist.map";
+    score = 15;
+    description = "Senders domain part is on the local blacklist";
+    group = "local_bl";
+  }
+
 It works as following.
 
 * If the override file overrides a Mailu defined config file,
@@ -292,10 +306,19 @@ Upgrading
 `````````
 
 Upgrade should run fine as long as you generate a new compose & mailu.env and then reapply custom config settings to mailu.env.
+Carefully read the :ref:`configuration page <common_cfg>` to check what old settings have been removed. If a setting is not listed anymore
+on the :ref:`configuration page <common_cfg>`, then this setting has been removed.
 
-If you use Fail2Ban, then the Fail2Ban intructions have been improved. It is mandatory to remove your Fail2Ban config and re-apply it using the instructions from :ref:`updated Fail2Ban documentation <Fail2Ban>`.
+If you use Fail2Ban, then the Fail2Ban intructions have been improved. It is **mandatory** to remove your Fail2Ban config
+and re-apply it using the instructions from :ref:`updated Fail2Ban documentation <Fail2Ban>`.
+
+If you use overrides for Rspamd, then please note that overrides are now placed in the location `/overrides` in the rspamd container.
+If you use your own map files, change the location to /override/myMapFile.map in the corresponding rspamd conf file.
 
 To use the new autoconfig endpoint and Mailu RESTFul API, you may need to update your reverse proxy config.
+If you use ``TLS_FLAVOR=letsencrypt``, add autoconfig.myhostname.com to the setting ``HOSTNAMES=`` in mailu.env to generate a certifficate for the autoconfig endpoint as well.
+After starting your Mailu deployment, please refer to the section `DNS client auto-configuration entries` on the domain details page
+in the web administration interface for the exact name of the autoconfig endpoint (https://test.mailu.io/admin/domain/details/test.mailu.io).
 
 
 Mailu 1.9 - 2021-12-29

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -68,7 +68,7 @@ It won't let any email which pretends to be for any of the local domains through
 Implement a password policy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In line with security best practices from `NIST (Special Publication 800-63B) <https://pages.nist.gov/800-63-3/sp800-63b.html#5111-memorized-secret-authenticators>`_, we have introduced password policy.
+In line with security best practices from `NIST (Special Publication 800-63B) <https://pages.nist.gov/800-63-3/sp800-63b.html#5111-memorized-secret-authenticators>`_, we have introduced a password policy.
 
 Passwords now need to:
 
@@ -86,7 +86,7 @@ Now the rate limiter will only take distinct attempts into account. We have two 
 
 We have also implemented state-of-the-art features such as `Device Cookies <https://owasp.org/www-community/Slow_Down_Online_Guessing_Attacks_with_Device_Cookies>`_ and IP-whitelisting post-authentication to ensure we don't lock genuine users out.
 
-Rate-limiters have a bad name because they are often misunderstood. If you used Mailu's rate-limiter in the past and had a bad experience please consider giving it another try after upgrading.
+Rate-limiters have a bad name because they are often misunderstood. If you have used Mailu's rate-limiter in the past and had a bad experience please consider giving it another try after upgrading.
 
 Remember the login URL
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -130,8 +130,8 @@ New override system for Rspamd
 The override system for Rspamd has been overhauled. While the config files were first completely overridden, they are now merged.
 Now overrides are placed in the location (in the Rspamd/Antispam container) /overrides.
 
-If you use your own map files, change the location to /override/myMapFile.map in the corresponding conf file.
-For example when overriding multimap.conf that use a custom \*.map file:
+If you use your own map files, change the location to ``/overrides/myMapFile.map`` in the corresponding conf file.
+For example when overriding multimap.conf that use a custom ``.map`` file:
 
 .. code-block:: bash
 
@@ -139,7 +139,7 @@ For example when overriding multimap.conf that use a custom \*.map file:
   LOCAL_BL_DOMAIN {
     type = "from";
     filter = "email:domain";
-    map = "/override/blacklist.map";
+    map = "/overrides/blacklist.map";
     score = 15;
     description = "Senders domain part is on the local blacklist";
     group = "local_bl";
@@ -260,7 +260,7 @@ Security hardening
 
 We have gone further than ever. Now Mailu containers drop their privileges and communicate on separate networks. They also share the same base image where on x86 `a Hardened memory allocator <https://github.com/GrapheneOS/hardened_malloc>`_ is configured.
 
-Webmails which are running PHP make use of `Snuffleupagus <https://github.com/jvoisin/snuffleupagus>`_.
+Webmails relying on PHP now make use of `Snuffleupagus <https://github.com/jvoisin/snuffleupagus>`_.
 
 
 New Functionality & Improvements
@@ -312,8 +312,8 @@ on the :ref:`configuration page <common_cfg>`, then this setting has been remove
 If you use Fail2Ban, then the Fail2Ban intructions have been improved. It is **mandatory** to remove your Fail2Ban config
 and re-apply it using the instructions from :ref:`updated Fail2Ban documentation <Fail2Ban>`.
 
-If you use overrides for Rspamd, then please note that overrides are now placed in the location `/overrides` in the rspamd container.
-If you use your own map files, change the location to /override/myMapFile.map in the corresponding rspamd conf file.
+If you use overrides for Rspamd, then please note that overrides are now placed in the location ``/overrides`` in the rspamd container.
+If you use your own map files, change the location to ``/overrides/myMapFile.map`` in the corresponding rspamd conf file.
 
 To use the new autoconfig endpoint and Mailu RESTFul API, you may need to update your reverse proxy config.
 If you use ``TLS_FLAVOR=letsencrypt``, add autoconfig.myhostname.com to the setting ``HOSTNAMES=`` in mailu.env to generate a certifficate for the autoconfig endpoint as well.

--- a/towncrier/newsfragments/2744.misc
+++ b/towncrier/newsfragments/2744.misc
@@ -1,0 +1,3 @@
+Fix tag-release step in workflow which prevented github releases from being created automatically. 
+Cause was that a specific method is required for assigning multi-line strings in github workflow files:
+https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

--- a/towncrier/newsfragments/2744.misc
+++ b/towncrier/newsfragments/2744.misc
@@ -1,3 +1,5 @@
 Fix tag-release step in workflow which prevented github releases from being created automatically. 
 Cause was that a specific method is required for assigning multi-line strings in github workflow files:
 https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
+
+Add some extra clarifications to release.rst. Upgrade section did not mention you need to check your rspamd overrides.


### PR DESCRIPTION
## What does this PR do?
Fix tag-release step in workflow which prevented github releases from being created automatically.

Cause was that a specific method is required for assigning multi-line strings in github workflow files: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

On my fork Mailu_Fork
Replicated the issue:
https://github.com/Diman0/Mailu_Fork/actions/runs/4626459175

Fix in action:
https://github.com/Diman0/Mailu_Fork/actions/runs/4626683488/jobs/8183697136
https://github.com/Diman0/Mailu_Fork/releases/tag/1.9.28

## What type of PR?

bug fix

### Related issue(s)
- closes #2744 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [n/a ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
