### PR TITLE
Prevent rspamc zombies, ensure that triggering learn-spam works

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -180,7 +180,7 @@ plugin {
 
   # Learn from spam
   imapsieve_mailbox1_name = Junk
-  imapsieve_mailbox1_causes = COPY
+  imapsieve_mailbox1_causes = COPY APPEND
   imapsieve_mailbox1_before = file:/conf/report-spam.sieve
   imapsieve_mailbox2_name = *
   imapsieve_mailbox2_from = Junk

--- a/core/dovecot/conf/ham.script
+++ b/core/dovecot/conf/ham.script
@@ -6,6 +6,6 @@ then
 	exit 1
 fi
 
-tee >(rspamc -h $RSPAMD_HOST -P mailu learn_ham /dev/stdin) \
-	>(rspamc -h $RSPAMD_HOST -P mailu -f 11 fuzzy_del /dev/stdin) \
-	| rspamc -h $RSPAMD_HOST -P mailu -f 13 fuzzy_add /dev/stdin
+exec tee >(rspamc -t 3 -h $RSPAMD_HOST -P mailu learn_ham /dev/stdin||true) \
+       >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 11 fuzzy_del /dev/stdin||true) \
+       >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 13 fuzzy_add /dev/stdin||true)

--- a/core/dovecot/conf/ham.script
+++ b/core/dovecot/conf/ham.script
@@ -8,4 +8,4 @@ fi
 
 exec tee >(rspamc -t 3 -h $RSPAMD_HOST -P mailu learn_ham /dev/stdin||true) \
        >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 11 fuzzy_del /dev/stdin||true) \
-       >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 13 fuzzy_add /dev/stdin||true)
+       >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 13 fuzzy_add /dev/stdin||true) > /dev/null

--- a/core/dovecot/conf/spam.script
+++ b/core/dovecot/conf/spam.script
@@ -9,4 +9,4 @@ fi
 
 exec tee >(rspamc -t 3 -h $RSPAMD_HOST -P mailu learn_spam /dev/stdin||true) \
        >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 13 fuzzy_del /dev/stdin||true) \
-       >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 11 fuzzy_add /dev/stdin||true)
+       >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 11 fuzzy_add /dev/stdin||true) > /dev/null

--- a/core/dovecot/conf/spam.script
+++ b/core/dovecot/conf/spam.script
@@ -7,6 +7,6 @@ then
 fi
 
 
-tee >(rspamc -h $RSPAMD_HOST -P mailu learn_spam /dev/stdin) \
-    >(rspamc -h $RSPAMD_HOST -P mailu -f 13 fuzzy_del /dev/stdin) \
-    | rspamc -h $RSPAMD_HOST -P mailu -f 11 fuzzy_add /dev/stdin
+exec tee >(rspamc -t 3 -h $RSPAMD_HOST -P mailu learn_spam /dev/stdin||true) \
+       >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 13 fuzzy_del /dev/stdin||true) \
+       >(rspamc -t 3 -h $RSPAMD_HOST -P mailu -f 11 fuzzy_add /dev/stdin||true)

--- a/towncrier/newsfragments/2908.bugfix
+++ b/towncrier/newsfragments/2908.bugfix
@@ -1,0 +1,2 @@
+Moving emails to the Junk folder may have created zombies (rspamc)
+Ensure that the spam reporting works even if the email isn't COPYed to the mailbox


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Prevent rspamc zombies, ensure that triggering learn-spam works even when using Outlook

### Related issue(s)
- closes #2908

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
