### PR TITLE
Feature: dkim for alternative domains

### DIFF
--- a/core/admin/mailu/internal/views/rspamd.py
+++ b/core/admin/mailu/internal/views/rspamd.py
@@ -24,6 +24,15 @@ def rspamd_dkim_key(domain_name):
                     'selector': flask.current_app.config.get('DKIM_SELECTOR', 'dkim'),
                 }
             )
+    elif domain := models.Alternative.query.get(domain_name):
+        if key := domain.domain.dkim_key:
+            selectors.append(
+                {
+                    'domain'  : domain.name,
+                    'key'     : key.decode('utf8'),
+                    'selector': flask.current_app.config.get('DKIM_SELECTOR', 'dkim'),
+                }
+            )
     return flask.jsonify({'data': {'selectors': selectors}})
 
 @internal.route("/rspamd/local_domains", methods=['GET'])

--- a/core/admin/mailu/translations/de/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/de/LC_MESSAGES/messages.po
@@ -545,6 +545,10 @@ msgstr "DNS TLSA Eintrag"
 msgid "DNS client auto-configuration entries"
 msgstr "DNS Einträge für die automatische Client-Konfiguration"
 
+#: mailu/ui/templates/domain/details.html:71
+msgid "Alternative Domain name"
+msgstr "Alternativer Domain Name"
+
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
 msgstr "Domain bearbeiten"

--- a/core/admin/mailu/ui/templates/domain/details.html
+++ b/core/admin/mailu/ui/templates/domain/details.html
@@ -63,4 +63,36 @@
   </pre></td>
 </tr>
 {%- endcall %}
+
+{%- for alternative in domain.alternatives %}
+
+{%- call macros.table(datatable=False) %}
+<tr>
+  <th>{% trans %}Alternative Domain name{% endtrans %}</th>
+  <td>{{ alternative.name }}</td>
+</tr>
+<tr>
+  <th>{% trans %}DNS MX entry{% endtrans %} <i class="fa {{ 'fa-check-circle text-success' if alternative.check_mx() else 'fa-exclamation-circle text-danger' }}"></i></th>
+  <td>{{ macros.clip("dns_mx") }}<pre id="dns_mx" class="pre-config border bg-light">{{ alternative.dns_mx }}</pre></td>
+</tr>
+<tr>
+  <th>{% trans %}DNS SPF entries{% endtrans %}</th>
+  <td>{{ macros.clip("dns_spf") }}<pre id="dns_spf" class="pre-config border bg-light">{{ alternative.dns_spf }}</pre>
+  </td>
+</tr>
+{%- if alternative.domain.dkim_publickey %}
+<tr>
+  <th>{% trans %}DNS DKIM entry{% endtrans %}</th>
+  <td>{{ macros.clip("dns_dkim") }}<pre id="dns_dkim" class="pre-config border bg-light">{{ alternative.dns_dkim }}</pre></td>
+</tr>
+<tr>
+  <th>{% trans %}DNS DMARC entry{% endtrans %}</th>
+  <td>
+    {{ macros.clip("dns_dmarc") }}<pre id="dns_dmarc" class="pre-config border bg-light">{{ alternative.dns_dmarc }}</pre>
+    {{ macros.clip("dns_dmarc_report") }}<pre id="dns_dmarc_report" class="pre-config border bg-light">{{ alternative.dns_dmarc_report }}</pre>
+  </td>
+</tr>
+{%- endif %}
+{%- endcall %}
+{%- endfor %}
 {%- endblock %}

--- a/towncrier/newsfragments/3350.feature
+++ b/towncrier/newsfragments/3350.feature
@@ -1,0 +1,1 @@
+Add DKIM support for alternative domains: alternative domains use the same DKIM key as the main domain.


### PR DESCRIPTION
## What type of PR?

feature

## What does this PR do?

### General Idea

#### use same DKIM key of main domain for signing

Instead of dealing with key creation for each alternative domain, this implementation of the solution uses one key for all domains, the main domain and all alternative domains. Upon Rspamd requesting the DKIM key of a domain, it is not only checked if the domain is in the list of main domains, it also checked if it part of the alternative domains. If it is in this list, it sends the DKIM key of the connected main domain together with the name of the alternative domain.

#### show needed entries in the domain detailed view of the main domain

To make it easier for the admin to create the DKIM and DMARC entries (and the MX and SPF entries) for the alternative domains, we go through all alternative domains and print the entries.

### missing (and currently not planned to be added)

The zonefile at the top of the detail page will still only cover the main domain.

### Related issue(s)
- DKIM signing of the alternative domains is a requested feature; it closes #1519
- it keeps the original file based handling of DKIM keys; it does not implement #2952

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
