### PR TITLE
Remove mail-* flavors from comments and config wizard

### DIFF
--- a/setup/flavors/compose/mailu.env
+++ b/setup/flavors/compose/mailu.env
@@ -26,7 +26,7 @@ HOSTNAMES={{ hostnames }}
 # Postmaster local part (will append the main mail domain)
 POSTMASTER={{ postmaster }}
 
-# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
+# Choose how secure connections will behave (value: letsencrypt, cert, notls)
 TLS_FLAVOR={{ tls_flavor }}
 
 # Authentication rate limit per IP (per /24 on ipv4 and /48 on ipv6)

--- a/setup/templates/steps/config.html
+++ b/setup/templates/steps/config.html
@@ -18,7 +18,7 @@ Or in plain English: if receivers start to classify your mail as spam, this post
   </label>
 <!--   Validates domain name -->
   <input class="form-control" type="text" name="domain" placeholder="e.g. mailu.io"
-  		required pattern="^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$">
+         required pattern="^([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}$">
 </div>
 
 <div class="form-group">
@@ -30,9 +30,9 @@ Or in plain English: if receivers start to classify your mail as spam, this post
   <label>Choose how you wish to handle security <a href="https://mailu.io/{{ version }}/compose/setup.html#tls-certificates">TLS certificates</a></label>
   <br/>
   <select class="btn btn-primary dropdown-toggle" name="tls_flavor">
-  	{% for tlsflavor in ["letsencrypt", "cert", "notls", "mail", "mail-letsencrypt"] %}
-  	<option value="{{ tlsflavor }}" >{{ tlsflavor }}</option>
-  	{% endfor %}
+  {% for tlsflavor in ["letsencrypt", "cert", "notls"] %}
+    <option value="{{ tlsflavor }}" >{{ tlsflavor }}</option>
+  {% endfor %}
   </select>
 </div>
 
@@ -46,8 +46,7 @@ Or in plain English: if receivers start to classify your mail as spam, this post
 <div class="form-group">
   <label>Authentication rate limit per user</label>
   <!--   Validates number input only -->
-  <p><input class="form-control" style="width: 9%; display: inline;" type="number" name="auth_ratelimit_user"
-  		value="50" required > / day
+  <p><input class="form-control" style="width: 9%; display: inline;" type="number" name="auth_ratelimit_user" value="50" required > / day
   </p>
 </div>
 
@@ -74,15 +73,15 @@ Or in plain English: if receivers start to classify your mail as spam, this post
   <label>Linked Website URL</label>
 <!--   Validates url with or without https:// -->
   <input class="form-control" type="url" name="website" value="https://mailu.io" required
-		pattern="^(https?://)?([a-zA-Z0-9]([a-zA-ZäöüÄÖÜ0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$">
+         pattern="^(https?://)?([a-zA-Z0-9]([a-zA-ZäöüÄÖÜ0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$">
 </div>
 
 <p>The admin interface is the main Mailu-specific bit, it provides tools to
 manage your email domains, users, etc.</p>
 
 <div class="form-group">
-    <input type="checkbox" name="admin_enabled" value="true" id="admin" checked>
-  	<label>Enable the admin UI</label>
+  <input type="checkbox" name="admin_enabled" value="true" id="admin" checked>
+  <label>Enable the admin UI</label>
 </div>
 
 <p>The API interface is a RESTful API for changing the Mailu configuration.
@@ -91,11 +90,11 @@ manage your email domains, users, etc.</p>
   It is not possible to use the API without an API token.</p>
 
   <div class="form-group">
-      <input type="checkbox" name="api_enabled" value="true" id="api_enabled" >
-      <label>Enable the API</label>
-      <br>
-      <label name="api_token_label" id="api_token_label">API token</label>
-      <input class="form-control" type="text" name="api_token" id="api_token" style="display: none" value="{{ secret(32) }}">
+    <input type="checkbox" name="api_enabled" value="true" id="api_enabled" >
+    <label>Enable the API</label>
+    <br>
+    <label name="api_token_label" id="api_token_label">API token</label>
+    <input class="form-control" type="text" name="api_token" id="api_token" style="display: none" value="{{ secret(32) }}">
   </div>
 
 {% endcall %}

--- a/tests/compose/api/mailu.env
+++ b/tests/compose/api/mailu.env
@@ -37,7 +37,7 @@ HOSTNAMES=localhost
 # Postmaster local part (will append the main mail domain)
 POSTMASTER=admin
 
-# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
+# Choose how secure connections will behave (value: letsencrypt, cert, notls)
 TLS_FLAVOR=cert
 
 # Authentication rate limit (per source IP address)

--- a/tests/compose/core/mailu.env
+++ b/tests/compose/core/mailu.env
@@ -37,7 +37,7 @@ HOSTNAMES=localhost
 # Postmaster local part (will append the main mail domain)
 POSTMASTER=admin
 
-# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
+# Choose how secure connections will behave (value: letsencrypt, cert, notls)
 TLS_FLAVOR=cert
 
 # Authentication rate limit (per source IP address)

--- a/tests/compose/fetchmail/mailu.env
+++ b/tests/compose/fetchmail/mailu.env
@@ -37,7 +37,7 @@ HOSTNAMES=localhost
 # Postmaster local part (will append the main mail domain)
 POSTMASTER=admin
 
-# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
+# Choose how secure connections will behave (value: letsencrypt, cert, notls)
 TLS_FLAVOR=cert
 
 # Authentication rate limit (per source IP address)

--- a/tests/compose/filters/mailu.env
+++ b/tests/compose/filters/mailu.env
@@ -37,7 +37,7 @@ HOSTNAMES=localhost
 # Postmaster local part (will append the main mail domain)
 POSTMASTER=admin
 
-# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
+# Choose how secure connections will behave (value: letsencrypt, cert, notls)
 TLS_FLAVOR=cert
 
 # Authentication rate limit (per source IP address)

--- a/tests/compose/webdav/mailu.env
+++ b/tests/compose/webdav/mailu.env
@@ -37,7 +37,7 @@ HOSTNAMES=localhost
 # Postmaster local part (will append the main mail domain)
 POSTMASTER=admin
 
-# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
+# Choose how secure connections will behave (value: letsencrypt, cert, notls)
 TLS_FLAVOR=cert
 
 # Authentication rate limit (per source IP address)

--- a/tests/compose/webmail/mailu.env
+++ b/tests/compose/webmail/mailu.env
@@ -37,7 +37,7 @@ HOSTNAMES=localhost
 # Postmaster local part (will append the main mail domain)
 POSTMASTER=admin
 
-# Choose how secure connections will behave (value: letsencrypt, cert, notls, mail, mail-letsencrypt)
+# Choose how secure connections will behave (value: letsencrypt, cert, notls)
 TLS_FLAVOR=cert
 
 # Authentication rate limit (per source IP address)


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?

mail-* flavors removed in a former PR - this removes it from the config wizard and comments.
