### PR TITLE
nginx: Add PROXY_PROTOCOL configure as HTTPS, not for HTTP

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -22,7 +22,7 @@ http {
 
     {% if REAL_IP_HEADER %}
     real_ip_header {{ REAL_IP_HEADER }};
-    {% elif PROXY_PROTOCOL in ['all', 'all-but-http', 'http'] %}
+    {% elif PROXY_PROTOCOL in ['all', 'all-but-http', 'http', 'https'] %}
     real_ip_header proxy_protocol;
     {% endif %}
 
@@ -104,9 +104,9 @@ http {
 
       # Only enable HTTPS if TLS is enabled with no error and not on kubernetes
       {% if not KUBERNETES_INGRESS and TLS and not TLS_ERROR %}
-      listen 443 ssl http2{% if PROXY_PROTOCOL in ['all', 'all-but-http', 'http'] %} proxy_protocol{% endif %};
+      listen 443 ssl http2{% if PROXY_PROTOCOL in ['all', 'all-but-http', 'http', 'https'] %} proxy_protocol{% endif %};
 {% if SUBNET6 %}
-      listen [::]:443 ssl http2{% if PROXY_PROTOCOL in ['all', 'all-but-http', 'http'] %} proxy_protocol{% endif %};
+      listen [::]:443 ssl http2{% if PROXY_PROTOCOL in ['all', 'all-but-http', 'http', 'https'] %} proxy_protocol{% endif %};
 {% endif %}
 
       include /etc/nginx/tls.conf;

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -271,7 +271,8 @@ The ``PROXY_PROTOCOL`` (default: unset) allows the the front container to receiv
 the `PROXY protocol`_ (originally introduced in HAProxy, now also configurable in other proxy servers).
 It can be set to:
 
-* ``http`` to accept the ``PROXY`` protocol on nginx's HTTP proxy ports
+* ``https`` to accept the ``PROXY`` protocol on nginx's HTTPS proxy ports
+* ``http`` to accept the ``PROXY`` protocol on nginx's HTTP and HTTPS proxy ports
 * ``mail`` to accept the ``PROXY`` protocol on nginx's mail proxy ports
 * ``all`` to accept the ``PROXY`` protocol on all nginx's HTTP and mail proxy ports
 


### PR DESCRIPTION
## What type of PR?

This submission is used to solve the problem of TCP proxy forwarding directly to the port monitored by Mailu through SNI diversion and maintaining the normal application of the letsencrypt certificate.

When 'proxy_protocol' is enabled, it only applies to HTTPS listening ports and not to HTTP ports.

## What does this PR do?

I found that at the beginning of the mailu configuration, the letsencrypt certificate can only be applied for through port 80. If the public IP port 80 is not properly connected to the mailu container, the certificate cannot be applied for.

If the mailu container uses "proxy_protocol", it will also enable this protocol for port 80. This way, the mailu inside the container needs an external anti proxy tool to handle the request correctly. If it is nginx, the HTTP request needs to be configured with "proxy_protocol on" in the stream module and forwarded, which is actually not elegant because it has to be forwarded twice with a new port.

The solution is to make the HTTP port that Mailu listens to not do "proxy_protocol".

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
