### PR TITLE
rspamd: Remove obsolete Nixspam RBL

### DIFF
--- a/core/rspamd/Dockerfile
+++ b/core/rspamd/Dockerfile
@@ -14,6 +14,10 @@ RUN set -euxo pipefail \
 COPY conf/ /conf/
 COPY start.py /
 
+# To be removed once https://gitlab.alpinelinux.org/alpine/aports/-/issues/16914 is resolved
+RUN sed -i '179,185d' /etc/rspamd/modules.d/rbl.conf
+RUN sed -i '384,388d' /etc/rspamd/scores.d/rbl_group.conf
+
 RUN echo $VERSION >/version
 
 #EXPOSE 11332/tcp 11334/tcp 11335/tcp

--- a/towncrier/newsfragments/3757.bugfix
+++ b/towncrier/newsfragments/3757.bugfix
@@ -1,0 +1,1 @@
+Remove obsolete Nixspam RBL (workaround until [Alpine upstream issue](https://gitlab.alpinelinux.org/alpine/aports/-/issues/16914) was resolved)


### PR DESCRIPTION

## What type of PR?

Bugfix / Workaround

## What does this PR do?
The Nixspam RBL has been shut down in mid-January and has been removed from rspamds since, but no release with this removal was created. Since Nixspams' provider has started sending abuse reports to the hosting providers of servers who are still issuing requests to this RBL, remove it from the default config here until Alpine does it in the upstream package.

This change should be rolled back once the upstream package was fixed.

### Related issue(s)
Closes: #3757
See-Also: https://gitlab.alpinelinux.org/alpine/aports/-/issues/16914

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
