### PR TITLE
Fix `clamav` path to allow for updates

### DIFF
--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -217,7 +217,7 @@ services:
   # Optional services
   {% if antivirus_enabled %}
   antivirus:
-    image: clamav/clamav-debian:1.2.3-45
+    image: clamav/clamav-debian:1.4.1-16
     restart: always
     logging:
       driver: journald
@@ -226,7 +226,7 @@ services:
     networks:
       - clamav
     volumes:
-      - "{{ root }}/filter/clamav:/var/lib/clamav"
+      - "{{ root }}/clamav:/var/lib/clamav"
     healthcheck:
       test: ["CMD-SHELL", "kill -0 `cat /tmp/clamd.pid` && kill -0 `cat /tmp/freshclam.pid`"]
       interval: 10s

--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -217,7 +217,7 @@ services:
   # Optional services
   {% if antivirus_enabled %}
   antivirus:
-    image: clamav/clamav-debian:1.4.1-16
+    image: clamav/clamav-debian:1.4
     restart: always
     logging:
       driver: journald

--- a/tests/compose/filters/docker-compose.yml
+++ b/tests/compose/filters/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     networks:
       - clamav
     volumes:
-      - "/mailu/filter/clamav:/var/lib/clamav"
+      - "/mailu/clamav:/var/lib/clamav"
     healthcheck:
       test: ["CMD-SHELL", "kill -0 `cat /tmp/clamd.pid` && kill -0 `cat /tmp/freshclam.pid`"]
       interval: 10s

--- a/towncrier/newsfragments/3735.bugfix
+++ b/towncrier/newsfragments/3735.bugfix
@@ -1,0 +1,7 @@
+Place ClamAV files under `mailu/clamav` instead of `mailu/filter/clamav` such that they can be modified by ClamAV
+itself.
+
+Users will want to change their `docker-compose.yml` accordingly and remove `mailu/filter/clamav` after upgrade.
+
+Also ClamAV image tag increased to `1.4` instead of specific (older) release, users will need to update it manually as
+well and keep it updated over time.


### PR DESCRIPTION
## What type of PR?

Bug-fix, documentation

## What does this PR do?

### Related issue(s)
Closes https://github.com/Mailu/Mailu/issues/3673 by placing ClamAV files under `mailu/clamav` instead of `mailu/filter/clamav`.

Users will want to change their `docker-compose.yml` accordingly and remove `mailu/filter/clamav` after upgrade.

I also updated ClamAV version while I was at it (I didn't find any breaking changes in the changelog), though [the latest release is not pushed to this image yet](https://github.com/Cisco-Talos/clamav/issues/1442). Also I'm wondering why is it using exact version instead of `:1` or `:1.4` for example, but decided to not change that to make it less controversial.

## Prerequisites
This will not affect existing setups, though it would be nice to notify users somehow.

<!-- Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file. -->