### PR TITLE
Enhance RESTful API user retrieval with quota used bytes. 

### DIFF
--- a/core/admin/mailu/api/v1/user.py
+++ b/core/admin/mailu/api/v1/user.py
@@ -14,6 +14,7 @@ user_fields_get = api.model('UserGet', {
     'password': fields.String(description="Hash of the user's password; Example='$bcrypt-sha256$v=2,t=2b,r=12$fmsAdJbYAD1gGQIE5nfJq.$zLkQUEs2XZfTpAEpcix/1k5UTNPm0jO'"),
     'comment': fields.String(description='A description for the user. This description is shown on the Users page', example='my comment'),
     'quota_bytes': fields.Integer(description='The maximum quota for the user’s email box in bytes', example='1000000000'),
+    'quota_bytes_used': fields.Integer(description='The size of the user’s email box in bytes', example='5000000'),
     'global_admin': fields.Boolean(description='Make the user a global administrator'),
     'enabled': fields.Boolean(description='Enable the user. When an user is disabled, the user is unable to login to the Admin GUI or webmail or access his email via IMAP/POP3 or send mail'),
     'change_pw_next_login': fields.Boolean(description='Force the user to change their password at next login'),

--- a/towncrier/newsfragments/2824.feature
+++ b/towncrier/newsfragments/2824.feature
@@ -1,0 +1,1 @@
+Enhance RESTful API user retrieval with quota used bytes. This is the current size of the user's email box in bytes.


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?
Enhance RESTful API user retrieval with quota used bytes.  This is the current size of the user's email box in bytes.

So the API calls for /api/v1/user and /api/v1/user/local@domain.tld now also provide the quota used bytes.

To test. Check the API key in mailu.env (API_TOKEN=MyAPIKey) and then call:

curl -X 'GET' \
  'https://**mydomain.com**/api/v1/user/test%40google.com' \
  -H 'accept: application/json' \
  -H 'Authorization: **MyAPIKey**'

### Related issue(s)
-  closes #2824 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
