### PR TITLE
Whitelist all mailso* stream types in snuffleupagus for snappymail

### DIFF
--- a/towncrier/newsfragments/2776.bugfix
+++ b/towncrier/newsfragments/2776.bugfix
@@ -1,0 +1,1 @@
+Fix downloading attachments through snappymail.

--- a/webmails/snuffleupagus.rules
+++ b/webmails/snuffleupagus.rules
@@ -25,7 +25,7 @@ sp.readonly_exec.enable();
 
 # PHP has a lot of wrappers, most of them aren't usually useful, you should
 # only enable the ones you're using.
-sp.wrappers_whitelist.list("file,php,phar,mailsosubstreams");
+sp.wrappers_whitelist.list("file,php,phar,mailsosubstreams,mailsoliteral,mailsotempfile,mailsobinary");
 
 # Prevent sloppy comparisons.
 sp.sloppy_comparison.enable();


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
For attachment download in snappymail to work, at least mailsoliteral is needed. The additionally used stream types (from looking at the snappymail source) have also been added, to ensure compatability with whatever feature might rely on them ….

### Context
I’m not sure the newly whitelisted stream types other than `mailsoliteral` are actually needed. Would like some input on that, so I’m creating a draft first ….

Also, should this go to `2.0` or both `2.0` and `master`?

### Related issue(s)
- closes #2776

## Prerequisites
- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
