### PR TITLE
Fix config-import. Config with dkim key could not be imported.

### DIFF
--- a/core/admin/mailu/schemas.py
+++ b/core/admin/mailu/schemas.py
@@ -574,8 +574,8 @@ class DkimKeyField(fields.String):
         if value.lower() == '-generate-':
             return dkim.gen_key()
 
-        # no key?
-        if not value:
+        # no key or key is <hidden>?
+        if not value or str(value) == '<hidden>':
             return None
 
         # remember part of value for ValidationError
@@ -610,7 +610,7 @@ class DkimKeyField(fields.String):
 
         # check key validity
         try:
-            serialization.load_pem_private_key(bytes(value, "ascii"), password=None)
+            serialization.load_pem_private_key(value, password=None)
         except (UnicodeEncodeError, ValueError) as exc:
             raise ValidationError(f'invalid dkim key {bad_key!r}') from exc
         else:

--- a/towncrier/newsfragments/2747.bugfix
+++ b/towncrier/newsfragments/2747.bugfix
@@ -1,0 +1,2 @@
+Fix breaking bug in config-import command line command.
+Import yml's containing dkim keys (the element 'dkim_key:') failed to import using `config-import`.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
Imports with dkim keys failed due to two bugs
- The situation where the DKIM key was included as \<hidden\> in the config.yml was not handled
- An attempt was made to byte encode a value that was already a byte encoded value

This PR fixes both issues. Now config yml's with valid dkim keys and dkim keys with value \<hidden\> can be imported again using config-import.

### Related issue(s)
- #2747 


## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
