### PR TITLE
webdav (radicale) not reachable

### DIFF
--- a/optional/radicale/radicale.conf
+++ b/optional/radicale/radicale.conf
@@ -1,5 +1,6 @@
 [server]
 ssl = False
+hosts = 0.0.0.0:5232
 
 [encoding]
 request = utf-8

--- a/towncrier/newsfragments/3294.bugfix
+++ b/towncrier/newsfragments/3294.bugfix
@@ -1,0 +1,1 @@
+Webdav (radicale) was not reachable. This has been resolved.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
Radicale was listening only on localhost:5232 (default setting). Due to this radicale was not reachable from front. Now it listens on 0.0.00:5232 and is reachable again.

### Related issue(s)
- closes #3294

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
