### PR TITLE
bugfix for gpg execution with roundcube

### DIFF
--- a/towncrier/newsfragments/2892.bugfix
+++ b/towncrier/newsfragments/2892.bugfix
@@ -1,0 +1,1 @@
+Fix GPG operations from Roundcube - calling gpg with full path was blocked

--- a/webmails/snuffleupagus.rules
+++ b/webmails/snuffleupagus.rules
@@ -74,6 +74,7 @@ sp.disable_function.function("shell_exec").param("command").value_r("[$|;&`\\n\\
 sp.disable_function.function("exec").param("command").value_r("[$|;&`\\n\\(\\)\\\\]").drop();
 # This is **very** broad but doing better is non-straightforward
 sp.disable_function.function("proc_open").param("command").value_r("^gpg ").allow();
+sp.disable_function.function("proc_open").param("command").value_r("^/usr/bin/gpg ").allow();
 sp.disable_function.function("proc_open").param("command").value_r("[$|;&`\\n\\(\\)\\\\]").drop();
 
 # Prevent runtime modification of interesting things

--- a/webmails/snuffleupagus.rules
+++ b/webmails/snuffleupagus.rules
@@ -73,8 +73,7 @@ sp.disable_function.function("system").param("command").value_r("[$|;&`\\n\\(\\)
 sp.disable_function.function("shell_exec").param("command").value_r("[$|;&`\\n\\(\\)\\\\]").drop();
 sp.disable_function.function("exec").param("command").value_r("[$|;&`\\n\\(\\)\\\\]").drop();
 # This is **very** broad but doing better is non-straightforward
-sp.disable_function.function("proc_open").param("command").value_r("^gpg ").allow();
-sp.disable_function.function("proc_open").param("command").value_r("^/usr/bin/gpg ").allow();
+sp.disable_function.function("proc_open").param("command").value_r("^(/usr/bin/)?gpg ").allow();
 sp.disable_function.function("proc_open").param("command").value_r("[$|;&`\\n\\(\\)\\\\]").drop();
 
 # Prevent runtime modification of interesting things


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

It adds another `allow`-rule for `snuffleupagus` when `gpg` is called via absolute path (`/usr/bin/gpg`).
I consider it a minor change so no update to changelog is proposed but if you feel different please let me know.

### Related issue(s)
- Auto close an issue like: closes #2892

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
