### PR TITLE
Add saveState to dataTables, add "∞" to page length

### DIFF
--- a/core/admin/assets/assets/app.js
+++ b/core/admin/assets/assets/app.js
@@ -111,6 +111,8 @@ $('document').ready(function() {
     var d = $(document.documentElement);
     $('.dataTable').DataTable({
         'responsive': true,
+	'stateSave': true,
+	'lengthMenu': [[10, 25, 50, 75, 100, -1], [10, 25, 50, 75, 100, '∞']],
         language: {
             url: d.data('static') + d.attr('lang') + '.json',
         },

--- a/core/admin/assets/assets/app.js
+++ b/core/admin/assets/assets/app.js
@@ -111,8 +111,8 @@ $('document').ready(function() {
     var d = $(document.documentElement);
     $('.dataTable').DataTable({
         'responsive': true,
-	'stateSave': true,
-	'lengthMenu': [[10, 25, 50, 75, 100, -1], [10, 25, 50, 75, 100, '∞']],
+        'stateSave': true,
+        'lengthMenu': [[10, 25, 50, 75, 100, -1], [10, 25, 50, 75, 100, '∞']],
         language: {
             url: d.data('static') + d.attr('lang') + '.json',
         },


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Add saveState to dataTables, so that the selected page length and sort direction(s) will be saved for the individual tables. Add "∞" option to the page length menu to display all table entries.

### Related issue(s)
none

## Prerequisites
considered as minor change, please notify, if not. Thanks
