### PR TITLE
Ensure we always use Mailu for sending emails in thunderbird

### DIFF
--- a/core/admin/mailu/internal/views/autoconfig.py
+++ b/core/admin/mailu/internal/views/autoconfig.py
@@ -31,7 +31,7 @@ def autoconfig_mozilla():
 <username>%EMAILADDRESS%</username>
 <authentication>password-cleartext</authentication>
 <addThisServer>true</addThisServer>
-<useGlobalPreferredServer>true</useGlobalPreferredServer>
+<useGlobalPreferredServer>false</useGlobalPreferredServer>
 </outgoingServer>
 
 <documentation url="https://{hostname}/admin/client">

--- a/tests/compose/core/05_connectivity.py
+++ b/tests/compose/core/05_connectivity.py
@@ -119,7 +119,7 @@ def test_managesieve(server, username, password):
     except managesieve.MANAGESIEVE.abort:
         pass
 
-    m=managesieve.MANAGESIEVE(server, use_tls=True)
+    m=managesieve.MANAGESIEVE(server, use_tls=True, tls_verify=False)
     if m.login('', username, 'wrongpass') != 'NO':
         print(f'Authenticating to sieve://{username}:{password}@{server}:4190/ with wrong creds has worked!')
         sys.exit(108)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
 docker==7.0.0
 colorama==0.4.6
-managesieve==0.7.1
+managesieve==0.8
 requests==2.31.0

--- a/towncrier/newsfragments/3721.bugfix
+++ b/towncrier/newsfragments/3721.bugfix
@@ -1,0 +1,1 @@
+autoconfig shouldn't set useGlobalPreferredServer


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Set useGlobalPreferredServer=false in autoconfig to ensure we always use Mailu's SMTP if there is more than one account configured.

The previous behaviour made no sense; it was set that way because the template at https://wiki.mozilla.org/Thunderbird:Autoconfiguration:ConfigFileFormat makes it the default.

### Related issue(s)
- close #3721

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
