### PR TITLE
fail2ban: improve limiter regex, add failed logins regex

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -671,6 +671,7 @@ Please note that the provided example will block the subnet from sending any ema
   # Fail2Ban configuration file
   [Definition]
   failregex = ^\s?\S+ mailu\-admin\[\d+\]: \[\S+ \S+\] WARNING in limiter: Authentication attempt from <HOST>(?: for (?:[^ ]+@[^ ]+))? has been rate-limited\.$
+              ^\s?\S+ mailu\-admin\[\d+\]: \[\S+ \S+\] INFO in base: Login attempt for:(?: [^ ]+@[^ ]+) from: <HOST>\/None: failed: badauth:.*$
   ignoreregex =
   journalmatch = CONTAINER_TAG=mailu-admin
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -670,7 +670,7 @@ Please note that the provided example will block the subnet from sending any ema
 
   # Fail2Ban configuration file
   [Definition]
-  failregex = : Authentication attempt from <HOST>(?: for (?:[^ ]+@[^ ]+))? has been rate-limited\.$
+  failregex = ^\s?\S+ mailu\-admin\[\d+\]: \[\S+ \S+\] WARNING in limiter: Authentication attempt from <HOST>(?: for (?:[^ ]+@[^ ]+))? has been rate-limited\.$
   ignoreregex =
   journalmatch = CONTAINER_TAG=mailu-admin
 


### PR DESCRIPTION
## What type of PR?

Minor FAQ update

## What does this PR do?

Improving fail2ban FAQ section. Namely, to:

- improve existing regex for rate limiter, matching the approach used for the failregex example of mailu-front
- add a new regex to match failed logins independent of rate-limiting.

### Related issue(s)
- None
