### PR TITLE
Long term fix against SMTP smuggling

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -25,8 +25,7 @@ podop = socketmap:unix:/tmp/podop.socket:
 
 postscreen_upstream_proxy_protocol = haproxy
 compatibility_level=3.6
-# see https://www.mail-archive.com/postfix-users@postfix.org/msg100901.html
-smtpd_forbid_unauth_pipelining=yes
+smtpd_forbid_bare_newline=yes
 
 # Only accept virtual emails
 mydestination =

--- a/towncrier/newsfragments/3101.bugfix
+++ b/towncrier/newsfragments/3101.bugfix
@@ -1,1 +1,1 @@
-Long term fix agaist SMTP smuggling (disable bare_newline)
+Long term fix against SMTP smuggling (disable bare_newline), see https://www.postfix.org/smtp-smuggling.html

--- a/towncrier/newsfragments/3101.bugfix
+++ b/towncrier/newsfragments/3101.bugfix
@@ -1,1 +1,1 @@
-Prevent SMTP smuggling; see https://www.mail-archive.com/postfix-users@postfix.org/msg100901.html
+Long term fix agaist SMTP smuggling (disable bare_newline)


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Long term fix against SMTP smuggling, see https://www.postfix.org/smtp-smuggling.html

This can't be hot-patched, you need postfix 3.8.4-r0 (which is now available in alpine 3.18)
https://git.alpinelinux.org/aports/commit/?id=19fa7e7fb3208bea9aded961f07b7ad2bb6493dc

### Related issue(s)
- closes #3108
- #3102 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
