### PR TITLE
Add trailing semicolon for DMARC authorisation record

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -250,7 +250,7 @@ class Domain(Base):
         """ return DMARC report record for mailu server """
         if self.dkim_key:
             domain = app.config['DOMAIN']
-            return f'{self.name}._report._dmarc.{domain}. 600 IN TXT "v=DMARC1"'
+            return f'{self.name}._report._dmarc.{domain}. 600 IN TXT "v=DMARC1;"'
 
     @cached_property
     def dns_autoconfig(self):


### PR DESCRIPTION
## What type of PR?

enhancement, bug-fix

## What does this PR do?

Add trailing semicolon for DMARC authorisation records, which seems to be necessary: https://stackoverflow.com/a/72463456
I ran into this when testing my domain with internet.nl.

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
