### PR TITLE
Fix #3260: double-quotes should be escaped/allowed in ooo

### DIFF
--- a/core/admin/mailu/internal/templates/default.sieve
+++ b/core/admin/mailu/internal/templates/default.sieve
@@ -31,6 +31,6 @@ if spamtest :percent :value "gt" :comparator "i;ascii-numeric" "{{ user.spam_thr
 
 {% if user.reply_active %}
 if not address :localpart :contains ["From","Reply-To"] ["noreply","no-reply"]{
-  vacation :days 1 {% if user.displayed_name != "" %}:from "{{ user.displayed_name }} <{{ user.email }}>"{% endif %} :subject "{{ user.reply_subject }}" "{{ user.reply_body }}";
+  vacation :days 1 {% if user.displayed_name != "" %}:from "{{ user.displayed_name | replace("\"", "\\\"") }} <{{ user.email | replace("\"", "\\\"") }}>"{% endif %} :subject "{{ user.reply_subject | replace("\"", "\\\"") }}" "{{ user.reply_body | replace("\"", "\\\"") }}";
 }
 {% endif %}

--- a/towncrier/newsfragments/3260.bugfix
+++ b/towncrier/newsfragments/3260.bugfix
@@ -1,0 +1,1 @@
+Fix a bug preventing double quotes from being used in ooo messages


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

double-quotes should be allowed in ooo messages

### Related issue(s)
- closes #3260 
- #3249

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
