### PR TITLE
Note ports that need to be open in the firewall

### DIFF
--- a/docs/compose/requirements.rst
+++ b/docs/compose/requirements.rst
@@ -65,8 +65,9 @@ with forward and reverse DNS entries for this IP address.
 Also, your host must not listen on ports ``25``, ``80``, ``110``, ``143``,
 ``443``, ``465``, ``587``, ``993``, ``995`` nor ``4190`` as these are used by Mailu
 services. Therefore, you should disable or uninstall any program that is
-listening on these ports (or have them listen on a different port). For
-instance, on a default Debian install:
+listening on these ports (or have them listen on a different port), and make sure
+that these ports are open in your firewall if you have one. For instance, on a
+default Debian install:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## What type of PR?

Documentation

## What does this PR do?

The primary purpose of this change is to include the keyword "firwall" because when I went to open up ports in my network security group I expected a search for "firewall" in the docs to instantly bring this information up, but it didn't.

### Related issue(s)

:shrug: none that I saw offhand

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
