### PR TITLE
Update Dockerfile

### DIFF
--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -17,7 +17,7 @@ ARG VERSION
 LABEL version=$VERSION
 
 RUN set -euxo pipefail \
-  ; apk add --no-cache certbot nginx nginx-mod-http-brotli nginx-mod-mail openssl \
+  ; apk add --no-cache certbot nginx nginx-mod-http-brotli nginx-mod-mail openssl nginx-mod-stream \
   ; apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main dovecot-lua dovecot-pigeonhole-plugin 'dovecot-lmtpd<2.4' dovecot-pop3d dovecot-submissiond
 
 COPY conf/ /conf/


### PR DESCRIPTION
missing  `nginx-mod-stream` on line 20 causes container to fail to start compleltely as described in https://github.com/Mailu/Mailu/issues/3777

## What type of PR?
bug-fix

## What does this PR do?
missing  `nginx-mod-stream` on line 20 causes container to fail to start completely as described in https://github.com/Mailu/Mailu/issues/3777

### Related issue(s)
closes #3777 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
