### PR TITLE
Fix smtpd_forbid_unauth_pipelining with XCLIENT

### DIFF
--- a/core/postfix/conf/main.cf
+++ b/core/postfix/conf/main.cf
@@ -26,6 +26,7 @@ podop = socketmap:unix:/tmp/podop.socket:
 postscreen_upstream_proxy_protocol = haproxy
 compatibility_level=3.6
 smtpd_forbid_bare_newline=yes
+smtpd_forbid_unauth_pipelining=no
 
 # Only accept virtual emails
 mydestination =

--- a/towncrier/newsfragments/3322.bugfix
+++ b/towncrier/newsfragments/3322.bugfix
@@ -1,0 +1,1 @@
+Postfix 3.9 has changed the default for smtpd_forbid_unauth_pipelining. We need it to be allowed for XCLIENT to work.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix smtpd_forbid_unauth_pipelining with XCLIENT. The default has changed in postfix 3.9, we need it enabled for XCLIENT to work.

### Related issue(s)
- close #3301

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
