### PR TITLE
Update to Roundcube 1.6.9

### DIFF
--- a/towncrier/newsfragments/3389.misc
+++ b/towncrier/newsfragments/3389.misc
@@ -1,0 +1,1 @@
+Update roundcube to 1.6.9

--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -28,7 +28,7 @@ RUN set -euxo pipefail \
   ; mkdir -p /run/nginx /conf
 
 # roundcube
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.8/roundcubemail-1.6.8-complete.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.9/roundcubemail-1.6.9-complete.tar.gz
 ENV CARDDAV_URL https://github.com/mstilkerich/rcmcarddav/releases/download/v5.1.0/carddav-v5.1.0.tar.gz
 
 RUN set -euxo pipefail \


### PR DESCRIPTION
## What type of PR?

Recommended update to roundcube

## What does this PR do?

This is the next service release to update the stable version 1.6.
It provides two regression fixes that were introduced in from the previous release.

This version is considered stable and it is recommended to update all productive installations of Roundcube with it.

See [here](https://github.com/roundcube/roundcubemail/releases/tag/1.6.9) for further details

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
