### PR TITLE
Forbidden_file_extension.map could not be overridden.

### DIFF
--- a/core/rspamd/start.py
+++ b/core/rspamd/start.py
@@ -16,7 +16,8 @@ env = system.set_env()
 config_files = []
 for rspamd_file in glob.glob("/conf/*"):
     conf.jinja(rspamd_file, env, os.path.join("/etc/rspamd/local.d", os.path.basename(rspamd_file)))
-    config_files.append(os.path.basename(rspamd_file))
+    if rspamd_file != '/conf/forbidden_file_extension.map':
+        config_files.append(os.path.basename(rspamd_file))
 
 for override_file in glob.glob("/overrides/*"):
     if os.path.basename(override_file) not in config_files:

--- a/towncrier/newsfragments/2937.bugfix
+++ b/towncrier/newsfragments/2937.bugfix
@@ -1,0 +1,2 @@
+forbidden_file_extension.map could not be overridden. This file can be overriden to tweak with file extensions are allowed.
+The instructions on https://mailu.io/master/antispam.html#can-i-change-the-list-of-authorized-file-attachments work again.


### PR DESCRIPTION
## What type of PR?

bug fix

## What does this PR do?

Forbidden_file_extension.map could not be overridden. Start.py has been modified to allow this map to be overridden.
Now the instructions on https://mailu.io/master/antispam.html#can-i-change-the-list-of-authorized-file-attachments are valid again.

### Related issue(s)
- closes #2937 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
