### PR TITLE
Fix 3420 - fixed syntax errors in certwatcher.py

### DIFF
--- a/core/nginx/certwatcher.py
+++ b/core/nginx/certwatcher.py
@@ -27,9 +27,9 @@ class ChangeHandler(FileSystemEventHandler):
         if exists("/var/run/nginx.pid"):
             print("Reloading a running nginx")
             system("nginx -s reload")
-        if os.path.exists("/run/dovecot/master.pid"):
+        if exists("/run/dovecot/master.pid"):
             print("Reloading a running dovecot")
-            os.system("doveadm reload")
+            system("doveadm reload")
 
     @staticmethod
     def reexec_config():

--- a/towncrier/newsfragments/3420.bugfix
+++ b/towncrier/newsfragments/3420.bugfix
@@ -1,0 +1,1 @@
+The reload functionality of nginx/dovecot upon change of the certificates failed with an error.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?
Fixes syntax errors in certwatcher.py that resulted in dovecot not being restarted upon detection of changed certificate files.

### Related issue(s)
- Auto close an issue like: closes #3420 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
