### PR TITLE
Quota bytes used

### DIFF
--- a/core/admin/mailu/api/v1/user.py
+++ b/core/admin/mailu/api/v1/user.py
@@ -14,6 +14,7 @@ user_fields_get = api.model('UserGet', {
     'password': fields.String(description="Hash of the user's password; Example='$bcrypt-sha256$v=2,t=2b,r=12$fmsAdJbYAD1gGQIE5nfJq.$zLkQUEs2XZfTpAEpcix/1k5UTNPm0jO'"),
     'comment': fields.String(description='A description for the user. This description is shown on the Users page', example='my comment'),
     'quota_bytes': fields.Integer(description='The maximum quota for the user’s email box in bytes', example='1000000000'),
+    'quota_bytes_used': fields.Integer(description='The size of the user’s email box in bytes', example='5000000'),
     'global_admin': fields.Boolean(description='Make the user a global administrator'),
     'enabled': fields.Boolean(description='Enable the user. When an user is disabled, the user is unable to login to the Admin GUI or webmail or access his email via IMAP/POP3 or send mail'),
     'change_pw_next_login': fields.Boolean(description='Force the user to change their password at next login'),

--- a/core/admin/mailu/schemas.py
+++ b/core/admin/mailu/schemas.py
@@ -1176,7 +1176,7 @@ class UserSchema(BaseSchema):
         model = models.User
         load_instance = True
         include_relationships = True
-        exclude = ['_email', 'domain', 'localpart', 'domain_name']
+        exclude = ['_email', 'domain', 'localpart', 'domain_name', 'quota_bytes_used']
 
         primary_keys = ['email']
         exclude_by_value = {

--- a/core/admin/mailu/schemas.py
+++ b/core/admin/mailu/schemas.py
@@ -1176,7 +1176,7 @@ class UserSchema(BaseSchema):
         model = models.User
         load_instance = True
         include_relationships = True
-        exclude = ['_email', 'domain', 'localpart', 'domain_name', 'quota_bytes_used']
+        exclude = ['_email', 'domain', 'localpart', 'domain_name']
 
         primary_keys = ['email']
         exclude_by_value = {

--- a/towncrier/newsfragments/2951.feature
+++ b/towncrier/newsfragments/2951.feature
@@ -1,0 +1,1 @@
+Implement quota_bytes_used in API


### PR DESCRIPTION
## What type of PR?

Enhancement

## What does this PR do?

Allows the mailbox size of the users to be queried by the api.

Previously quota_bytes_used key was excluded from the api when you queried for a list of users.  This is useful to allow a user to monitor the volume of emails being used.

### Related issue(s)
- Auto close an issue: [closes 2824](https://github.com/Mailu/Mailu/issues/2824)

## Prerequisites

- [x] In case of feature or enhancement: documentation updated accordingly
