### PR TITLE
Include sensible error messages for LMTP protocol

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -14,6 +14,7 @@ STATUSES = {
         "imap": "AUTHENTICATIONFAILED",
         "smtp": "535 5.7.8",
         "submission": "535 5.7.8",
+        "lmtp": "535 5.7.8",
         "pop3": "-ERR Authentication failed",
         "sieve": "AuthFailed"
     }),
@@ -21,6 +22,7 @@ STATUSES = {
         "imap": "PRIVACYREQUIRED",
         "smtp": "530 5.7.0",
         "submission": "530 5.7.0",
+        "lmtp": "530 5.7.0",
         "pop3": "-ERR Authentication canceled.",
         "sieve": "ENCRYPT-NEEDED"
     }),
@@ -28,6 +30,7 @@ STATUSES = {
         "imap": "LIMIT",
         "smtp": "451 4.3.2",
         "submission": "451 4.3.2",
+        "lmtp": "451 4.3.2",
         "pop3": "-ERR [LOGIN-DELAY] Retry later",
         "sieve": "AuthFailed"
     }),

--- a/towncrier/newsfragments/3696.bugfix
+++ b/towncrier/newsfragments/3696.bugfix
@@ -1,0 +1,1 @@
+Include error messages for LMTP


### PR DESCRIPTION
Running into the rate limit yields difficult to debug log messages by the smtp container. Specifically the `Temporary user lookup failure` message by the smtp container is misleading.

## Example

Although this is running on Podman, the bugs are in the Python code and almost certainly are not influenced by the host infrastructure. (Leaving aside that I likely have a configuration problem, because the client IP address is not passed along correctly. But the present fix applies nevertheless and is not related to any specific cause of the rate limit triggering.) 

### smtp logs

```shell
> podman logs --since "2024-12-25T07:33:31" --until "2024-12-25T07:33:33" systemd-mail-smtp
Dec 25 08:33:31 example postfix/smtpd[398]: connect from front[10.115.0.96]
INFO:root:Connect
Dec 25 08:33:31 example postfix/smtpd[398]: 6774324DE71C1: client=systemd-mail-front[10.115.0.96]
INFO:root:Connect
Dec 25 08:33:31 example postfix/cleanup[428]: 6774324DE71C1: message-id=<CAPhkJv+GTxVtwn6eNbBzPscohn6fgkhrYd2gEpUm2prr-5_7bg@mail.gmail.com>
Dec 25 08:33:32 example postfix/qmgr[376]: 6774324DE71C1: from=<SRS0=O1up=TS=gmail.com=fabiamos@example.com>, size=3968, nrcpt=1 (queue active)
Dec 25 08:33:32 example postfix/lmtp[429]: 6774324DE71C1: host front[10.115.0.96] said: 451 4.3.0 <fabian@example.com> Temporary user lookup failure (in reply to RCPT TO command)
Dec 25 08:33:32 example postfix/lmtp[429]: connect to front[10.115.0.9]:2525: Connection refused
Dec 25 08:33:32 example postfix/lmtp[429]: 6774324DE71C1: to=<fabian@example.com>, orig_to=<me+fancy@example.com>, relay=none, delay=0.63, delays=0.61/0.01/0.01/0, dsn=4.4.1, status=deferred (connect to front[10.115.0.9]:2525: Connection refused)
```

### admin logs

```shell
> podman logs --since "2024-12-25T07:33:31" --until "2024-12-25T07:33:33" systemd-mail-admin
10.115.0.96 - - [25/Dec/2024:08:33:31 +0100] "GET /internal/auth/email HTTP/1.0" 200 0 "-" "-"
[2024-12-25 08:33:32,030] WARNING in limiter: Authentication attempt from 10.115.0.99 has been rate-limited.
[2024-12-25 08:33:32,030] ERROR in app: Exception on /internal/auth/email [GET]
Traceback (most recent call last):
  File "/app/venv/lib/python3.12/site-packages/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.12/site-packages/flask/app.py", line 882, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.12/site-packages/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/venv/lib/python3.12/site-packages/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/mailu/internal/views/auth.py", line 27, in nginx_authentication
    status, code = nginx.get_status(flask.request.headers['Auth-Protocol'], 'ratelimit')
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/mailu/internal/nginx.py", line 140, in get_status
    return status, codes[protocol]
                   ~~~~~^^^^^^^^^^
KeyError: 'lmtp'
10.115.0.96 - - [25/Dec/2024:08:33:32 +0100] "GET /internal/auth/email HTTP/1.0" 200 0 "-" "-"
```

## What type of PR?

bug-fix

## What does this PR do?

### Related issue(s)
None

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly - not an enhancement
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file. - is a minor change
