### PR TITLE
Reenable nginx request buffering to fix roundcube (backport)

### DIFF
--- a/towncrier/newsfragments/3913.bugfix
+++ b/towncrier/newsfragments/3913.bugfix
@@ -1,0 +1,1 @@
+Re-enable nginx buffering as apparently roundcube is broken without

--- a/webmails/nginx-webmail.conf
+++ b/webmails/nginx-webmail.conf
@@ -60,7 +60,10 @@ server {
         fastcgi_param CONTENT_LENGTH  $content_length;
         fastcgi_param PATH_INFO       $fastcgi_path_info;
 
-        fastcgi_request_buffering off;
+        # unclear why this is required, see #3913
+        fastcgi_buffers 16 32k;
+        fastcgi_buffer_size 64k;
+        fastcgi_busy_buffers_size 64k;
 
         # nginx buffers #
         proxy_buffer_size 128k;


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Re-enable nginx request buffering to fix roundcube

### Related issue(s)
- closes #3913 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
