### PR TITLE
chore: fix link to charts

### DIFF
--- a/docs/kubernetes/mailu/index.rst
+++ b/docs/kubernetes/mailu/index.rst
@@ -7,5 +7,5 @@ Please see `the Helm Chart documentation`_.
 
 We are looking for maintainers: if you are interested please join our `Matrix`_ room.
 
-.. _`the Helm Chart documentation`: https://github.com/Mailu/helm-charts/blob/master/mailu/README.md
+.. _`the Helm Chart documentation`: https://github.com/Mailu/helm-charts/blob/master/charts/mailu/README.md
 .. _`Matrix`: https://matrix.to/#/#mailu:tedomum.net


### PR DESCRIPTION
charts moved to the charts folder in https://github.com/Mailu/helm-charts/commit/f76c60a540a5693fbadd51e3ce21d47e83106abb

## What type of PR?

documentation

## What does this PR do?
track moved link destination

### Related issue(s)
- the chart was moved in: [#001](https://github.com/Mailu/helm-charts/pull/389)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [X] In case of feature or enhancement: documentation updated accordingly
- [X] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
