### PR TITLE
Documentation: config-export had wrong example.

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -162,7 +162,7 @@ Attributes explicitly specified in filters are automatically exported: there is 
 
 .. code-block:: bash
 
-  $ docker compose exec admin flask mailu config-export --output mail-config.yml
+  $ docker compose exec admin flask mailu config-export --output-file mail-config.yml
 
   $ docker compose exec -T admin flask mailu config-export domain.dns_mx domain.dns_spf
 

--- a/docs/database.rst
+++ b/docs/database.rst
@@ -17,7 +17,7 @@ This means it is not possible to switch the database back-end used by roundcube 
 
 To switch to a different database back-end:
 
-1. Run config-export to export the configuration. E.g. `docker compose exec admin flask mailu config-export --secrets --output /data/mail-config.yml`
+1. Run config-export to export the configuration. E.g. `docker compose exec admin flask mailu config-export --secrets --output-file /data/mail-config.yml`
 2. Set up your new database server. Refer to the subsequent sections for tips for creating the database.
 3. Modify the database settings (SQLAlchemy database URL) in mailu.env. Refer to the :ref:`configuration guide (link) <db_settings>` for the exact settings.
 4. Start your Mailu deployment.


### PR DESCRIPTION
fixing the example command flag.
running the example command to export the configuration throws: Error: [KeyError] 'mail-config'

this is valid for any version of mailu (at the time)

## What type of PR?

documentation

## What does this PR do?


