### PR TITLE
LD_PRELOAD may not be in ENV

### DIFF
--- a/core/base/libs/socrate/socrate/system.py
+++ b/core/base/libs/socrate/socrate/system.py
@@ -76,7 +76,7 @@ def set_env(required_secrets=[], log_filters=[], log_file=None):
         sys.stderr = LogFilter(sys.stderr, log_filters, log_file)
     log.basicConfig(stream=sys.stderr, level=os.environ.get("LOG_LEVEL", 'WARNING'))
 
-    if not _is_compatible_with_hardened_malloc():
+    if 'LD_PRELOAD' in os.environ and not _is_compatible_with_hardened_malloc():
         del os.environ['LD_PRELOAD']
 
     """ This will set all the environment variables and retains only the secrets we need """

--- a/towncrier/newsfragments/2789.bugfix
+++ b/towncrier/newsfragments/2789.bugfix
@@ -1,0 +1,1 @@
+In front, config.py can be called several times. LD_PRELOAD may have already been removed from ENV


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

In front, config.py can be called several times. LD_PRELOAD may have already been removed from ENV

### Related issue(s)
- close #2789 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
