### PR TITLE
Allow setting collation via env variable and add uvloop

### DIFF
--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -25,6 +25,7 @@ DEFAULT_CONFIG = {
     'DB_PW': None,
     'DB_HOST': 'database',
     'DB_NAME': 'mailu',
+    'DB_APPENDIX': '',
     'SQLITE_DATABASE_FILE': 'data/main.db',
     'SQLALCHEMY_DATABASE_URI': 'sqlite:////data/main.db',
     'SQLALCHEMY_DATABASE_URI_ROUNDCUBE': 'sqlite:////data/roundcube.db',
@@ -102,8 +103,8 @@ class ConfigManager:
 
     DB_TEMPLATES = {
         'sqlite': 'sqlite:////{SQLITE_DATABASE_FILE}',
-        'postgresql': 'postgresql://{DB_USER}:{DB_PW}@{DB_HOST}/{DB_NAME}',
-        'mysql': 'mysql+mysqlconnector://{DB_USER}:{DB_PW}@{DB_HOST}/{DB_NAME}',
+        'postgresql': 'postgresql://{DB_USER}:{DB_PW}@{DB_HOST}/{DB_NAME}{DB_APPENDIX}',
+        'mysql': 'mysql+mysqlconnector://{DB_USER}:{DB_PW}@{DB_HOST}/{DB_NAME}{DB_APPENDIX}',
     }
 
     def __init__(self):

--- a/core/base/requirements-dev.txt
+++ b/core/base/requirements-dev.txt
@@ -46,6 +46,7 @@ watchdog
 
 # core/postfix
 postfix-mta-sts-resolver
+uvloop
 
 # core/oletools
 python-magic
@@ -56,4 +57,3 @@ requests
 
 # optional/radicale
 radicale
-

--- a/core/base/requirements-prod.txt
+++ b/core/base/requirements-prod.txt
@@ -78,6 +78,7 @@ tabulate==0.9.0
 tenacity==8.2.3
 typing_extensions==4.11.0
 urllib3==2.2.1
+uvloop==0.21.0
 validators==0.28.1
 visitor==0.1.3
 vobject==0.9.7

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -992,6 +992,7 @@ Admin container fails to connect to external MariaDB database
 `````````````````````````````````````````````````````````````
 
 If the admin container is `unable to connect to an external MariaDB database due to incompatible collation`_, you may need to change the ``SQLALCHEMY_DATABASE_URI`` setting to ensure the right connector is used.
+Alternatively, you may set ``DB_APPENDIX`` accordingly. For example: ``?collation=utf8mb4_unicode_ci`` is appended as is just after the database name in case DB_TYPE and related values are set.
 
 MariaDB has no support for utf8mb4_0900_ai_ci which is the new default since MySQL version 8.0.
 

--- a/towncrier/newsfragments/3729.misc
+++ b/towncrier/newsfragments/3729.misc
@@ -1,0 +1,1 @@
+Add optional DB_APPENDIX configuration parameter which is appended as is to the postgresql or mysql URI


### PR DESCRIPTION
## What type of PR?

Enhancement / Bugfix

## What does this PR do?

As of https://github.com/Mailu/Mailu/pull/3701, the collation shall be set by overwriting `SQLALCHEMY_DATABASE_URI` to contain the collation of the related DB. However, this is currently not possible in the Helm chart of Mailu at all. It's statically set there and would also require not setting DB_NAME etc. to not have it overwritten, see https://github.com/Mailu/Mailu/blob/master/core/admin/mailu/configuration.py#L144

Additionally, uvloop is added to the prod requirements of which postfix-mta-sts-resolver makes use of.

### Related issue(s)
- Mention an issue like: #3449 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ x ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
