### PR TITLE
download zonefile including the dns entries of the alternative domains

### DIFF
--- a/core/admin/mailu/ui/views/domains.py
+++ b/core/admin/mailu/ui/views/domains.py
@@ -81,8 +81,18 @@ def domain_download_zonefile(domain_name):
         txt = ' '.join(f'"{txt[p:p+250]}"' for p in range(0, len(txt), 250))
         res.append(f'{record} {txt}')
         res.append(domain.dns_dmarc)
+        res.append(domain.dns_dmarc_report)
     res.extend(domain.dns_tlsa)
     res.extend(domain.dns_autoconfig)
+    for alternative in domain.alternatives:
+        res.extend([alternative.dns_mx, alternative.dns_spf])
+        if alternative.domain.dkim_publickey:
+            record = alternative.dns_dkim.split('"', 1)[0].strip()
+            txt = f'v=DKIM1; k=rsa; p={alternative.domain.dkim_publickey}'
+            txt = ' '.join(f'"{txt[p:p+250]}"' for p in range(0, len(txt), 250))
+            res.append(f'{record} {txt}')
+            res.append(alternative.dns_dmarc)
+            res.append(alternative.dns_dmarc_report)
     res.append("")
     return flask.Response(
         "\n".join(res),


### PR DESCRIPTION
## What type of PR?

feature, bug-fix

## What does this PR do?

### Related issue(s)
- in PR #3350, a list of dns entries for alternative domains was added to the details page; the lines for the alternative domains were missing in the download of the zonefile
- the PR also includes a small bugfix; the zonefile included only one of the two DMARC lines for the main domain; the dmarc report dns entry is now also included for the main domain

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
