### PR TITLE
SECURITY FIX: Update to Roundcube 1.6.5

### DIFF
--- a/towncrier/newsfragments/3024.misc
+++ b/towncrier/newsfragments/3024.misc
@@ -1,0 +1,1 @@
+Upgrade to roundcube 1.6.5 (fix XSS)

--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -27,7 +27,7 @@ RUN set -euxo pipefail \
   ; mkdir -p /run/nginx /conf
 
 # roundcube
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.4/roundcubemail-1.6.4-complete.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.5/roundcubemail-1.6.5-complete.tar.gz
 ENV CARDDAV_URL https://github.com/mstilkerich/rcmcarddav/releases/download/v5.1.0/carddav-v5.1.0.tar.gz
 
 RUN set -euxo pipefail \


### PR DESCRIPTION
## What type of PR?

Security bug fix

## What does this PR do?

This is a security update to the stable version 1.6 of Roundcube Webmail.
It provides a fix to a recently reported XSS vulnerability:

Fix cross-site scripting (XSS) vulnerability in setting Content-Type/Content-Disposition for attachment preview/download reported by Rene Rehme (rehme.infosec).

### Related issue(s)

see [here](https://github.com/roundcube/roundcubemail/releases/tag/1.6.5)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
