### PR TITLE
Update Dockerfile

### DIFF
--- a/core/nginx/Dockerfile
+++ b/core/nginx/Dockerfile
@@ -17,7 +17,7 @@ ARG VERSION
 LABEL version=$VERSION
 
 RUN set -euxo pipefail \
-  ; apk add --no-cache certbot nginx nginx-mod-http-brotli nginx-mod-mail openssl dovecot-lua dovecot-pigeonhole-plugin 'dovecot-lmtpd<2.4' dovecot-pop3d dovecot-submissiond
+  ; apk add --no-cache certbot nginx nginx-mod-http-brotli nginx-mod-mail nginx-mod-stream openssl dovecot-lua dovecot-pigeonhole-plugin 'dovecot-lmtpd<2.4' dovecot-pop3d dovecot-submissiond
 
 COPY conf/ /conf/
 COPY --from=static /static/ /static/


### PR DESCRIPTION
missing nginx-mod-stream on line 20 causes container to fail to start completely as described in #3777

## What type of PR?
bug-fix

## What does this PR do?
missing nginx-mod-stream on line 20 causes container to fail to start completely as described in https://github.com/Mailu/Mailu/issues/3777

### Related issue(s)
closes #3777 

## Prerequisites
none