### PR TITLE
Move Actions concurrency limits to the build step

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -79,6 +79,11 @@ on:
         default: false
         required: false
         type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.docker_org }}-${{ inputs.pinned_mailu_version }}-${{ inputs.architecture }}
+  cancel-in-progress: true
+
 env:
   HCL_FILE: ./tests/build-ci.hcl
 

--- a/.github/workflows/multiarch.yml
+++ b/.github/workflows/multiarch.yml
@@ -8,8 +8,6 @@ on:
       - master
       - test-*
 
-concurrency: ci-multiarch-${{ github.ref }}
-
 # REQUIRED global variables
 # DOCKER_ORG, docker org used for pushing images.
 env:


### PR DESCRIPTION
## What type of PR?

Enhancement

## What does this PR do?

This lays the groundwork for a cron workflow to rebuild nightly in order to get security updates. I considered trying to just add a schedule trigger to multiarch.yml, but schedule only supports the default branch as `github.ref` which gets irritating because anywhere that uses `github.ref` now has to fall back to another value if the workflow was triggered by a schedule. It's much easier to just add another workflow and

Note that there is technically now a race here because GitHub doesn't guarantee ordering of jobs within a concurrency group, so in theory if commit B got merged very shortly after commit A, and commit B's multiarch run was super slow for some reason, commit A might end up preempting it. However AFAICT this is basically impossible in practice because Bors will properly serialize merges. This is the reason we remove concurrency control from multiarch.yml.

I enabled `cancel-in-progress` since it just kinda seemed like we might as well - if we let the build finish, it'll just be overwritten in a few minutes anyway.

### Related issue(s)

None AFAIK

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
