### PR TITLE
feat(webmail): customize php memory limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pip-selfcheck.json
 /.idea
 /.vscode
 qemu-arm-static
+/build/

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -104,7 +104,7 @@ def user(localpart, domain_name, password):
         localpart=localpart,
         domain=domain,
         global_admin=False,
-        change_pw_next_login=True,
+        change_pw_next_login=False,
     )
     user.set_password(password)
     db.session.add(user)
@@ -123,7 +123,7 @@ def password(localpart, domain_name, password):
     user  = models.User.query.get(email)
     if user:
         user.set_password(password)
-        user.change_pw_next_login=True
+        user.change_pw_next_login=False
     else:
         print(f'User {email} not found.')
     db.session.commit()

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -481,3 +481,16 @@ def setmanager(domain_name, user_name='manager'):
     domain.managers.append(manageruser)
     db.session.add(domain)
     db.session.commit()
+
+
+@mailu.command()
+@click.argument('domain_name')
+@with_appcontext
+def gendkim(domain_name):
+    """ Generate dkim key for domain_name
+    """
+    domain = models.Domain.query.get(domain_name) or flask.abort(404)
+    domain.generate_dkim_key()
+    models.db.session.add(domain)
+    models.db.session.commit()
+    print(f"Generated dkim pubkey for {domain_name}:\n{domain.dkim_publickey}")

--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -136,6 +136,7 @@ http {
       add_header X-Content-Type-Options 'nosniff';
       add_header X-Permitted-Cross-Domain-Policies 'none';
       add_header Referrer-Policy 'same-origin';
+      add_header Cet-Header-Server 'Cetmail'
 
       # mozilla autoconfiguration
       location ~ ^/(\.well\-known/autoconfig/)?mail/config\-v1\.1\.xml {

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -160,4 +160,4 @@ LOG_LEVEL=WARNING
 
 # Webmail php settings `memory_limit=` 
 # unit is M
-WEBMAIL_MEMORY_LIMIT=256
+WEBMAIL_MEMORY_LIMIT=128

--- a/docs/compose/.env
+++ b/docs/compose/.env
@@ -157,3 +157,7 @@ LOG_LEVEL=WARNING
 # (AVX2 on x86_64, lrcpc on ARM64), you should consider enabling
 # hardened-malloc earlier by uncommenting this
 # LD_PRELOAD=/usr/lib/libhardened_malloc.so
+
+# Webmail php settings `memory_limit=` 
+# unit is M
+WEBMAIL_MEMORY_LIMIT=256

--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -192,3 +192,7 @@ API_TOKEN={{ api_token }}
 
 # Whether tika should be enabled (scan/OCR email attachements). To enable this feature, recreate the docker-compose.yml file via setup.
 FULL_TEXT_SEARCH_ATTACHMENTS={{ tika_enabled }}
+
+# Webmail php settings `memory_limit=` 
+# unit is M
+WEBMAIL_MEMORY_LIMIT=128

--- a/tests/build.hcl
+++ b/tests/build.hcl
@@ -9,7 +9,7 @@
 # If the env var is not set, then the default value is used
 #-----------------------------------------------------------------------------------------
 variable "DOCKER_ORG" {
-  default = "mailu"
+  default = "cetmail"
 }
 variable "DOCKER_PREFIX" {
   default = ""

--- a/webmails/php.ini
+++ b/webmails/php.ini
@@ -4,6 +4,7 @@ upload_max_filesize = {{ MAX_FILESIZE }}M
 post_max_size = {{ MAX_FILESIZE }}M
 session.auto_start=Off
 mbstring.func_overload=Off
+memory_limit = {{ MEMORY_LIMIT }}M
 file_uploads=On
 error_reporting = E_ALL & ~E_DEPRECATED & ~E_STRICT & ~E_NOTICE
 display_errors=Off

--- a/webmails/start.py
+++ b/webmails/start.py
@@ -18,6 +18,7 @@ context = {}
 context.update(env)
 
 context["MAX_FILESIZE"] = str(int(int(env.get("MESSAGE_SIZE_LIMIT", "50000000")) * 0.66 / 1048576))
+context["MEMORY_LIMIT"] = str(int(env.get("WEBMAIL_MEMORY_LIMIT", "256")))
 
 # Get the first DNS server
 with open("/etc/resolv.conf") as handle:

--- a/webmails/start.py
+++ b/webmails/start.py
@@ -18,7 +18,7 @@ context = {}
 context.update(env)
 
 context["MAX_FILESIZE"] = str(int(int(env.get("MESSAGE_SIZE_LIMIT", "50000000")) * 0.66 / 1048576))
-context["MEMORY_LIMIT"] = str(int(env.get("WEBMAIL_MEMORY_LIMIT", "256")))
+context["MEMORY_LIMIT"] = str(int(env.get("WEBMAIL_MEMORY_LIMIT", "128")))
 
 # Get the first DNS server
 with open("/etc/resolv.conf") as handle:


### PR DESCRIPTION
## What type of PR?

Feature: Customize php setting: `memory_limit` for webmail container.

## What does this PR do?

### Related issue(s)

When there are a large number of emails, the webmail container fails to boot because of insufficent memory.

## Prerequisites

Add a new variable `WEBMAIL_MEMORY_LIMIT` in `mailu.env`
