### PR TITLE
Ensure mobileconfig has the right content-type

### DIFF
--- a/core/admin/mailu/internal/views/autoconfig.py
+++ b/core/admin/mailu/internal/views/autoconfig.py
@@ -180,4 +180,4 @@ def autoconfig_apple():
 <integer>1</integer>
 </dict>
 </plist>\r\n'''
-    return flask.Response(xml, mimetype='text/xml', status=200)
+    return flask.Response(xml, content_type='application/x-apple-aspen-config', status=200)

--- a/towncrier/newsfragments/3690.bugfix
+++ b/towncrier/newsfragments/3690.bugfix
@@ -1,0 +1,1 @@
+Ensure the apple mobileconfig is served with the appropriate content-type


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Ensure Apple mobileconfig is served using the right Content-Type

### Related issue(s)
- #3684

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
