### PR TITLE
Update reverse.rst to include TLS_FLAVOR=mail for nginx

### DIFF
--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -100,7 +100,7 @@ Because the admin interface is served as ``/admin``, the RESTful API as ``/api``
     }
   }
 
-.. warning:: If Nginx is upgrading HTTP connection to HTTPS then `TLS_FLAVOR=mail` must be set in the mailu.env. Otherwise you will be indefinitely redirected.
+.. warning:: If Nginx is upgrading HTTP connections to HTTPS, then `TLS_FLAVOR=mail` must be set in the mailu.env. Otherwise, you will be indefinitely redirected.
 .. note:: Please don’t add a ``/`` at the end of the location pattern or all your redirects will fail with 404 because the ``/`` would be missing, and you would have to add it manually to move on
 
 .. code-block:: docker

--- a/docs/reverse.rst
+++ b/docs/reverse.rst
@@ -100,6 +100,7 @@ Because the admin interface is served as ``/admin``, the RESTful API as ``/api``
     }
   }
 
+.. warning:: If Nginx is upgrading HTTP connection to HTTPS then `TLS_FLAVOR=mail` must be set in the mailu.env. Otherwise you will be indefinitely redirected.
 .. note:: Please don’t add a ``/`` at the end of the location pattern or all your redirects will fail with 404 because the ``/`` would be missing, and you would have to add it manually to move on
 
 .. code-block:: docker


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?
Changes the documentation about using external proxies.
If Nginx is used to upgrade HTTP to HTTPS connections and the TLS_FLAVOR isn't set to `mail`, then you will be indefinitely redirected. This PR adds a warning in the documentation about that.

This option is already mentioned for Traefik in a later section, but not for Nginx.

### Related issue(s)
#1021

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.