### PR TITLE
nginx should recursively set the realip until the first no trusted ad…

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -26,9 +26,10 @@ http {
     real_ip_header proxy_protocol;
     {% endif %}
 
-    {% if REAL_IP_FROM %}{% for from_ip in REAL_IP_FROM.split(',') %}
-    set_real_ip_from {{ from_ip }};
+    {% if REAL_IP_FROM %}
     real_ip_recursive on;
+    {% for from_ip in REAL_IP_FROM.split(',') %}
+    set_real_ip_from {{ from_ip }};
     {% endfor %}{% endif %}
 
     # Header maps

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -28,6 +28,7 @@ http {
 
     {% if REAL_IP_FROM %}{% for from_ip in REAL_IP_FROM.split(',') %}
     set_real_ip_from {{ from_ip }};
+    real_ip_recursive on;
     {% endfor %}{% endif %}
 
     # Header maps

--- a/towncrier/newsfragments/3311.bugfix
+++ b/towncrier/newsfragments/3311.bugfix
@@ -1,0 +1,1 @@
+Enable nginx setting `real_ip_recursive` to recursively replace real user ip


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)

closes https://github.com/Mailu/Mailu/issues/3311

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
