### PR TITLE
Add `-e` to local PIP packages in requirements-dev.txt

### DIFF
--- a/core/base/requirements-dev.txt
+++ b/core/base/requirements-dev.txt
@@ -1,6 +1,6 @@
 # core/base
-libs/podop
-libs/socrate
+-e libs/podop
+-e libs/socrate
 
 # core/admin
 alembic


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
- Dependabot fails if the `-e` parameter is missing for editable pip packages. This means you won't get notified for outdated versions properly when using Dependabot

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.

_Checked because documentation does not need updating and it's a minor change._