### PR TITLE
Allow PROXY_PROTOCOL to be per-port customizable.

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -315,7 +315,7 @@ mail {
     ssl_session_cache shared:SSLMAIL:3m;
     {% endif %}
 
-    {% if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] and REAL_IP_FROM %}{% for from_ip in REAL_IP_FROM.split(',') %}
+    {% if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'smtp', 'imap', 'pop3', 'submission', 'submissions', 'imaps', 'pop3s'] and REAL_IP_FROM %}{% for from_ip in REAL_IP_FROM.split(',') %}
     set_real_ip_from {{ from_ip }};
     {% endfor %}{% endif %}
 
@@ -324,9 +324,9 @@ mail {
 
     # SMTP is always enabled, to avoid losing emails when TLS is failing
     server {
-      listen 25{% if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %} proxy_protocol{% endif %};
+      listen 25{% if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'smtp'] %} proxy_protocol{% endif %};
 {% if SUBNET6 %}
-      listen [::]:25{% if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %} proxy_protocol{% endif %};
+      listen [::]:25{% if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'smtp'] %} proxy_protocol{% endif %};
 {% endif %}
       {% if TLS and not TLS_ERROR %}
       {% if TLS_FLAVOR in ['letsencrypt','mail-letsencrypt'] %}

--- a/core/nginx/dovecot/proxy.conf
+++ b/core/nginx/dovecot/proxy.conf
@@ -79,7 +79,7 @@ service managesieve-login {
   executable = managesieve-login
   inet_listener sieve {
     port = 4190
-{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %}
+{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'managesieve'] %}
     haproxy = yes
 {% endif %}
   }
@@ -96,7 +96,7 @@ protocol imap {
 service imap-login {
   inet_listener imap {
     port = 143
-{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %}
+{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'imap'] %}
     haproxy = yes
 {% endif %}
   }
@@ -105,7 +105,7 @@ service imap-login {
 {%- if TLS %}
     ssl = yes
 {% endif %}
-{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %}
+{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'imaps'] %}
     haproxy = yes
 {% endif %}
   }
@@ -117,7 +117,7 @@ service imap-login {
 service pop3-login {
   inet_listener pop3 {
     port = 110
-{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %}
+{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'pop3'] %}
     haproxy = yes
 {% endif %}
   }
@@ -126,7 +126,7 @@ service pop3-login {
 {%- if TLS %}
     ssl = yes
 {% endif %}
-{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %}
+{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'pop3s'] %}
     haproxy = yes
 {% endif %}
   }
@@ -143,7 +143,7 @@ service lmtp {
 service submission-login {
    inet_listener submission {
     port = 587
-{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %}
+{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'submission'] %}
     haproxy = yes
 {% endif %}
    }
@@ -152,7 +152,7 @@ service submission-login {
 {%- if TLS %}
     ssl = yes
 {% endif %}
-{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %}
+{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail', 'submissions'] %}
     haproxy = yes
 {% endif %}
    }

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -274,6 +274,13 @@ It can be set to:
 * ``http`` to accept the ``PROXY`` protocol on nginx's HTTP proxy ports
 * ``mail`` to accept the ``PROXY`` protocol on nginx's mail proxy ports
 * ``all`` to accept the ``PROXY`` protocol on all nginx's HTTP and mail proxy ports
+* ``smtp`` to accept the ``PROXY`` protocol on TCP 25 only
+* ``imap`` to accept the ``PROXY`` protocol on TCP 143 only
+* ``pop3`` to accept the ``PROXY`` protocol on TCP 110 only
+* ``submissions`` to accept the ``PROXY`` protocol on TCP 465 only
+* ``submission`` to accept the ``PROXY`` protocol on TCP 587 only
+* ``smtp`` to accept the ``PROXY`` protocol on TCP 995 only
+* ``imaps`` to accept the ``PROXY`` protocol on TCP 993 only
 
 .. _`PROXY protocol`: https://github.com/haproxy/haproxy/blob/master/doc/proxy-protocol.txt
 


### PR DESCRIPTION
## What type of PR?

Enhancement

## What does this PR do?

Allow `PROXY_PROTOCOL` env variable to be set on only a specific port.  Eg, in my case, only tcp/25 needs to have PROXY_PROTOCOL enabled.

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ x ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.