### PR TITLE
Fix highligting disabled users

### DIFF
--- a/core/admin/mailu/ui/templates/user/list.html
+++ b/core/admin/mailu/ui/templates/user/list.html
@@ -28,7 +28,7 @@
 </thead>
 <tbody>
   {%- for user in domain.users %}
-  <tr{% if not user.enabled %} class="warning"{% endif %}>
+  <tr{% if not user.enabled %} class="text-muted"{% endif %}>
     <td>
       <a href="{{ url_for('.user_edit', user_email=user.email) }}" title="{% trans %}Edit{% endtrans %}"><i class="fas fa-pencil-alt"></i></a>&nbsp;
     </td>


### PR DESCRIPTION
This just changes the class on the rows of disabled users from `warning` to `bg-warning` . As warning is not available in AdminLTE 3 disabled users where not highlighted anymore-

![image](https://github.com/Mailu/Mailu/assets/81554102/af501719-5234-405a-8300-2db69a7e4ef6)


## What type of PR?
bug-fix

## What does this PR do?

### Related issue(s)
#3166 


