### PR TITLE
Upgrade Tika and switch to the upstream image

### DIFF
--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -158,7 +158,7 @@ services:
 
 {% if tika_enabled %}
   fts_attachments:
-    image: ghcr.io/paperless-ngx/tika:2.9.1-full
+    image: apache/tika:2.9.2-alpha-multi-arch-full
     hostname: tika
     logging:
       driver: journald

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 docker==7.0.0
 colorama==0.4.6
 managesieve==0.7.1
+requests==2.31.0


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Upgrade Tika to 2.9.2 and switch to the upstream image

We couldn't do it before as there was no multi-arch image upstream
See https://github.com/apache/tika-docker/pull/19

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
