### PR TITLE
Fixes around non-blocking I/O in the thread manager

### DIFF
--- a/core/base/libs/socrate/socrate/system.py
+++ b/core/base/libs/socrate/socrate/system.py
@@ -9,6 +9,7 @@ import socket
 import tenacity
 import subprocess
 import threading
+import time
 
 @tenacity.retry(stop=tenacity.stop_after_attempt(100),
                 wait=tenacity.wait_random(min=2, max=5))
@@ -163,12 +164,14 @@ def drop_privs_to(username='mailu'):
 def forward_text_lines(src, dst):
     while True:
         current_line = src.readline()
+        if not current_line:
+            return
         dst.write(current_line)
 
 
 # runs a process and passes its standard/error output to the standard/error output of the current python script
 def run_process_and_forward_output(cmd):
-    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, errors='replace')
 
     stdout_thread = threading.Thread(target=forward_text_lines, args=(process.stdout, sys.stdout))
     stdout_thread.daemon = True
@@ -178,7 +181,11 @@ def run_process_and_forward_output(cmd):
     stderr_thread.daemon = True
     stderr_thread.start()
 
-    rc = process.wait()
-    sys.stdout.flush()
-    sys.stderr.flush()
-    return rc
+    while True:
+        rc = process.poll()
+        if rc is not None or threading.active_count() < 3:
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os._exit(rc if rc > 0 else 143)
+
+        time.sleep(1)

--- a/towncrier/newsfragments/3927.bugfix
+++ b/towncrier/newsfragments/3927.bugfix
@@ -1,0 +1,1 @@
+Fix an edge case in the process scheduler, where stdio handlers would hang and consume 100% CPU each if the process had any children that failed to stop. Also introduces a workaround for handling invalid UTF-8 in logs.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Attempts to fix an issue around blocking I/O in `start.py`. Currently, if a process crashes leaving a zombie thread, `start.py` will use 100% CPU on two threads (trying to read stdout/stderr). This can be reproduced by starting a vanilla Mailu, and running `killall dovecot` (can be outside the container); Dovecot always leaves one zombie thread on crash/exit, so the container *never* restarts. My patch fixes this.

This is related to (closes #3852), although I haven't been able to create a repro for that exact case. Nonetheless, I added `errors='replace'` to the popen invocation, as it should prevent mangling the log output. I've seen a couple more issues that are likely related, but can't find them now.

**Important note**: Despite my efforts, `mailu-front` still seems to connect to the old dovecot process, which renders the UI unusable (webmail throws me into a redirect loop). Restarting `mailu-front` frees up the defunct dovecot process and fixes the application - I suppose someone should look into detecting this condition and restarting `mailu-front` if it happens. Unfortunately, I'm not sure how to approach this.
