### PR TITLE
Remove the usage of capabilities, use port 8080 for admin

### DIFF
--- a/core/admin/Dockerfile
+++ b/core/admin/Dockerfile
@@ -22,8 +22,8 @@ RUN set -euxo pipefail \
 
 RUN echo $VERSION >/version
 
-#EXPOSE 80/tcp
-HEALTHCHECK CMD curl -skfLo /dev/null http://localhost/ping
+#EXPOSE 8080/tcp
+HEALTHCHECK CMD curl -skfLo /dev/null http://localhost:8080/ping
 
 VOLUME ["/data","/dkim"]
 

--- a/core/admin/start.py
+++ b/core/admin/start.py
@@ -55,7 +55,7 @@ cmdline = [
     "gunicorn",
     "--threads", f"{os.cpu_count()}",
     # If SUBNET6 is defined, gunicorn must listen on IPv6 as well as IPv4
-    "-b", f"{'[::]' if os.environ.get('SUBNET6') else ''}:80",
+    "-b", f"{'[::]' if os.environ.get('SUBNET6') else '0.0.0.0'}:8080",
     "--logger-class mailu.Logger",
     f"--log-level {os.environ.get('LOG_LEVEL', 'INFO')}",
     "--worker-tmp-dir /dev/shm",

--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -14,7 +14,7 @@ ARG MAILU_GID=1000
 RUN set -euxo pipefail \
   ; addgroup -Sg ${MAILU_GID} mailu \
   ; adduser -Sg ${MAILU_UID} -G mailu -h /app -g "mailu app" -s /bin/bash mailu \
-  ; apk add --no-cache bash ca-certificates curl python3 tzdata libcap \
+  ; apk add --no-cache bash ca-certificates curl python3 tzdata \
   ; ! [[ "$(uname -m)" == x86_64 ]] \
     || apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hardened-malloc==11-r0
 
@@ -75,7 +75,6 @@ FROM system
 
 COPY --from=build /app/venv/ /app/venv/
 COPY --chown=root:root --from=build /app/snuffleupagus.so /usr/lib/php81/modules/
-RUN setcap 'cap_net_bind_service=+ep' /app/venv/bin/gunicorn 'cap_net_bind_service=+ep' /usr/bin/python3.10
 
 ENV \
   VIRTUAL_ENV=/app/venv \

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -6,11 +6,11 @@ protocols = imap pop3 lmtp sieve
 postmaster_address = {{ POSTMASTER }}@{{ DOMAIN }}
 hostname = {{ HOSTNAMES.split(",")[0] }}
 submission_host = {{ FRONT_ADDRESS }}
-{%- if SUBNET6 -%}
+{%- if SUBNET6 %}
 listen = *,::
-{%- else -%}
+{% else %}
 listen = *
-{%- endif %}
+{% endif %}
 
 default_internal_user = dovecot
 default_login_user = mail

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -6,6 +6,11 @@ protocols = imap pop3 lmtp sieve
 postmaster_address = {{ POSTMASTER }}@{{ DOMAIN }}
 hostname = {{ HOSTNAMES.split(",")[0] }}
 submission_host = {{ FRONT_ADDRESS }}
+{%- if SUBNET6 -%}
+listen = *,::
+{%- else -%}
+listen = *
+{%- endif %}
 
 default_internal_user = dovecot
 default_login_user = mail

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -13,7 +13,7 @@ system.set_env(log_filters=r'Error\: SSL context initialization failed, disablin
 
 def start_podop():
     system.drop_privs_to('mail')
-    url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/dovecot/§"
+    url = "http://" + os.environ["ADMIN_ADDRESS"] + ":8080/internal/dovecot/§"
     run_server(0, "dovecot", "/tmp/podop.socket", [
 		("quota", "url", url ),
 		("auth", "url", url),

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -84,7 +84,7 @@ http {
       # Favicon stuff
       root /static;
       # Variables for proxifying
-      set $admin {{ ADMIN_ADDRESS }};
+      set $admin {{ ADMIN_ADDRESS }}:8080;
       set $antispam {{ ANTISPAM_ADDRESS }}:11334;
       {% if WEBMAIL_ADDRESS %}
       set $webmail {{ WEBMAIL_ADDRESS }};
@@ -283,7 +283,7 @@ http {
     # Forwarding authentication server
     server {
       # Variables for proxifying
-      set $admin {{ ADMIN_ADDRESS }};
+      set $admin {{ ADMIN_ADDRESS }}:8080;
 
       listen 127.0.0.1:8000;
 

--- a/core/nginx/dovecot/login.lua
+++ b/core/nginx/dovecot/login.lua
@@ -12,7 +12,7 @@ local http_client = dovecot.http.client {
 
 function auth_passdb_lookup(req)
   local auth_request = http_client:request {
-    url = "http://{{ ADMIN_ADDRESS }}/internal/auth/email";
+    url = "http://{{ ADMIN_ADDRESS }}:8080/internal/auth/email";
   }
   auth_request:add_header('Auth-Port', req.local_port)
   auth_request:add_header('Auth-User', req.user)

--- a/core/nginx/dovecot/proxy.conf
+++ b/core/nginx/dovecot/proxy.conf
@@ -21,6 +21,12 @@ imap_urlauth_host=
 lmtp_proxy = yes
 lmtp_client_workarounds = whitespace-before-path mailbox-for-path
 
+{%- if SUBNET6 -%}
+listen = *,::
+{%- else -%}
+listen = *
+{%- endif %}
+
 default_internal_user = dovecot
 default_login_user = mail
 default_internal_group = dovecot

--- a/core/nginx/dovecot/proxy.conf
+++ b/core/nginx/dovecot/proxy.conf
@@ -21,11 +21,11 @@ imap_urlauth_host=
 lmtp_proxy = yes
 lmtp_client_workarounds = whitespace-before-path mailbox-for-path
 
-{%- if SUBNET6 -%}
+{%- if SUBNET6 %}
 listen = *,::
-{%- else -%}
+{% else %}
 listen = *
-{%- endif %}
+{% endif %}
 
 default_internal_user = dovecot
 default_login_user = mail

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -21,7 +21,7 @@ os.system("flock -n /queue/pid/master.pid rm /queue/pid/master.pid")
 def start_podop():
     system.drop_privs_to('postfix')
     os.makedirs('/dev/shm/postfix',mode=0o700, exist_ok=True)
-    url = "http://" + os.environ["ADMIN_ADDRESS"] + "/internal/postfix/"
+    url = "http://" + os.environ["ADMIN_ADDRESS"] + ":8080/internal/postfix/"
     # TODO: Remove verbosity setting from Podop?
     run_server(0, "postfix", "/tmp/podop.socket", [
         ("transport", "url", url + "transport/§"),

--- a/core/rspamd/conf/arc.conf
+++ b/core/rspamd/conf/arc.conf
@@ -2,6 +2,6 @@ try_fallback = false;
 use_esld = false;
 allow_username_mismatch = true;
 use_vault = true;
-vault_url = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/vault";
+vault_url = "http://{{ ADMIN_ADDRESS }}:8080/internal/rspamd/vault";
 vault_token = "mailu";
 .include(try=true,priority=1,duplicate=merge) "/overrides/arc.conf"

--- a/core/rspamd/conf/dkim_signing.conf
+++ b/core/rspamd/conf/dkim_signing.conf
@@ -2,6 +2,6 @@ try_fallback = false;
 use_esld = false;
 allow_username_mismatch = true;
 use_vault = true;
-vault_url = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/vault";
+vault_url = "http://{{ ADMIN_ADDRESS }}:8080/internal/rspamd/vault";
 vault_token = "mailu";
 .include(try=true,priority=1,duplicate=merge) "/overrides/dkim_signing.conf"

--- a/core/rspamd/conf/multimap.conf
+++ b/core/rspamd/conf/multimap.conf
@@ -1,12 +1,12 @@
 IS_LOCAL_DOMAIN_H {
   type = "selector"
   selector = "from('mime'):domain";
-  map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+  map = "http://{{ ADMIN_ADDRESS }}:8080/internal/rspamd/local_domains";
 }
 IS_LOCAL_DOMAIN_E {
   type = "selector"
   selector = "from('smtp'):domain";
-  map = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+  map = "http://{{ ADMIN_ADDRESS }}:8080/internal/rspamd/local_domains";
 }
 IS_LOCALLY_GENERATED {
   type = "ip"

--- a/core/rspamd/conf/whitelist.conf
+++ b/core/rspamd/conf/whitelist.conf
@@ -3,7 +3,7 @@ rules {
         BLACKLIST_ANTISPOOF = {
             valid_dmarc = true;
             blacklist = true;
-            domains = "http://{{ ADMIN_ADDRESS }}/internal/rspamd/local_domains";
+            domains = "http://{{ ADMIN_ADDRESS }}:8080/internal/rspamd/local_domains";
 	    score = 0.0;
         }
 }

--- a/core/rspamd/start.py
+++ b/core/rspamd/start.py
@@ -23,7 +23,7 @@ for override_file in glob.glob("/overrides/*"):
         shutil.copyfile(override_file, os.path.join("/etc/rspamd/local.d", os.path.basename(override_file)))
 
 # Admin may not be up just yet
-healthcheck = f'http://{env["ADMIN_ADDRESS"]}/internal/rspamd/local_domains'
+healthcheck = f'http://{env["ADMIN_ADDRESS"]}:8080/internal/rspamd/local_domains'
 while True:
     time.sleep(1)
     try:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -872,6 +872,7 @@ We recommend that you run your own DNS resolver (enable unbound and update your 
 We have seen a fair amount of support requests related to the following:
 
 - dnsmasq won't forward DNSSEC results unless instructed to do so. If you are running openwrt or pi-hole, you do need to enable DNSSEC.
+- systemd-resolve won't validate DNSSEC results unless instructed to do so. If you are using it you can check its configuration using ``systemd-resolve --status | grep DNSSEC``
 - `coredns has a bug`_ that we have now worked around
 - `netplan does not play nicely with docker` by default and may need to be configured to leave docker's network alone.
 

--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -48,7 +48,7 @@ def fetchmail(fetchmailrc):
 
 def run(debug):
     try:
-        fetches = requests.get(f"http://{os.environ['ADMIN_ADDRESS']}/internal/fetch").json()
+        fetches = requests.get(f"http://{os.environ['ADMIN_ADDRESS']}:8080/internal/fetch").json()
         for fetch in fetches:
             fetchmailrc = ""
             options = "options antispam 501, 504, 550, 553, 554"
@@ -84,7 +84,7 @@ def run(debug):
                         user_info in error_message):
                     print(error_message)
             finally:
-                requests.post("http://{}/internal/fetch/{}".format(os.environ['ADMIN_ADDRESS'],fetch['id']),
+                requests.post("http://{}:8080/internal/fetch/{}".format(os.environ['ADMIN_ADDRESS'],fetch['id']),
                     json=error_message.split('\n')[0]
                 )
     except Exception:

--- a/towncrier/newsfragments/2906.bugfix
+++ b/towncrier/newsfragments/2906.bugfix
@@ -1,2 +1,3 @@
 Switch the admin container from port 80 to port 8080. This should solve issues related to capabilities not working as expected
 Document that systemd-resolve may need to be configured to validate DNSSEC
+Ensure that dovecot is not attempting to bind a v6 socket if SUBNET6 is not configured

--- a/towncrier/newsfragments/2906.bugfix
+++ b/towncrier/newsfragments/2906.bugfix
@@ -1,0 +1,2 @@
+Switch the admin container from port 80 to port 8080. This should solve issues related to capabilities not working as expected
+Document that systemd-resolve may need to be configured to validate DNSSEC


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

In the real world users can't get them to work... I wonder if they use patched-up kernels or if xattrs are lost somehow... in any case, we can do without capabilities so let's do that.

Ensure that dovecot doesn't attempt to bind a v6 socket if SUBNET6 is not configured

Also, document that systemd-resolve may cause trouble with DNSSEC.

### Related issue(s)
- closes #2906
- closes #2913

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
