### PR TITLE
Upgrade roundcube to 1.6.6

### DIFF
--- a/towncrier/newsfragments/3130.misc
+++ b/towncrier/newsfragments/3130.misc
@@ -1,0 +1,1 @@
+Upgrade to roundcube 1.6.6

--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -29,7 +29,7 @@ RUN set -euxo pipefail \
   ; mkdir -p /run/nginx /conf
 
 # roundcube
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.5/roundcubemail-1.6.5-complete.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.6/roundcubemail-1.6.6-complete.tar.gz
 ENV CARDDAV_URL https://github.com/mstilkerich/rcmcarddav/releases/download/v5.1.0/carddav-v5.1.0.tar.gz
 
 RUN set -euxo pipefail \


### PR DESCRIPTION
## What type of PR?

Roundcube has been updated to version 1.6.6 which contains various small fixes and improvements.

See [release notes](https://github.com/roundcube/roundcubemail/releases/tag/1.6.6)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
