### PR TITLE
Fix #3531

### DIFF
--- a/core/nginx/letsencrypt.py
+++ b/core/nginx/letsencrypt.py
@@ -20,6 +20,7 @@ command = [
     "--preferred-challenges", "http", "--http-01-port", "8008",
     "--keep-until-expiring",
     "--allow-subset-of-names",
+    "--key-type", "rsa",
     "--renew-with-new-domains",
     "--config-dir", "/certs/letsencrypt",
     "--post-hook", "/config.py"

--- a/towncrier/newsfragments/3531.bugfix
+++ b/towncrier/newsfragments/3531.bugfix
@@ -1,0 +1,1 @@
+Ensure we have both RSA and ECDSA certs when using letsencrypt


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Ensure we have both RSA and ECDSA certs when using letsencrypt now that the default behaviour from certbot has changed.
This is only important for new installs, not those renewing existing certs.

### Related issue(s)
- closes #3531

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
