### PR TITLE
fix #3252

### DIFF
--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -110,6 +110,8 @@ def postfix_recipient_map(recipient):
 
     This is meant for bounces to go back to the original sender.
     """
+    if recipient.count('@') > 1 or recipient.startswith('"'):
+        return flask.abort(404)
     srs = srslib.SRS(flask.current_app.srs_key)
     if srslib.SRS.is_srs_address(recipient):
         try:

--- a/towncrier/newsfragments/3252.bugfix
+++ b/towncrier/newsfragments/3252.bugfix
@@ -1,0 +1,1 @@
+Ensure that sending emails to invalid addresses with an '@' in localpart is permanently and not temporarily rejected.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Ensure that sending emails to invalid addresses with an '@' in localpart is permanently and not temporarily rejected.

This is the sister commit of 15569c62df2336faf3c3ffabb7190a3caff2983a

### Related issue(s)
- closes #3252

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
