### PR TITLE
Upgrade Tika to fix CVE-2025-54988

### DIFF
--- a/setup/flavors/compose/docker-compose.yml
+++ b/setup/flavors/compose/docker-compose.yml
@@ -156,7 +156,7 @@ services:
 
 {% if tika_enabled %}
   fts_attachments:
-    image: apache/tika:2.9.2.1-full
+    image: apache/tika:latest-full
     hostname: tika
     logging:
       driver: journald

--- a/towncrier/newsfragments/3903.bugfix
+++ b/towncrier/newsfragments/3903.bugfix
@@ -1,0 +1,1 @@
+Upgrade Tika to latest to fix CVE-2025-54988 (XXE). You will need to run setup again for the fix to be applied! This is defence in depth rather than something critical as on docker deployments there is no impact.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Upgrade Tika to fix CVE-2025-54988 ; Current stable is v3.2.2 ... we pin latest as we have a poor record of keeping up with upstream and the interface we use ought to be stable.

You will need to run setup again for the fix to be applied.

This is defence in depth (very low risk on docker deployments).

### Related issue(s)
- closes #3903

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
