### PR TITLE
Remove IMAP ID capability from nginx

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -340,7 +340,7 @@ mail {
     # Advertise real capabilities of backends (postfix/dovecot)
     smtp_capabilities PIPELINING "SIZE {{ MESSAGE_SIZE_LIMIT }}" ETRN ENHANCEDSTATUSCODES 8BITMIME DSN;
     pop3_capabilities TOP UIDL RESP-CODES PIPELINING AUTH-RESP-CODE USER;
-    imap_capabilities IMAP4 IMAP4rev1 UIDPLUS SASL-IR LOGIN-REFERRALS ID ENABLE IDLE LITERAL+;
+    imap_capabilities IMAP4 IMAP4rev1 UIDPLUS SASL-IR LOGIN-REFERRALS ENABLE IDLE LITERAL+;
 
     # Default SMTP server for the webmail (no encryption, but authentication)
     server {

--- a/towncrier/newsfragments/2938-remove-id.bugfix
+++ b/towncrier/newsfragments/2938-remove-id.bugfix
@@ -1,0 +1,1 @@
+No longer advertize IMAP ID capability before authentication. This fixes issues with clients which send ID commands before authentication. One notable client with this issue is offlineimap.


### PR DESCRIPTION
The ID capability is not supported by nginx. Advertizing it leads to problems with client which send an ID command before authenticating. Before authentication commands are not forwarded to dovecot, but directly processed by nginx.

## What type of PR?

bugfix PR

## What does this PR do?

### Related issue(s)

Closes #2938

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
