### PR TITLE
Use redis as IMAP- and session-cache

### DIFF
--- a/towncrier/newsfragments/2943.feature
+++ b/towncrier/newsfragments/2943.feature
@@ -1,0 +1,1 @@
+Enable redis cache for IMAP- and session-cache for roundcube

--- a/webmails/roundcube/config/config.inc.php
+++ b/webmails/roundcube/config/config.inc.php
@@ -18,6 +18,12 @@ $config['session_lifetime'] = {{ (((PERMANENT_SESSION_LIFETIME | default(10800))
 $config['request_path'] = '{{ WEB_WEBMAIL or "none" }}';
 $config['trusted_host_patterns'] = [ {{ HOSTNAMES.split(",") | map("tojson") | join(',') }}];
 
+// use redis for session and IMAP-Cache
+$config['session_storage'] = 'redis';
+$config['redis_hosts'] = ['{{ REDIS_ADDRESS }}:1'];
+$config['redis_max_allowed_packet'] = '8M';
+$config['imap_cache'] = 'redis';
+
 // Mail servers
 $config['imap_host'] = 'tls://{{ FRONT_ADDRESS or "front" }}:10143';
 $config['imap_conn_options'] = array(


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

This PR uses the already used redis-deployment for storing roundcube IMAP- and session-cache in order to speed up the Web-UI of roundcube.

### Related issue(s)

* Fixes #2943 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
