### PR TITLE
increase the number of postfix workers

### DIFF
--- a/core/postfix/conf/master.cf
+++ b/core/postfix/conf/master.cf
@@ -2,10 +2,10 @@
 #               (yes)   (yes)   (yes)   (never) (100)
 
 # Exposed SMTP service
-smtp      inet  n       -       n       -       1       smtpd
+smtp      inet  n       -       n       -       -       smtpd
 
 # Internal SMTP service
-10025     inet  n       -       n       -       1       smtpd
+10025     inet  n       -       n       -       -       smtpd
   -o smtpd_sasl_auth_enable=yes
   -o smtpd_discard_ehlo_keywords=pipelining,silent-discard
   -o smtpd_client_restrictions=$check_ratelimit,reject_unlisted_sender,reject_authenticated_sender_login_mismatch,permit

--- a/towncrier/newsfragments/2869.bugfix
+++ b/towncrier/newsfragments/2869.bugfix
@@ -1,0 +1,1 @@
+Increase the number of postfix workers, this should reduce the number of time Mailu replies with "451 4.3.2 Internal server error". To be clear, well behaved MTAs will retry so no email have been lost. 


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

increase the number of postfix workers. It was reduced when we were using postscreen ... but this specific part hasn't been reverted properly.

The practical effect is that we should see less ``451 4.3.2 Internal server error``.

### Related issue(s)
- #2861

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
