### PR TITLE
Fix postfix logging to file

### DIFF
--- a/towncrier/newsfragments/2819.bugfix
+++ b/towncrier/newsfragments/2819.bugfix
@@ -1,0 +1,1 @@
+Fix postfix file logging


### PR DESCRIPTION
## What type of PR?

Bug-fix

## What does this PR do?

Postfix standard/error output is polled by the startup script and forwarded to the standard/error output of the script. Consequently, this output is passed through the LogFilter class which allows logging to a file. 

### Related issue(s)

Solves issue #2819 .

## Prerequisites

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
