### PR TITLE
Enable snowball on FTS

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -65,9 +65,9 @@ plugin {
   fts_enforced = yes
   fts_autoindex_exclude = \Trash
   fts_autoindex_exclude1 = \Junk
-  fts_filters = normalizer-icu stopwords
-  fts_filters_en = lowercase english-possessive stopwords
-  fts_filters_fr = lowercase contractions stopwords
+  fts_filters = normalizer-icu snowball stopwords
+  fts_filters_en = lowercase snowball english-possessive stopwords
+  fts_filters_fr = lowercase snowball contractions stopwords
   fts_header_excludes = Received DKIM-* ARC-* X-* x-* Comments Delivered-To Return-Path Authentication-Results Message-ID References In-Reply-To Thread-* Accept-Language Content-* MIME-Version
   {% if FULL_TEXT_SEARCH_ATTACHMENTS %}
   fts_tika = http://{{ FTS_ATTACHMENTS_ADDRESS }}:9998/tika/

--- a/core/rspamd/conf/external_services.conf
+++ b/core/rspamd/conf/external_services.conf
@@ -7,8 +7,8 @@ oletools {
   scan_mime_parts = true;
   extended = true;
   max_size = 3145728;
-  timeout = 20.0;
-  retransmits = 1;
+  timeout = 60.0;
+  retransmits = 10;
 
   patterns {
     OLETOOLS_MACRO_FOUND= '^.....M..$';

--- a/towncrier/newsfragments/2977.misc
+++ b/towncrier/newsfragments/2977.misc
@@ -1,0 +1,1 @@
+Improve FTS by adding the snowball filter. This should significantly cut down the size of indexes. You may want to re-index after upgrading.

--- a/webmails/roundcube/config/config.inc.php
+++ b/webmails/roundcube/config/config.inc.php
@@ -18,6 +18,11 @@ $config['session_lifetime'] = {{ (((PERMANENT_SESSION_LIFETIME | default(10800))
 $config['request_path'] = '{{ WEB_WEBMAIL or "none" }}';
 $config['trusted_host_patterns'] = [ {{ HOSTNAMES.split(",") | map("tojson") | join(',') }}];
 
+{% (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
+$config['search_mods'] = ['*' => ['subject'=>1, 'from'=>1, 'to'=>1, 'cc'=>1, 'bcc'=>1, 'replyto'=>1, 'followupto'=>1, 'body'=>1]];
+$config['search_scope'] = 'sub';
+{% endif %}
+
 // Mail servers
 $config['imap_host'] = 'tls://{{ FRONT_ADDRESS or "front" }}:10143';
 $config['imap_conn_options'] = array(

--- a/webmails/roundcube/config/config.inc.php
+++ b/webmails/roundcube/config/config.inc.php
@@ -18,7 +18,7 @@ $config['session_lifetime'] = {{ (((PERMANENT_SESSION_LIFETIME | default(10800))
 $config['request_path'] = '{{ WEB_WEBMAIL or "none" }}';
 $config['trusted_host_patterns'] = [ {{ HOSTNAMES.split(",") | map("tojson") | join(',') }}];
 
-{% (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
+{% if (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
 $config['search_mods'] = ['*' => ['subject'=>1, 'from'=>1, 'to'=>1, 'cc'=>1, 'bcc'=>1, 'replyto'=>1, 'followupto'=>1, 'body'=>1]];
 $config['search_scope'] = 'sub';
 {% endif %}

--- a/webmails/snappymail/defaults/default.json
+++ b/webmails/snappymail/defaults/default.json
@@ -14,7 +14,7 @@
             "security_level": 1
         },
 	{% if (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
-        "fast_simple_search": "false",
+        "fast_simple_search": "false"
 	{% endif %}
     },
     "SMTP": {

--- a/webmails/snappymail/defaults/default.json
+++ b/webmails/snappymail/defaults/default.json
@@ -12,7 +12,10 @@
             "SNI_enabled": true,
             "disable_compression": true,
             "security_level": 1
-        }
+        },
+	{% (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
+	"fast_simple_search": "false",
+	{% endif %}
     },
     "SMTP": {
         "host": "{{ FRONT_ADDRESS }}",

--- a/webmails/snappymail/defaults/default.json
+++ b/webmails/snappymail/defaults/default.json
@@ -13,8 +13,8 @@
             "disable_compression": true,
             "security_level": 1
         },
-	{% (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
-	"fast_simple_search": "false",
+	{% if (FULL_TEXT_SEARCH or '').lower() not in ['off', 'false', '0'] %}
+        "fast_simple_search": "false",
 	{% endif %}
     },
     "SMTP": {


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Enable [snowball](http://snowball.tartarus.org/algorithms/english/stemmer.html), a filter that will significantly cut down the size of FTS indexes.

It looks like the packages for aarch64 haven't been built yet... but this works on x64_86.
Don't unblock as long as  https://dl-cdn.alpinelinux.org/alpine/edge/testing/aarch64/dovecot-fts-flatcurve-0.3.4-r3.apk is 404

### Related issue(s)
- close #2977 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
