### PR TITLE
Add missing translations for Dutch, German, French and Polish

### DIFF
--- a/core/admin/mailu/translations/de/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/de/LC_MESSAGES/messages.po
@@ -307,6 +307,14 @@ msgstr "Antispam"
 msgid "RSPAMD status page"
 msgstr "RSPAMD Statusseite"
 
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "Falls es sich um ein Apple-Gerät handelt,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "kann dieses hier automatisch eingerichtet werden."
+
 #: mailu/ui/templates/client.html:8
 msgid "configure your email client"
 msgstr "Informationen zur Einrichtung Ihres Email-Clients"

--- a/core/admin/mailu/translations/fr/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/fr/LC_MESSAGES/messages.po
@@ -84,6 +84,22 @@ msgstr "Confirmer"
 msgid "Domain name"
 msgstr "Nom de domaine"
 
+#: mailu/ui/forms.py:134
+msgid "Current password"
+msgstr "Mot de passe actuel"
+
+#: mailu/ui/forms.py:98
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr "Permettre à l'utilisateur de changer l'expéditeur (envoyer un e-mail en tant que n'importe qui)"
+
+#: mailu/ui/forms.py:102
+msgid "Force password change at next login"
+msgstr "Forcer le changement du mot de passe à la prochaine connexion"
+
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr "Télécharger le fichier de zone"
+
 #: mailu/ui/forms.py:49
 msgid "Maximum user count"
 msgstr "Nombre maximum d'utilisateurs"
@@ -268,6 +284,14 @@ msgstr "Nom d'hôte ou adresse IP"
 #: mailu/ui/templates/client.html:45
 msgid "TCP port"
 msgstr "Port TCP"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "Si vous utilisez un appareil Apple,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "cliquez ici pour le configurer automatiquement."
 
 #: mailu/ui/forms.py:164
 msgid "Enable TLS"

--- a/core/admin/mailu/translations/nl/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/nl/LC_MESSAGES/messages.po
@@ -293,6 +293,14 @@ msgstr "TLS inschakelen"
 msgid "Username"
 msgstr "Gebruikersnaam"
 
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "Indien u een Apple-apparaat gebruikt,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "kunt u hier klikken om deze automatisch te configureren."
+
 #: mailu/ui/forms.py:167
 msgid "Keep emails on the server"
 msgstr "Behoud de e-mails op de server"

--- a/core/admin/mailu/translations/nl/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/nl/LC_MESSAGES/messages.po
@@ -24,7 +24,7 @@ msgstr "E-mail"
 msgid "Password"
 msgstr "Wachtwoord"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
 #: mailu/ui/templates/sidebar.html:142
 msgid "Sign in"
 msgstr "Aanmelden"
@@ -83,6 +83,14 @@ msgstr "Bevestigen"
 msgid "Domain name"
 msgstr "Domeinnaam"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr "Download zone-bestand"
+
+#: mailu/ui/forms.py:98
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr "Sta toe dat de gebruiker de verzender kan vervalsen (namens iedereen email versturen)"
+
 #: mailu/ui/forms.py:49
 msgid "Maximum user count"
 msgstr "Maximaal aantal gebruikers"
@@ -98,6 +106,10 @@ msgstr "Maximum quotum gebruikers"
 #: mailu/ui/forms.py:52
 msgid "Enable sign-up"
 msgstr "Schakel registreren in"
+
+#: mailu/ui/forms.py:102
+msgid "Force password change at next login"
+msgstr "Forceer dat bij de volgende aanmelding het wachtwoord veranderd moet worden"
 
 #: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
 #: mailu/ui/forms.py:132 mailu/ui/forms.py:144
@@ -123,6 +135,10 @@ msgstr "Beheerder wachtwoord"
 #: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
 msgid "Confirm password"
 msgstr "Bevestig wachtwoord"
+
+#: mailu/ui/forms.py:134
+msgid "Current password"
+msgstr "Huidig wachtwoord"
 
 #: mailu/ui/forms.py:63
 msgid "Create"

--- a/core/admin/mailu/translations/pl/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/pl/LC_MESSAGES/messages.po
@@ -85,6 +85,22 @@ msgstr "Zatwierdź"
 msgid "Domain name"
 msgstr "Nazwa domeny"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr "Pobierz plik strefy DNS"
+
+#: mailu/ui/forms.py:134
+msgid "Current password"
+msgstr "Aktualne hasło"
+
+#: mailu/ui/forms.py:102
+msgid "Force password change at next login"
+msgstr "Wymuś zmianę hasła przy następnym logowaniu"
+
+#: mailu/ui/forms.py:98
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr "Zezwól użytkownikowi na podrobienie adresu nadawcy (wysłanie emaila w czyimkolwiek imieniu)"
+
 #: mailu/ui/forms.py:49
 msgid "Maximum user count"
 msgstr "Maksymalna liczba użytkowników"
@@ -270,6 +286,14 @@ msgstr "Nazwa hosta lub adres IP"
 #: mailu/ui/templates/client.html:45
 msgid "TCP port"
 msgstr "Port TCP"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "Jeśli używasz urządzenia firmy Apple,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "kliknij tutaj by skonfigurować je automatycznie."
 
 #: mailu/ui/forms.py:164
 msgid "Enable TLS"

--- a/towncrier/newsfragments/3029.bugfix
+++ b/towncrier/newsfragments/3029.bugfix
@@ -1,5 +1,5 @@
 Added missing translations for Dutch, German and French.
-4 new strings were introduced after 2.0. These must be translated for all languages.
+6 new strings were introduced after 2.0. These must be translated for all languages.
 If this translation is missing for your native language, please submit a PR with the translation,
 or open a new issue where you mention the translated strings.
 
@@ -19,3 +19,11 @@ msgstr "translation of password change at next login"
 #: mailu/ui/forms.py:98
 msgid "Allow the user to spoof the sender (send email as anyone)"
 msgstr "translation of Allow the user to spoof the sender (send email as anyone)"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "translation of If you use an Apple device,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "translation of click here to auto-configure it."

--- a/towncrier/newsfragments/3029.bugfix
+++ b/towncrier/newsfragments/3029.bugfix
@@ -1,0 +1,21 @@
+Added missing translations for Dutch, German and French.
+4 new strings were introduced after 2.0. These must be translated for all languages.
+If this translation is missing for your native language, please submit a PR with the translation,
+or open a new issue where you mention the translated strings.
+
+The missing translations are:
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr "translation of Download zonefile"
+
+#: mailu/ui/forms.py:134
+msgid "Current password"
+msgstr "translation of Current password"
+
+#: mailu/ui/forms.py:102
+msgid "Force password change at next login"
+msgstr "translation of password change at next login"
+
+#: mailu/ui/forms.py:98
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr "translation of Allow the user to spoof the sender (send email as anyone)"


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
Adds missing translations for Dutch. These strings were introduced after 2.0. Practically **all** translations must be updated with these strings.

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [n/a] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
