### PR TITLE
Fix ooo/sieve when proxy protocol is in use

### DIFF
--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -5,7 +5,11 @@ log_path = /dev/stderr
 protocols = imap pop3 lmtp sieve
 postmaster_address = {{ POSTMASTER }}@{{ DOMAIN }}
 hostname = {{ HOSTNAMES.split(",")[0] }}
+{%- if PROXY_PROTOCOL in ['all', 'all-but-http', 'mail'] %}
+submission_host = {{ HOSTNAMES.split(",")[0] }}
+{% else %}
 submission_host = {{ FRONT_ADDRESS }}
+{% endif %}
 {%- if SUBNET6 %}
 listen = *,::
 {% else %}

--- a/towncrier/newsfragments/3172.bugfix
+++ b/towncrier/newsfragments/3172.bugfix
@@ -1,0 +1,1 @@
+Fix ooo/sieve replies when proxy protocol is in use


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix ooo/sieve when proxy protocol is in use; If it is enabled we shouldn't talk to front but to the proxy.

I am not proposing to backport this; it will be a 2.1 thing.

### Related issue(s)
- close #3172
- close #3159

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
