### PR TITLE
Fix 3095: fix the form validator of forwarding addresses

### DIFF
--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -39,7 +39,7 @@ class MultipleEmailAddressesVerify(object):
 
     def __call__(self, form, field):
         pattern = re.compile(r'^([_a-z0-9\-\+]+)(\.[_a-z0-9\-\+]+)*@([a-z0-9\-]{1,}\.)*([a-z]{1,})(,([_a-z0-9\-\+]+)(\.[_a-z0-9\-\+]+)*@([a-z0-9\-]{1,}\.)*([a-z]{2,}))*$')
-        if not pattern.match(field.data.replace(" ", "")):
+        if not pattern.match(field.data.lower().replace(" ", "")):
             raise validators.ValidationError(self.message)
 
 class MultipleFoldersVerify(object):

--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -38,8 +38,8 @@ class MultipleEmailAddressesVerify(object):
         self.message = message
 
     def __call__(self, form, field):
-        pattern = re.compile(r'^([_a-z0-9\-\+]+)(\.[_a-z0-9\-\+]+)*@([a-z0-9\-]{1,}\.)*([a-z]{1,})(,([_a-z0-9\-\+]+)(\.[_a-z0-9\-\+]+)*@([a-z0-9\-]{1,}\.)*([a-z]{2,}))*$')
-        if not pattern.match(field.data.lower().replace(" ", "")):
+        pattern = re.compile(r"^(?:\s*\S+@([a-z0-9\-]{1,}\.)*([a-z]{1,})[\s|,]*)+$", re.IGNORECASE)
+        if not pattern.match(field.data.replace(" ", "")):
             raise validators.ValidationError(self.message)
 
 class MultipleFoldersVerify(object):

--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -38,7 +38,7 @@ class MultipleEmailAddressesVerify(object):
         self.message = message
 
     def __call__(self, form, field):
-        pattern = re.compile(r"^(?:\s*\S+@([a-z0-9\-]{1,}\.)*([a-z]{1,})[\s|,]*)+$", re.IGNORECASE)
+        pattern = re.compile(r'^([_a-z0-9\-\+]+)(\.[_a-z0-9\-\+]+)*@([a-z0-9\-]{1,}\.)*([a-z]{1,})(,([_a-z0-9\-\+]+)(\.[_a-z0-9\-\+]+)*@([a-z0-9\-]{1,}\.)*([a-z]{2,}))*$', re.IGNORECASE)
         if not pattern.match(field.data.replace(" ", "")):
             raise validators.ValidationError(self.message)
 

--- a/towncrier/newsfragments/3095.bugfix
+++ b/towncrier/newsfragments/3095.bugfix
@@ -1,0 +1,1 @@
+Ensure that the form validator related to forwarding addresses allows for uppercase


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix the form validator of forwarding addresses (allow uppercase).

I don't think this warrants a backport but if you think it does add the label.

### Related issue(s)
- closes #3095

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
