### PR TITLE
Fix issues with log filter and remove POSTFIX_LOG_FILE

### DIFF
--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -3,13 +3,11 @@
 import os
 import glob
 import multiprocessing
-import logging as log
-import sys
 
 from podop import run_server
 from socrate import system, conf
 
-system.set_env(log_filters=r'Error\: SSL context initialization failed, disabling SSL\: Can\'t load SSL certificate \(ssl_cert setting\)\: The certificate is empty$')
+system.set_env(log_filters=[r'Error\: SSL context initialization failed, disabling SSL\: Can\'t load SSL certificate \(ssl_cert setting\)\: The certificate is empty$'])
 
 def start_podop():
     system.drop_privs_to('mail')
@@ -35,4 +33,5 @@ os.system("chown mail:mail /mail")
 os.system("chown -R mail:mail /var/lib/dovecot /conf")
 
 multiprocessing.Process(target=start_podop).start()
-os.system("dovecot -c /etc/dovecot/dovecot.conf -F")
+cmd = ['/usr/sbin/dovecot', '-c', '/etc/dovecot/dovecot.conf', '-F']
+system.run_process_and_forward_output(cmd)

--- a/core/nginx/start.py
+++ b/core/nginx/start.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 from socrate import system
 
-system.set_env(log_filters=r'could not be resolved \(\d\: [^\)]+\) while in resolving client address, client\: [^,]+, server: [^\:]+\:(25,110,143,587,465,993,995)$')
+system.set_env(log_filters=r'could not be resolved \(\d\: [^\)]+\) while in resolving client address, client\: [^,]+, server: [^\:]+\:(25|110|143|587|465|993|995)$')
 
 # Check if a stale pid file exists
 if os.path.exists("/var/run/nginx.pid"):
@@ -17,4 +17,5 @@ elif os.environ["TLS_FLAVOR"] in [ "mail", "cert" ]:
 
 subprocess.call(["/config.py"])
 os.system("dovecot -c /etc/dovecot/proxy.conf")
-os.execv("/usr/sbin/nginx", ["nginx", "-g", "daemon off;"])
+cmd = ['/usr/sbin/nginx', '-g', 'daemon off;']
+system.run_process_and_forward_output(cmd)

--- a/core/postfix/start.py
+++ b/core/postfix/start.py
@@ -13,8 +13,8 @@ from socrate import system, conf
 system.set_env(log_filters=[
     r'(dis)?connect from localhost\[(\:\:1|127\.0\.0\.1)\]( quit=1 commands=1)?$',
     r'haproxy read\: short protocol header\: QUIT$',
-    r'discarding EHLO keywords\: PIPELINING$',
-    ], log_file=os.environ.get('POSTFIX_LOG_FILE'))
+    r'discarding EHLO keywords\: PIPELINING$'
+    ])
 
 os.system("flock -n /queue/pid/master.pid rm /queue/pid/master.pid")
 
@@ -100,4 +100,5 @@ os.system("/usr/libexec/postfix/post-install meta_directory=/etc/postfix create-
 # Before starting postfix, we need to check permissions on /queue
 # in the event that postfix,postdrop id have changed
 os.system("postfix set-permissions")
-os.system("postfix start-fg")
+cmd = ['postfix', 'start-fg']
+system.run_process_and_forward_output(cmd)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -376,22 +376,6 @@ To disable all plugins just set ``ROUNDCUBE_PLUGINS`` to ``mailu``.
 
 To configure a plugin add php files named ``*.inc.php`` to roundcube's :ref:`override section <override-label>`.
 
-Mail log settings
------------------
-
-By default, all services log directly to stdout/stderr. Logs can be collected by any docker log processing solution.
-
-Postfix writes the logs to a syslog server which logs to stdout. This is used to filter
-out messages from the healthcheck. In some situations, a separate mail log is required
-(e.g. for legal reasons). The syslog server can be configured to write log files to a volume.
-It can be configured with the following option:
-
-- ``POSTFIX_LOG_FILE``: The file to log the mail log to. When enabled, the syslog server will also log to stdout.
-
-When ``POSTFIX_LOG_FILE`` is enabled, the logrotate program will automatically rotate the
-logs every week and keep 52 logs. To override the logrotate configuration, create the file logrotate.conf
-with the desired configuration in the :ref:`Postfix overrides folder<override-label>`.
-
 .. _header_authentication:
 
 Header authentication using an external proxy

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -58,6 +58,10 @@ services:
   resolver:
     image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}unbound:${MAILU_VERSION:-{{ version }}}
     env_file: {{ env }}
+    logging:
+      driver: journald
+      options:
+        tag: mailu-resolver
     restart: always
     networks:
       default:
@@ -220,7 +224,7 @@ services:
     logging:
       driver: journald
       options:
-        tag: mailu-clamav
+        tag: mailu-antivirus
     networks:
       - clamav
     volumes:
@@ -237,6 +241,10 @@ services:
   webdav:
     image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}radicale:${MAILU_VERSION:-{{ version }}}
     restart: always
+    logging:
+      driver: journald
+      options:
+        tag: mailu-webdav
     volumes:
       - "{{ root }}/dav:/data"
     networks:
@@ -248,6 +256,10 @@ services:
     image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}fetchmail:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
+    logging:
+      driver: journald
+      options:
+        tag: mailu-fetchmail
     volumes:
       - "{{ root }}/data/fetchmail:/data"
     depends_on:
@@ -267,6 +279,10 @@ services:
     image: ${DOCKER_ORG:-ghcr.io/mailu}/${DOCKER_PREFIX:-}webmail:${MAILU_VERSION:-{{ version }}}
     restart: always
     env_file: {{ env }}
+    logging:
+      driver: journald
+      options:
+        tag: mailu-webmail
     volumes:
       - "{{ root }}/webmail:/data"
       - "{{ root }}/overrides/{{ webmail_type }}:/overrides:ro"

--- a/towncrier/newsfragments/2939.bugfix
+++ b/towncrier/newsfragments/2939.bugfix
@@ -1,0 +1,4 @@
+Fixed log filter not filtering out log messages for dovecot/nginx/postfix.
+Fixed postfix not logging to standard out.
+Fixed not all containers logging to journald.
+Removed POSTFIX_LOG_FILE functionality. Added documentation on how to achieve the same (log to file) via journald & rsyslogd (see new FAQ entry 'How can I view and export the logs of a Mailu container?').


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
Fixed log filter not filtering out log messages for dovecot/nginx/postfix.
Fixed postfix not logging to standard out.
Fixed not all containers logging to journald.
Removed POSTFIX_LOG_FILE functionality. A new FAQ entry is created that documents how to log to file with journald & rsyslog.

Thank you @Lex999 for providing the sample code in #2839 for how to capture the standard out of called sub processes.

### Related issue(s)
- closes #2839
- closes #2819 
- closes #2939 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
