### PR TITLE
Add the mariadb connector as per 3449

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -53,7 +53,7 @@ ENV \
 
 RUN set -euxo pipefail \
   ;  machine="$(uname -m)" \
-  ; deps="build-base gcc libffi-dev python3-dev" \
+  ; deps="build-base gcc libffi-dev python3-dev mariadb-dev" \
   ; [[ "${machine}" != x86_64 ]] && \
       deps="${deps} cargo git libretls-dev mariadb-connector-c-dev postgresql-dev" \
   ; apk add --virtual .build-deps ${deps} \

--- a/core/base/requirements-dev.txt
+++ b/core/base/requirements-dev.txt
@@ -22,6 +22,7 @@ gunicorn
 idna
 itsdangerous
 limits
+mariadb
 marshmallow
 marshmallow-sqlalchemy
 mysql-connector-python

--- a/core/base/requirements-prod.txt
+++ b/core/base/requirements-prod.txt
@@ -42,6 +42,7 @@ jsonschema==4.22.0
 jsonschema-specifications==2023.12.1
 limits==3.11.0
 Mako==1.3.3
+mariadb==1.1.11
 MarkupSafe==2.1.5
 marshmallow==3.21.2
 marshmallow-sqlalchemy==1.0.0

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -986,3 +986,13 @@ Below are the steps for writing the postfix (mail) logs to a log file on the fil
   if [ -d /run/systemd/system ]; then
       systemctl kill -s HUP rsyslog.service
   fi
+
+
+Admin container fails to connect to external MariaDB database
+`````````````````````````````````````````````````````````````
+
+If the admin container is `unable to connect to an external MariaDB database due to incompatible collation`_, you may need to change the ``SQLALCHEMY_DATABASE_URI`` setting to ensure the right connector is used.
+
+MariaDB has no support for utf8mb4_0900_ai_ci which is the new default since MySQL version 8.0.
+
+.. _`unable to connect to an external MariaDB database due to incompatible collation`: https://github.com/Mailu/Mailu/issues/3449

--- a/towncrier/newsfragments/3449.bugfix
+++ b/towncrier/newsfragments/3449.bugfix
@@ -1,0 +1,1 @@
+Add the mariadb connector, as per #3449


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Add the mariadb connector as per #3449.

MariaDB has no support for utf8mb4_0900_ai_ci which is the new default since MySQL version 8.0. In the current sqlalchemy version shipped with mailu, the mysqlconnector sets utf8mb4_0900_ai_ci as the collation to use when connecting. This causes all MariaDB connections to fail.

To fix the issue, either use the right connector or ensure it's configured with the right collation:
```
SQLALCHEMY_DATABASE_URI=mysql+mysqlconnector://<user>:<passwd>@<host>/<database>?collation=utf8mb4_unicode_ci
```

### Related issue(s)
- closes #3449

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
