### PR TITLE
Upgrade Roundcube to version 1.6.8 due to XSS vulnerabilities

### DIFF
--- a/towncrier/newsfragments/3357.bugfix
+++ b/towncrier/newsfragments/3357.bugfix
@@ -1,0 +1,1 @@
+Updated roundcube to version 1.6.8

--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -28,7 +28,7 @@ RUN set -euxo pipefail \
   ; mkdir -p /run/nginx /conf
 
 # roundcube
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.7/roundcubemail-1.6.7-complete.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.8/roundcubemail-1.6.8-complete.tar.gz
 ENV CARDDAV_URL https://github.com/mstilkerich/rcmcarddav/releases/download/v5.1.0/carddav-v5.1.0.tar.gz
 
 RUN set -euxo pipefail \


### PR DESCRIPTION
## What type of PR?

Bug-fix

## What does this PR do?
Fixes reported XSS vulnerabilities by updating to the latest roundcube release

### Related issue(s)
See [Roundcube Release Information](https://github.com/roundcube/roundcubemail/releases/tag/1.6.8)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
