### PR TITLE
Remove the version pinning on hardened malloc

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -16,7 +16,7 @@ RUN set -euxo pipefail \
   ; adduser -Sg ${MAILU_UID} -G mailu -h /app -g "mailu app" -s /bin/bash mailu \
   ; apk add --no-cache bash ca-certificates curl python3 tzdata \
   ; ! [[ "$(uname -m)" == x86_64 ]] \
-    || apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hardened-malloc==11-r0
+    || apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hardened-malloc
 
 WORKDIR /app
 

--- a/towncrier/newsfragments/2955.misc
+++ b/towncrier/newsfragments/2955.misc
@@ -1,0 +1,1 @@
+Remove the version pinning on hardened malloc


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Remove the version pinning on hardened malloc. Pinning a specific version makes sense... but it won't work if alpine/edge doesn't keep old versions around.

Without it the CI is broken; I think we should merge it to master and wait until it's required to backport it

### Related issue(s)
- close #2955

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
