### PR TITLE
Fix issue #2811. Clamav Healthcheck created zombie processes

### DIFF
--- a/optional/clamav/Dockerfile
+++ b/optional/clamav/Dockerfile
@@ -15,7 +15,7 @@ COPY start.py /
 RUN echo $VERSION >/version
 
 #EXPOSE 3310/tcp
-HEALTHCHECK --start-period=350s CMD echo PING|nc localhost 3310|grep "PONG"
+HEALTHCHECK CMD kill -0 `cat /run/clamd.pid` && kill -0 `cat /run/freshclam.pid`
 
 VOLUME ["/data"]
 

--- a/towncrier/newsfragments/2811.bugfix
+++ b/towncrier/newsfragments/2811.bugfix
@@ -1,0 +1,1 @@
+Healthcheck of clamav image created zombie processes


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
The healthcheck of clamav results in zombie processes for some users. This PR addresses this issue. Now the healtcheck checks for the existence of the pid file of clamd and freshclam

Note: [kill -0](https://unix.stackexchange.com/questions/169898/what-does-kill-0-do) can be used to check if a process exists and perform an error check.

### Related issue(s)
- closes #2811 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
