### PR TITLE
Delete the dovecot PID file to avoid race conditions

### DIFF
--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -33,6 +33,7 @@ for script_file in glob.glob("/conf/*.script"):
 # Run Podop, then postfix
 os.system("chown mail:mail /mail")
 os.system("chown -R mail:mail /var/lib/dovecot /conf")
+os.system("rm -rf /run/dovecot/master.pid")
 
 multiprocessing.Process(target=start_podop).start()
 os.system("dovecot -c /etc/dovecot/dovecot.conf -F")

--- a/towncrier/newsfragments/2917.bugfix
+++ b/towncrier/newsfragments/2917.bugfix
@@ -1,0 +1,1 @@
+Ensure that we delete any pre-exising PID file before starting dovecot


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Apparently sometimes the podop subprocess can be re-assigned the same PID when the container is restarted, causing havoc.

This may explain some of the "I can't access the webmail" tickets.

I wonder if the same can happen in other containers too (front for instance).

### Related issue(s)
- closes #2917 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
