### PR TITLE
Fix #2720: make letsencrypt work when reverse proxies are misconfigured

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -64,7 +64,7 @@ http {
 {% if SUBNET6 %}
       listen [::]:80{% if PROXY_PROTOCOL in ['all', 'http'] %} proxy_protocol{% endif %};
 {% endif %}
-      {% if TLS_FLAVOR == 'letsencrypt' %}
+      {% if TLS_FLAVOR in ['letsencrypt', 'mail-letsencrypt'] %}
       location ^~ /.well-known/acme-challenge/ {
           proxy_pass http://127.0.0.1:8008;
       }
@@ -153,7 +153,7 @@ http {
         proxy_pass http://$admin;
       }
 
-      {% if TLS_FLAVOR == 'mail-letsencrypt' %}
+      {% if TLS_FLAVOR in ['letsencrypt', 'mail-letsencrypt'] %}
       location ^~ /.well-known/acme-challenge/ {
           proxy_pass http://127.0.0.1:8008;
       }

--- a/optional/fetchmail/Dockerfile
+++ b/optional/fetchmail/Dockerfile
@@ -16,6 +16,4 @@ RUN echo $VERSION >/version
 
 HEALTHCHECK --start-period=350s CMD ["/bin/sh", "-c", "ps ax | grep [/]fetchmail.py"]
 
-VOLUME ["/var/lib/rspamd"]
-
 CMD ["/fetchmail.py"]

--- a/towncrier/newsfragments/2720.bugfix
+++ b/towncrier/newsfragments/2720.bugfix
@@ -1,0 +1,1 @@
+Letsencrypt only works if port 80 is reachable. Users behind reverse-proxies don't read instructions... this makes the common misconfiguration work too.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Letsencrypt only works if port 80 is reachable. Users behind reverse-proxies don't read instructions... this makes the common misconfiguration work too.

### Related issue(s)
- closes #2720 
- closes #2766

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
