### PR TITLE
Fixed "core" Docker image to allow x86_32 building, updated documenta…

### DIFF
--- a/core/base/Dockerfile
+++ b/core/base/Dockerfile
@@ -15,7 +15,7 @@ RUN set -euxo pipefail \
   ; addgroup -Sg ${MAILU_GID} mailu \
   ; adduser -Sg ${MAILU_UID} -G mailu -h /app -g "mailu app" -s /bin/bash mailu \
   ; apk add --no-cache bash ca-certificates curl python3 tzdata \
-  ; ! [[ "$(uname -m)" == x86_64 ]] \
+  ; ! [[ "$(apk --print-arch)" == x86_64 ]] \
     || apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing hardened-malloc
 
 WORKDIR /app
@@ -52,10 +52,10 @@ ENV \
   SNUFFLEUPAGUS_URL="https://github.com/jvoisin/snuffleupagus/archive/refs/tags/v${SNUFFLEUPAGUS_VERSION}.tar.gz"
 
 RUN set -euxo pipefail \
-  ;  machine="$(uname -m)" \
+  ;  machine="$(apk --print-arch)" \
   ; deps="build-base gcc libffi-dev python3-dev mariadb-dev" \
   ; [[ "${machine}" != x86_64 ]] && \
-      deps="${deps} cargo git libretls-dev mariadb-connector-c-dev postgresql-dev" \
+      deps="${deps} rust cargo git libretls-dev mariadb-connector-c-dev postgresql-dev" \
   ; apk add --virtual .build-deps ${deps} \
   ; [[ "${machine}" == armv7* ]] && \
       mkdir -p /root/.cargo/registry/index && \

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -996,3 +996,16 @@ If the admin container is `unable to connect to an external MariaDB database due
 MariaDB has no support for utf8mb4_0900_ai_ci which is the new default since MySQL version 8.0.
 
 .. _`unable to connect to an external MariaDB database due to incompatible collation`: https://github.com/Mailu/Mailu/issues/3449
+
+Why is Rspamd giving me an "Illegal instruction" error ?
+`````````````````````````````````````````````````````````
+
+On Linux amd64 (x84_64), if the antispam container is crashing and gives you an `Illegal instruction` error, you may have a CPU that lacks support of the ``SSE4.2`` instruction set.
+The more modern and FOSS ``vectorscan`` library used by rspamd superseeded the now closed source Intel ``hyperscan`` library in Alpine Linux, and since August 2024 it requires the ``SSE4.2`` instruction set to work properly.
+
+Pre-2013 Intel Atom CPUs (Like N2800 or D425), Intel pre-Nehalem architectures and AMD pre-Bulldozer architectures does not support ``SSE4.2``.
+
+A workaround to this issue is to use a x86_32 (or i686) version of rspamd, because the ``vectorscan`` library is only used on 64-bit capable systems.
+Note that this may stop working in the future, as 32-bit software support is being progressively dropped.
+
+*Issue reference:* `3713`_.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1000,7 +1000,7 @@ MariaDB has no support for utf8mb4_0900_ai_ci which is the new default since MyS
 Why is Rspamd giving me an "Illegal instruction" error ?
 `````````````````````````````````````````````````````````
 
-On Linux amd64 (x84_64), if the antispam container is crashing and gives you an `Illegal instruction` error, you may have a CPU that lacks support of the ``SSE4.2`` instruction set.
+On Linux amd64 (x84_64), if the antispam container is crashing and gives you an ``Illegal instruction`` error, you may have a CPU that lacks support of the ``SSE4.2`` instruction set.
 The more modern and FOSS ``vectorscan`` library used by rspamd superseeded the now closed source Intel ``hyperscan`` library in Alpine Linux, and since August 2024 it requires the ``SSE4.2`` instruction set to work properly.
 
 Pre-2013 Intel Atom CPUs (Like N2800 or D425), Intel pre-Nehalem architectures and AMD pre-Bulldozer architectures does not support ``SSE4.2``.
@@ -1009,3 +1009,5 @@ A workaround to this issue is to use a x86_32 (or i686) version of rspamd, becau
 Note that this may stop working in the future, as 32-bit software support is being progressively dropped.
 
 *Issue reference:* `3713`_.
+
+.. _`3713`: https://github.com/Mailu/Mailu/issues/3713

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1003,7 +1003,10 @@ Why is Rspamd giving me an "Illegal instruction" error ?
 On Linux amd64 (x84_64), if the antispam container is crashing and gives you an ``Illegal instruction`` error, you may have a CPU that lacks support of the ``SSE4.2`` instruction set.
 The more modern and FOSS ``vectorscan`` library used by rspamd superseeded the now closed source Intel ``hyperscan`` library in Alpine Linux, and since August 2024 it requires the ``SSE4.2`` instruction set to work properly.
 
-Pre-2013 Intel Atom CPUs (Like N2800 or D425), Intel pre-Nehalem architectures and AMD pre-Bulldozer architectures does not support ``SSE4.2``.
+Pre-2013 Intel Atom CPUs (Like N2800 or D425), Intel pre-Nehalem architectures and AMD pre-Bulldozer architectures do not support ``SSE4.2``.
+To check if your CPU supports ``SSE4.2`` you can use this one liner command:
+
+``if grep -q sse4_2 /proc/cpuinfo; then echo "CPU is SSE4.2 Capable"; else echo "CPU is NOT SSE4.2 capable"; fi``
 
 A workaround to this issue is to use a x86_32 (or i686) version of rspamd, because the ``vectorscan`` library is only used on 64-bit capable systems.
 Note that this may stop working in the future, as 32-bit software support is being progressively dropped.

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -22,6 +22,9 @@ linux/arm64v8 or linux/armv7 hardware, so it
 should run on pretty much any cloud server as long as enough power is
 provided.
 
+On x86_64, check that your processor supports the ``SSE4.2`` instruction set.
+For example, pre-2013 Intel Atom CPUs lacks ``SSE4.2`` support. See :ref:`faq`.
+
 You should also have at least a DNS hostname and a DNS name for receiving
 emails. Some instructions are provided on the matter in the article
 :ref:`dns_setup`.


### PR DESCRIPTION
## What type of PR?

bugfix / documentation

## What does this PR do?

Allow building a i686 linux image on a amd64 machine by switching from `uname -m` architecture detection to `apk --print-arch` to better reflect the binary distribution architecture instead of the current Kernel architecture and adding the rust toolchain in dependencies.
Also updated the documentation to mention SSE4.2 requirement and reference to the mailu issue i opened earlier.

I didn't wanted to add any kind of automated building changes in this PR before discussions, as it may add unneeded pressure on mailu pipelines. To solve the issue with rspamd mentioned in #3713, only the `base` and the `antispam` images needs to be rebuilt on i686, and it can be done locally if needed.

### Related issue(s)
- closes #3713 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
