### PR TITLE
Fix bug 3068. Spam messages were always marked as read.

### DIFF
--- a/core/dovecot/conf/report-spam.sieve
+++ b/core/dovecot/conf/report-spam.sieve
@@ -1,5 +1,4 @@
 require "imap4flags";
 require "vnd.dovecot.execute";
 
-setflag "\\seen";
 execute :pipe "spam";

--- a/docs/webadministration.rst
+++ b/docs/webadministration.rst
@@ -93,6 +93,8 @@ The exception to this rule, are email messages with an extremely high spam score
 
 When the spam filter is enabled, received email messages will be moved to the logged in user's inbox folder or junk folder depending on the user defined spam filter tolerance.
 
+When `Enable marking spam mails as read` is enabled. Received messages moved to the Junk folder are marked as read. When this setting is disabled. Received messages moved to the Junk folder are not marked as read. They remain marked as unread.
+
 The user defined spam filter tolerance determines when an email is classified as ham (moved to the inbox folder) or spam (moved to the junk folder).
 The default value is 80%. The lower the spam filter tolerance, the more false positives (ham classified as spam). The higher the spam filter tolerance, the more false negatives (spam classified as ham).
 For more information see the :ref:`antispam documentation <antispam_howto>`.

--- a/towncrier/newsfragments/3068.bugfix
+++ b/towncrier/newsfragments/3068.bugfix
@@ -1,0 +1,2 @@
+When "Enable marking spam mails as read" was disabled, new spam messages were still marked as read.
+Updated documentation with the setting "Enable marking spam mails as read".


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
When `Enable marking spam mails as read`  was disabled, spam messages were still marked as read. This PR resolves this defect.

### Related issue(s)
- Auto close an issue like: closes #3068

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
