### PR TITLE
Update Roundcube to 1.6.10

### DIFF
--- a/towncrier/newsfragments/3753.misc
+++ b/towncrier/newsfragments/3753.misc
@@ -1,0 +1,1 @@
+Update roundcube to 1.6.10

--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -28,7 +28,7 @@ RUN set -euxo pipefail \
   ; mkdir -p /run/nginx /conf
 
 # roundcube
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.9/roundcubemail-1.6.9-complete.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.10/roundcubemail-1.6.10-complete.tar.gz
 ENV CARDDAV_URL https://github.com/mstilkerich/rcmcarddav/releases/download/v5.1.0/carddav-v5.1.0.tar.gz
 
 RUN set -euxo pipefail \


### PR DESCRIPTION
## What type of PR?

Update

## What does this PR do?

Updates roundcube to the latest version - 1.6.10

The new version of roundcube includes various fixes, is the next service release and considered stable.

The change log can be found [here](https://github.com/roundcube/roundcubemail/releases/)

### Related issue(s)
- None

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
