### PR TITLE
Retry up to 5 times if not ready

### DIFF
--- a/tests/compose/filters/02_email_antispam.sh
+++ b/tests/compose/filters/02_email_antispam.sh
@@ -1,7 +1,7 @@
 # GTUBE should be blocked, see https://rspamd.com/doc/gtube_patterns.html
 python3 tests/email_test.py "XJS*C4JDBQADN1.NSBN3*2IDNEN*GTUBE-STANDARD-ANTI-UBE-TEST-EMAIL*C.34X"
-if [ $? -eq 25 ]; then
-	exit 0
-else
+if [ $? -ne 25 ]; then
 	exit 1
 fi
+
+exit 0

--- a/tests/email_test.py
+++ b/tests/email_test.py
@@ -33,14 +33,18 @@ for i in range(5):
 
         smtp_server.sendmail("admin@mailu.io", "user@mailu.io", msg.as_string())
         smtp_server.quit()
+    except smtplib.SMTPRecipientsRefused:
+            sys.exit(25)
     except smtplib.SMTPDataError as e:
         if e.smtp_code == 451:
             print(f"Not ready attempt {i}")
             time.sleep(5)
             continue
-        sys.exit(25)
+        if e.smtp_code >= 500 and e.smtp_code <600:
+            sys.exit(25)
+        sys.exit(2525)
     except:
-        sys.exit(25)
+        sys.exit(2525)
     break
 
 time.sleep(30)

--- a/tests/email_test.py
+++ b/tests/email_test.py
@@ -21,19 +21,27 @@ if len(sys.argv) == 3:
     part.add_header('Content-Disposition', "attachment; filename=%s" % ntpath.basename(sys.argv[2]))
     msg.attach(part)
 
-try:
-    smtp_server = smtplib.SMTP('localhost')
-    smtp_server.set_debuglevel(1)
-    smtp_server.connect('localhost', 587)
-    smtp_server.ehlo()
-    smtp_server.starttls()
-    smtp_server.ehlo()
-    smtp_server.login("admin@mailu.io", "password")
+for i in range(5):
+    try:
+        smtp_server = smtplib.SMTP('localhost')
+        smtp_server.set_debuglevel(1)
+        smtp_server.connect('localhost', 587)
+        smtp_server.ehlo()
+        smtp_server.starttls()
+        smtp_server.ehlo()
+        smtp_server.login("admin@mailu.io", "password")
 
-    smtp_server.sendmail("admin@mailu.io", "user@mailu.io", msg.as_string())
-    smtp_server.quit()
-except:
-    sys.exit(25)
+        smtp_server.sendmail("admin@mailu.io", "user@mailu.io", msg.as_string())
+        smtp_server.quit()
+    except smtplib.SMTPDataError as e:
+        if e.smtp_code == 451:
+            print(f"Not ready attempt {i}")
+            time.sleep(5)
+            continue
+        sys.exit(25)
+    except:
+        sys.exit(25)
+    break
 
 time.sleep(30)
 


### PR DESCRIPTION
Add retry logic to ensure we don't always pass if clamav is not ready; return a 25 error only if it's a permanent rejection code so that we can differentiate in between "definitely reject" and "was rejected because of a glitch"