### PR TITLE
Update version to 2.+ in release template

### DIFF
--- a/RELEASE_TEMPLATE.md
+++ b/RELEASE_TEMPLATE.md
@@ -1,6 +1,6 @@
 This is a new automatic release of Mailu. The new version can be seen in the tag name.
-The main version X.Y (e.g. 1.9) will always reflect the latest version of the branch. To update your Mailu installation simply pull the latest images `docker compose pull && docker compose up -d`.
-The pinned version X.Y.Z (e.g. 1.9.1) is not updated. It is pinned to the commit that was used for creating this release. You can use a pinned version to make sure your Mailu installation is not suddenly updated when recreating containers. The pinned version allows the user to manually update. It also allows to go back to a previous pinned version.
+The main version X.Y (e.g. 2.1) will always reflect the latest version of the branch. To update your Mailu installation simply pull the latest images `docker compose pull && docker compose up -d`.
+The pinned version X.Y.Z (e.g. 2.1.1) is not updated. It is pinned to the commit that was used for creating this release. You can use a pinned version to make sure your Mailu installation is not suddenly updated when recreating containers. The pinned version allows the user to manually update. It also allows to go back to a previous pinned version.
 
 To check what was changed:
 - Go to https://github.com/Mailu/Mailu/tree/master/towncrier/newsfragments


### PR DESCRIPTION
## What type of PR?

Documentation

## What does this PR do?

It's really weird that releases 2.0+ such as https://github.com/Mailu/Mailu/releases/tag/2.0.12 mention 1.9 and 1.9.1; fixin' this.