### PR TITLE
Give more time to clamav in CI

### DIFF
--- a/tests/compose/filters/docker-compose.yml
+++ b/tests/compose/filters/docker-compose.yml
@@ -86,6 +86,8 @@ services:
       - "/mailu/overrides/rspamd:/etc/rspamd/override.d"
     depends_on:
       - front
+      - antivirus
+      - oletools
 
   # Optional services
   antivirus:


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

In the CI, give time to clamav and oletools to start-up.

Without this we see failures where rspamd gives up before they are up and EICAR is let through

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
