### PR TITLE
Fix passphrase changed errors in snappymail

### DIFF
--- a/towncrier/newsfragments/3906.bugfix
+++ b/towncrier/newsfragments/3906.bugfix
@@ -1,0 +1,2 @@
+Fix "passphrase changed" errors in snappymail. You may need to run:
+   find webmail/_data_/_default_/storage/ -name .cryptkey -delete

--- a/webmails/snappymail/defaults/application.ini
+++ b/webmails/snappymail/defaults/application.ini
@@ -6,6 +6,7 @@ attachment_size_limit = {{ MAX_FILESIZE }}
 [security]
 allow_admin_panel = Off
 openpgp = On
+insecure_cryptkey = On
 
 [labs]
 allow_gravatar = Off


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix "passphrase changed" errors in snappymail; tell it to encrypt data against the email address instead of the transient token used by SSO.

You may need to run the following for the error message to disappear completely
   ``find webmail/_data_/_default_/storage/ -name .cryptkey -delete``

### Related issue(s)
- closes #3906 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
