### PR TITLE
Avoid a stack-trace when the ratelimit is hit

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -23,6 +23,7 @@ STATUSES = {
     "ratelimit": ("Temporary authentication failure (rate-limit)", {
         "imap": "LIMIT",
         "smtp": "451 4.3.2",
+        "submission": "451 4.3.2",
         "pop3": "-ERR [LOGIN-DELAY] Retry later"
     }),
 }


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Avoid a stack-trace when the ratelimit is hit. This is only affecting the last few commits of master.

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
