### PR TITLE
Move DKIM keys to database

### DIFF
--- a/core/admin/mailu/api/v1/domains.py
+++ b/core/admin/mailu/api/v1/domains.py
@@ -223,7 +223,8 @@ class Domain(Resource):
         if not domain_found:
             return { 'code': 404, 'message': f'Domain {domain} does not exist'}, 404
         domain_found.generate_dkim_key()
-        domain_found.save_dkim_key()
+        db.session.add(domain_found)
+        db.session.commit()
         return {'code': 200, 'message': f'DKIM/DMARC keys have been generated for domain {domain}'}, 200
 
 @dom.route('/<domain>/manager')

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -55,7 +55,6 @@ DEFAULT_CONFIG = {
     'WELCOME_SUBJECT': 'Dummy welcome topic',
     'WELCOME_BODY': 'Dummy welcome body',
     'DKIM_SELECTOR': 'dkim',
-    'DKIM_PATH': '/dkim/{domain}.{selector}.key',
     'DEFAULT_QUOTA': 1000000000,
     'MESSAGE_RATELIMIT': '200/day',
     'MESSAGE_RATELIMIT_EXEMPTION': '',

--- a/core/admin/mailu/dkim.py
+++ b/core/admin/mailu/dkim.py
@@ -16,6 +16,8 @@ def gen_key(bits=2048):
 def strip_key(pem):
     """ Return only the b64 part of the ASCII armored PEM.
     """
+    if isinstance(pem, str):
+      pem = pem.encode('utf-8')
     priv_key = serialization.load_pem_private_key(pem, password=None)
     public_pem = priv_key.public_key().public_bytes(encoding=serialization.Encoding.PEM,format=serialization.PublicFormat.SubjectPublicKeyInfo)
     return public_pem.replace(b"\n", b"").split(b"-----")[2]

--- a/core/admin/mailu/dkim.py
+++ b/core/admin/mailu/dkim.py
@@ -16,8 +16,6 @@ def gen_key(bits=2048):
 def strip_key(pem):
     """ Return only the b64 part of the ASCII armored PEM.
     """
-    if isinstance(pem, str):
-      pem = pem.encode('utf-8')
     priv_key = serialization.load_pem_private_key(pem, password=None)
     public_pem = priv_key.public_key().public_bytes(encoding=serialization.Encoding.PEM,format=serialization.PublicFormat.SubjectPublicKeyInfo)
     return public_pem.replace(b"\n", b"").split(b"-----")[2]

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -186,7 +186,8 @@ class Domain(Base):
     max_aliases = db.Column(db.Integer, nullable=False, default=-1)
     max_quota_bytes = db.Column(db.BigInteger, nullable=False, default=0)
     signup_enabled = db.Column(db.Boolean, nullable=False, default=False)
-    dkim_key = db.Column(db.String, nullable=True, default=None)
+
+    _dkim_key = db.Column('dkim_key', db.String, nullable=True, default=None)
 
     @cached_property
     def dns_mx(self):
@@ -257,6 +258,19 @@ class Domain(Base):
         if app.config['TLS_FLAVOR'] in ('letsencrypt', 'mail-letsencrypt'):
             # current ISRG Root X1 (RSA 4096, O = Internet Security Research Group, CN = ISRG Root X1) @20210902
             return f'_25._tcp.{hostname}. 86400 IN TLSA 2 1 1 0b9fa5a59eed715c26c1020c711b4f6ec42d58b0015e14337a39dad301c5afc3'
+
+    @property
+    def dkim_key(self):
+        """ return private DKIM key """
+        if not self._dkim_key is None:
+            if isinstance(self._dkim_key, str):
+                return self._dkim_key.encode('utf-8')
+        return self._dkim_key
+
+    @dkim_key.setter
+    def dkim_key(self, value):
+        """ set private DKIM key """
+        self._dkim_key = value if value is not None else b''
 
     @property
     def dkim_publickey(self):

--- a/core/admin/migrations/versions/227c8a72b822_.py
+++ b/core/admin/migrations/versions/227c8a72b822_.py
@@ -1,0 +1,22 @@
+"""Add user.change_pw_next_login
+
+Revision ID: 227c8a72b822
+Revises: 0ba45693748d
+Create Date: 2023-09-23 22:20:51.458092
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '227c8a72b822'
+down_revision = '0ba45693748d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('domain', sa.Column('dkim_key', sa.String(length=4096), nullable=True))
+
+
+def downgrade():
+    op.drop_column('domain', 'dkim_key')


### PR DESCRIPTION
This PR solves issue #2949.

Moving the DKIM keys to database removes the requirement for shared storage in the admin. 

Currently a migration path from files to database is missing. My idea is it to add this to the migration file, but i am not to deeply into the python framework here to know if this is a good idea or not. If you have some tips i happily add this feature so that this PR can get merged.