### PR TITLE
Don't check empty passwords against HIBP

### DIFF
--- a/core/admin/assets/assets/app.js
+++ b/core/admin/assets/assets/app.js
@@ -21,6 +21,9 @@ function sha1(string) {
 }
 
 function hibpCheck(pwd) {
+    if (pwd === null || pwd === undefined || pwd.length === 0) {
+	    return;
+    }
     // We hash the pwd first
     sha1(pwd).then(function(hash){
         // We send the first 5 chars of the hash to hibp's API

--- a/towncrier/newsfragments/3650.bugfix
+++ b/towncrier/newsfragments/3650.bugfix
@@ -1,0 +1,1 @@
+Don't check empty passwords against HIBP


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Don't check empty passwords against HIBP; Apparently some password managers will trigger a race condition otherwise

### Related issue(s)
- closes #3633

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
