### PR TITLE
Fixing ES "Website" translation and more untranslated bits

### DIFF
--- a/core/admin/mailu/translations/es/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/es/LC_MESSAGES/messages.po
@@ -53,7 +53,7 @@ msgstr "Configuración del cliente"
 
 #: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
 msgid "Website"
-msgstr "Correo web"
+msgstr "Sitio web"
 
 #: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
 msgid "Help"
@@ -173,7 +173,7 @@ msgstr "Habilitar filtro de spam"
 
 #: mailu/ui/forms.py:103
 msgid "Enable marking spam mails as read"
-msgstr ""
+msgstr "Habilitar marcado de correos spam como leídos"
 
 #: mailu/ui/forms.py:104
 msgid "Spam filter tolerance"
@@ -218,7 +218,7 @@ msgstr "Texto de la respuesta"
 
 #: mailu/ui/forms.py:122
 msgid "Start of vacation"
-msgstr ""
+msgstr "Comienzo de las vacaciones"
 
 #: mailu/ui/forms.py:123
 msgid "End of vacation"
@@ -346,7 +346,7 @@ msgstr "Ocurrió un error en la comunicación con el servidor Docker."
 
 #: mailu/ui/templates/macros.html:129
 msgid "copy to clipboard"
-msgstr ""
+msgstr "copiar en portapapeles"
 
 #: mailu/ui/templates/sidebar.html:15
 msgid "My account"


### PR DESCRIPTION
Both webmail and website have been translated as "Correo Web" incorrectly imho.

## What type of PR?
Enhancement

## What does this PR do?
Minor corrections and additions to ES translation.

### Related issue(s)

## Prerequisites
None.
