### PR TITLE
Upgrade snappymail to v2.38.2

### DIFF
--- a/towncrier/newsfragments/3648.bugfix
+++ b/towncrier/newsfragments/3648.bugfix
@@ -1,1 +1,1 @@
-Upgrade snappymail to v2.38.1 ; this is a security fix for GHSA-2rq7-79vp-ffxm (mXSS)
+Upgrade snappymail to v2.38.2 ; this is a security fix for GHSA-2rq7-79vp-ffxm (mXSS)

--- a/towncrier/newsfragments/3648.bugfix
+++ b/towncrier/newsfragments/3648.bugfix
@@ -1,0 +1,1 @@
+Upgrade snappymail to v2.38.1 ; this is a security fix for GHSA-2rq7-79vp-ffxm (mXSS)

--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -54,7 +54,7 @@ COPY roundcube/config/config.inc.carddav.php /var/www/roundcube/plugins/carddav/
 
 # snappymail
 
-ENV SNAPPYMAIL_URL https://github.com/the-djmaze/snappymail/releases/download/v2.36.4/snappymail-2.36.4.tar.gz
+ENV SNAPPYMAIL_URL https://github.com/the-djmaze/snappymail/releases/download/v2.38.2/snappymail-2.38.2.tar.gz
 
 RUN set -euxo pipefail \
   ; mkdir  /var/www/snappymail \


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Upgrade snappymail to v2.38.2. This is a security fix for [GHSA-2rq7-79vp-ffxm](https://github.com/the-djmaze/snappymail/security/advisories/GHSA-2rq7-79vp-ffxm) (mXSS)

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
