### PR TITLE
Fix logs in the SMTP container

### DIFF
--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -16,7 +16,7 @@ COPY start.py /
 RUN echo $VERSION >/version
 
 EXPOSE 110/tcp 143/tcp 993/tcp 4190/tcp 2525/tcp
-HEALTHCHECK CMD echo PING|nc -w2 localhost 5001|grep "PONG"
+HEALTHCHECK CMD kill -0 `cat /run/dovecot/master.pid`
 
 VOLUME ["/mail"]
 

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -95,13 +95,6 @@ service auth-worker {
   }
 }
 
-service health-check {
-  executable = script -p health-check.sh
-  inet_listener health-check {
-      port = 5001
-  }
-}
-
 ###############
 # IMAP & POP
 ###############

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -9,7 +9,7 @@ import sys
 from podop import run_server
 from socrate import system, conf
 
-system.set_env(log_filters=r'waitpid\(\) returned unknown PID \d+$')
+system.set_env()
 
 def start_podop():
     system.drop_privs_to('mail')

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -9,7 +9,7 @@ import sys
 from podop import run_server
 from socrate import system, conf
 
-system.set_env()
+system.set_env(log_filters=r'Error\: SSL context initialization failed, disabling SSL\: Can\'t load SSL certificate \(ssl_cert setting\)\: The certificate is empty$')
 
 def start_podop():
     system.drop_privs_to('mail')

--- a/core/postfix/Dockerfile
+++ b/core/postfix/Dockerfile
@@ -15,7 +15,7 @@ COPY start.py /
 RUN echo $VERSION >/version
 
 #EXPOSE 25/tcp 10025/tcp
-HEALTHCHECK --start-period=350s CMD /usr/sbin/postfix status
+HEALTHCHECK --start-period=30s CMD ! /usr/libexec/postfix/master -t
 
 VOLUME ["/queue"]
 

--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -6,6 +6,7 @@
 mydomain = {{ DOMAIN }}
 myhostname = {{ HOSTNAMES.split(",")[0] }}
 myorigin = $mydomain
+maillog_file = /dev/stdout
 
 # Queue location
 queue_directory = /queue

--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -52,6 +52,7 @@ discard   unix  -       -       n       -       -       discard
 lmtp      unix  -       -       n       -       -       lmtp
 anvil     unix  -       -       n       -       1       anvil
 scache    unix  -       -       n       -       1       scache
+postlog   unix-dgram n  -       n       -       1       postlogd
 
 {# Ensure that the rendered file ends with a newline #}
 {{- "\n" }}

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -11,7 +11,6 @@ from podop import run_server
 from socrate import system, conf
 
 system.set_env(log_filters=[
-    r'the Postfix mail system is running\: \d+$',
     r'(dis)?connect from localhost\[(\:\:1|127\.0\.0\.1)\]( quit=1 commands=1)?$',
     r'haproxy read\: short protocol header\: QUIT$',
     r'discarding EHLO keywords\: PIPELINING$',

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -241,7 +241,9 @@ but slows down the performance of modern devices.
 
 The ``TLS_PERMISSIVE`` (default: true) setting controls whether ciphers and protocols offered on port 25 for STARTTLS are optimized for maximum compatibility. We **strongly recommend** that you do **not** change this setting on the basis that any encryption beats no encryption. If you are subject to compliance requirements and are not afraid of losing emails as a result of artificially reducing compatibility, set it to 'false'. Keep in mind that servers that are running a software stack old enough to not be compatible with the current TLS requirements will either a) deliver in plaintext b) bounce emails c) silently drop emails; moreover, modern servers will benefit from various downgrade protections (DOWNGRD, RFC7507) making the security argument mostly a moot point.
 
-The ``COMPRESSION`` (default: unset) setting controls whether emails are stored compressed at rest on disk. Valid values are ``gz``, ``bz2`` or ``zstd``. If the underlying filesystem supports compression natively you should use it instead of this setting as it will be more efficient and will improve compatibility with 3rd party tools.
+The ``COMPRESSION`` (default: unset) setting controls whether emails are stored compressed at rest on disk. Valid values are ``gz``, ``bz2`` or ``zstd`` and additional settings can be configured via ``COMPRESSION_LEVEL``, see `zlib_save_level`_ for accepted values. If the underlying filesystem supports compression natively you should use it instead of this setting as it will be more efficient and will improve compatibility with 3rd party tools.
+
+.. _`zlib_save_level`: https://doc.dovecot.org/settings/plugin/zlib-plugin/#plugin_setting-zlib-zlib_save_level
 
 .. _reverse_proxy_headers:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -241,6 +241,8 @@ but slows down the performance of modern devices.
 
 The ``TLS_PERMISSIVE`` (default: true) setting controls whether ciphers and protocols offered on port 25 for STARTTLS are optimized for maximum compatibility. We **strongly recommend** that you do **not** change this setting on the basis that any encryption beats no encryption. If you are subject to compliance requirements and are not afraid of losing emails as a result of artificially reducing compatibility, set it to 'false'. Keep in mind that servers that are running a software stack old enough to not be compatible with the current TLS requirements will either a) deliver in plaintext b) bounce emails c) silently drop emails; moreover, modern servers will benefit from various downgrade protections (DOWNGRD, RFC7507) making the security argument mostly a moot point.
 
+The ``COMPRESSION`` (default: unset) setting controls whether emails are stored compressed at rest on disk. Valid values are ``gz``, ``bz2`` or ``zstd``. If the underlying filesystem supports compression natively you should use it instead of this setting as it will be more efficient and will improve compatibility with 3rd party tools.
+
 .. _reverse_proxy_headers:
 
 The ``REAL_IP_HEADER`` (default: unset) and ``REAL_IP_FROM`` (default: unset) settings

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -105,7 +105,7 @@ WELCOME_SUBJECT={{ welcome_subject or 'Welcome to your new email account' }}
 WELCOME_BODY={{ welcome_body or 'Welcome to your new email account, if you can read this, then it is configured properly!' }}
 
 # Maildir Compression
-# choose compression-method, default: none (value: gz, bz2)
+# choose compression-method, default: none (value: gz, bz2, zstd)
 COMPRESSION={{ compression }}
 # change compression-level, default: 6 (value: 1-9)
 COMPRESSION_LEVEL={{ compression_level }}

--- a/towncrier/newsfragments/2793.bugfix
+++ b/towncrier/newsfragments/2793.bugfix
@@ -1,1 +1,2 @@
 The SMTP container wasn't logging things like it should
+The health-check of dovecot was creating zombies

--- a/towncrier/newsfragments/2793.bugfix
+++ b/towncrier/newsfragments/2793.bugfix
@@ -1,0 +1,1 @@
+The SMTP container wasn't logging things like it should

--- a/towncrier/newsfragments/2793.bugfix
+++ b/towncrier/newsfragments/2793.bugfix
@@ -1,2 +1,3 @@
 The SMTP container wasn't logging things like it should
 The health-check of dovecot was creating zombies
+Document that COMPRESSION=zstd is now possible (see #2139)


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

- #2771 broke logging in the postfix container. This fixes it
- The health-check of Dovecot is creating a zillion zombies... this simplifies it.
- Document that COMPRESSION=zstd can be used

### Related issue(s)
- #2771
- #2139

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
