### PR TITLE
Authentication failed for email clients when the password contained a non latin-1 character.

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -111,7 +111,7 @@ def handle_authentication(headers):
                         "Auth-Server": server,
                         "Auth-User": user_email,
                         "Auth-User-Exists": is_valid_user,
-                        "Auth-Password": password,
+                        "Auth-Password": urllib.parse.quote(password),
                         "Auth-Port": port
                     }
         status, code = get_status(protocol, "authentication")

--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -111,7 +111,6 @@ def handle_authentication(headers):
                         "Auth-Server": server,
                         "Auth-User": user_email,
                         "Auth-User-Exists": is_valid_user,
-                        "Auth-Password": urllib.parse.quote(password),
                         "Auth-Port": port
                     }
         status, code = get_status(protocol, "authentication")
@@ -120,7 +119,6 @@ def handle_authentication(headers):
             "Auth-Error-Code": code,
             "Auth-User": user_email,
             "Auth-User-Exists": is_valid_user,
-            "Auth-Password": urllib.parse.quote(password),
             "Auth-Wait": 0
         }
     # Unexpected

--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -120,7 +120,7 @@ def handle_authentication(headers):
             "Auth-Error-Code": code,
             "Auth-User": user_email,
             "Auth-User-Exists": is_valid_user,
-            "Auth-Password": password,
+            "Auth-Password": urllib.parse.quote(password),
             "Auth-Wait": 0
         }
     # Unexpected

--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -58,7 +58,7 @@ def nginx_authentication():
         try:
             password = raw_password.encode("iso8859-1").decode("utf8")
         except:
-            app.logger.warn(f'Received undecodable password from nginx: {raw_password!r}')
+            app.logger.warn(f'Received undecodable password for {username} from nginx: {raw_password!r}')
             utils.limiter.rate_limit_user(username, client_ip, password=None)
         else:
             utils.limiter.rate_limit_user(username, client_ip, password=password)

--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -6,6 +6,7 @@ import flask
 import flask_login
 import base64
 import sqlalchemy.exc
+import urllib
 
 @internal.route("/auth/email")
 def nginx_authentication():
@@ -52,7 +53,15 @@ def nginx_authentication():
         if not is_port_25:
             utils.limiter.exempt_ip_from_ratelimits(client_ip)
     elif is_valid_user:
-        utils.limiter.rate_limit_user(username, client_ip, password=response.headers.get('Auth-Password', None))
+        raw_password = urllib.parse.unquote(headers["Auth-Pass"])
+        password = None
+        try:
+            password = raw_password.encode("iso8859-1").decode("utf8")
+        except:
+            app.logger.warn(f'Received undecodable password from nginx: {raw_password!r}')
+            utils.limiter.rate_limit_user(username, client_ip, password=None)
+        else:
+            utils.limiter.rate_limit_user(username, client_ip, password=password)
     elif not is_from_webmail:
         utils.limiter.rate_limit_ip(client_ip, username)
     return response

--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -31,6 +31,7 @@ def nginx_authentication():
         if int(flask.request.headers['Auth-Login-Attempt']) < 10:
             response.headers['Auth-Wait'] = '3'
         return response
+    raw_password = urllib.parse.unquote(headers["Auth-Pass"])
     headers = nginx.handle_authentication(flask.request.headers)
     response = flask.Response()
     for key, value in headers.items():
@@ -53,7 +54,6 @@ def nginx_authentication():
         if not is_port_25:
             utils.limiter.exempt_ip_from_ratelimits(client_ip)
     elif is_valid_user:
-        raw_password = urllib.parse.unquote(headers["Auth-Pass"])
         password = None
         try:
             password = raw_password.encode("iso8859-1").decode("utf8")

--- a/tests/compose/core/00_create_users.sh
+++ b/tests/compose/core/00_create_users.sh
@@ -8,4 +8,5 @@ docker compose -f tests/compose/core/docker-compose.yml exec -T admin flask mail
 docker compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu admin admin mailu.io 'password' --mode=update || exit 1
 docker compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu user user mailu.io 'password' || exit 1
 docker compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu user 'user/with/slash' mailu.io 'password' || exit 1
+docker compose -f tests/compose/core/docker-compose.yml exec -T admin flask mailu user 'user_UTF8' mailu.io 'password€' || exit 1
 echo "User testing successful!"

--- a/towncrier/newsfragments/2837.bugfix
+++ b/towncrier/newsfragments/2837.bugfix
@@ -1,0 +1,1 @@
+Authentication failed for email clients when the password contained a non latin-1 character.


### PR DESCRIPTION
## What type of PR?

bug fix

## What does this PR do?
Fixes a bug that results in authentication failing for email clients when the password contains a non latin-1 character.
Issue was caused by the header Auth-Password being returned with non latin-1 characters. Headers must always be latin-1 encoded. Resolved the issue by url encoding the password.

Since the returned password is only used as a partial hash for the rate limiter, I did not add code for un-quoting the password in the /internal/email endpoint.

### Related issue(s)
- closes #2837 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
