### PR TITLE
Bugfix rspamd config errors

### DIFF
--- a/core/rspamd/conf/external_services.conf
+++ b/core/rspamd/conf/external_services.conf
@@ -3,9 +3,6 @@ oletools {
   # default olefy settings
   servers = "{{ OLETOOLS_ADDRESS }}:11343";
 
-  # symbol to add (add it to metric if you want non-zero weight)
-  symbol = "OLETOOLS";
-
   # needs to be set explicitly for Rspamd < 1.9.5
   scan_mime_parts = true;
   extended = true;

--- a/core/rspamd/conf/external_services.conf
+++ b/core/rspamd/conf/external_services.conf
@@ -1,7 +1,10 @@
 {% if SCAN_MACROS %}
 oletools {
   # default olefy settings
-  servers = "{{ OLETOOLS_ADDRESS }}:11343"
+  servers = "{{ OLETOOLS_ADDRESS }}:11343";
+
+  # symbol to add (add it to metric if you want non-zero weight)
+  symbol = "OLETOOLS";
 
   # needs to be set explicitly for Rspamd < 1.9.5
   scan_mime_parts = true;

--- a/core/rspamd/conf/external_services.conf
+++ b/core/rspamd/conf/external_services.conf
@@ -3,6 +3,9 @@ oletools {
   # default olefy settings
   servers = "{{ OLETOOLS_ADDRESS }}:11343";
 
+  # symbol to add (add it to metric if you want non-zero weight)
+  symbol = "OLETOOLS";
+
   # needs to be set explicitly for Rspamd < 1.9.5
   scan_mime_parts = true;
   extended = true;

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -18,13 +18,13 @@ rules {
     action = "reject";
     expression = "CLAM_VIRUS | OLETOOLS_MACRO_MRAPTOR | OLETOOLS_MACRO_SUSPICIOUS";
     message = "Rejected (dangerous/malicious code detected)";
-    honor_action = "reject"
+    honor_action = ["discard", "reject"];
   }
   ANTIVIRUS_FAILED {
     action = "soft reject";
     expression = "CLAM_VIRUS_FAIL | OLETOOLS_FAIL";
     message = "Please retry later (anti-virus/oletools not ready)";
-    honor_action = "soft reject"
+    honor_action = ["discard", "reject", "soft reject"];
   }
 }
 .include(try=true,priority=1,duplicate=merge) "/overrides/force_actions.conf"

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -18,11 +18,13 @@ rules {
     action = "reject";
     expression = "CLAM_VIRUS | OLETOOLS_MACRO_MRAPTOR | OLETOOLS_MACRO_SUSPICIOUS";
     message = "Rejected (dangerous/malicious code detected)";
+    honor_action = "reject"
   }
   ANTIVIRUS_FAILED {
     action = "soft reject";
     expression = "CLAM_VIRUS_FAIL | OLETOOLS_FAIL";
     message = "Please retry later (anti-virus/oletools not ready)";
+    honor_action = "soft reject"
   }
 }
 .include(try=true,priority=1,duplicate=merge) "/overrides/force_actions.conf"

--- a/core/rspamd/conf/force_actions.conf
+++ b/core/rspamd/conf/force_actions.conf
@@ -16,15 +16,18 @@ rules {
   }
   ANTIVIRUS_FLAGGED {
     action = "reject";
-    expression = "CLAM_VIRUS | OLETOOLS_MACRO_MRAPTOR | OLETOOLS_MACRO_SUSPICIOUS";
+    expression = "CLAM_VIRUS";
     message = "Rejected (dangerous/malicious code detected)";
-    honor_action = ["discard", "reject"];
+  }
+  OLETOOLS_DANGEROUS {
+    action = "reject";
+    expression = "((OLETOOLS_A & OLETOOLS_W) | (OLETOOLS_A & OLETOOLS_X) | (OLETOOLS_W & OLETOOLS_X)) | OLETOOLS_FLAG | OLETOOLS_VBASTOMP | OLETOOLS_A";
+    message = "Rejected (dangerous macro detected)";
   }
   ANTIVIRUS_FAILED {
     action = "soft reject";
     expression = "CLAM_VIRUS_FAIL | OLETOOLS_FAIL";
     message = "Please retry later (anti-virus/oletools not ready)";
-    honor_action = ["discard", "reject", "soft reject"];
   }
 }
 .include(try=true,priority=1,duplicate=merge) "/overrides/force_actions.conf"

--- a/core/rspamd/conf/worker-controller.inc
+++ b/core/rspamd/conf/worker-controller.inc
@@ -1,4 +1,3 @@
-type = "controller";
 bind_socket = "*:11334";
 password = "mailu";
 secure_ip = "{{ SUBNET }}";

--- a/core/rspamd/conf/worker-fuzzy.inc
+++ b/core/rspamd/conf/worker-fuzzy.inc
@@ -1,4 +1,3 @@
-type = "fuzzy";
 bind_socket = "*:11335";
 count = 1;
 backend = "redis";

--- a/core/rspamd/conf/worker-normal.inc
+++ b/core/rspamd/conf/worker-normal.inc
@@ -1,2 +1,1 @@
-type = "normal";
 enabled = false;

--- a/towncrier/newsfragments/3784.bugfix
+++ b/towncrier/newsfragments/3784.bugfix
@@ -1,0 +1,1 @@
+clean-up config errors in the rspamd module that caused error messages


### PR DESCRIPTION
## What type of PR?

This **bug-fix** addresses configuration errors that show up in the rspamd module.

## What does this PR do?

 When I performed a configdump in the antispam module (e.g., by executing `docker exec mailu-antispam-1 rspamadm configdump mx_check`), I received the following error messages:

```
unknown worker attribute: type; worker type: normal
unknown worker attribute: type; worker type: controller
cannot add dependency from OLETOOLS_MACRO_MRAPTOR on FORCE_ACTION_ANTIVIRUS_FLAGGED: invalid symbol types
cannot add dependency from OLETOOLS_MACRO_SUSPICIOUS on FORCE_ACTION_ANTIVIRUS_FLAGGED: invalid symbol types
cannot add dependency from OLETOOLS_FAIL on FORCE_ACTION_ANTIVIRUS_FAILED: invalid symbol types
```

### Related issue(s)
- the errors were shown as well in issue #3262.
- the bug-fix should also close some of the errors in discussion #3263

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
