### PR TITLE
Disallow bots, maybe fix smartscreen FPs?

### DIFF
--- a/core/nginx/conf/nginx.conf
+++ b/core/nginx/conf/nginx.conf
@@ -33,6 +33,10 @@ http {
     {% endfor %}{% endif %}
 
     # Header maps
+    map $http_user_agent $is_bot {
+      default 0;
+      ~*(bot) 1;
+    }
     map $http_x_forwarded_proto $proxy_x_forwarded_proto {
       default $http_x_forwarded_proto;
       ''      $scheme;
@@ -168,6 +172,13 @@ http {
       }
       {% endif %}
 
+      location ^~ /robots.txt {
+        return 200 "User-agent: *\r\nDisallow: /\r\n";
+      }
+      location ^~ /ads.txt {
+        return 200 "placeholder.example.com, placeholder, DIRECT, placeholder\r\n";
+      }
+
       # If TLS is failing, prevent access to anything except certbot
       {% if TLS_ERROR and not (TLS_FLAVOR in [ 'mail-letsencrypt', 'mail' ]) %}
       location / {
@@ -179,17 +190,20 @@ http {
       # Actual logic
       {% if ADMIN or WEBMAIL != 'none' %}
       location ~ ^/(sso|static)/ {
+        if ($is_bot) { return 403; }
         include /etc/nginx/proxy.conf;
         proxy_pass http://$admin;
       }
       {% endif %}
 
       location @sso_login {
+        if ($is_bot) { return 403; }
         return 302 /sso/login?url=$request_uri;
       }
 
       {% if WEB_WEBMAIL != '/' and WEBROOT_REDIRECT != 'none' %}
       location / {
+        if ($is_bot) { return 403; }
         expires $expires;
       {% if WEBROOT_REDIRECT %}
         try_files $uri {{ WEBROOT_REDIRECT }}?homepage;
@@ -201,6 +215,7 @@ http {
 
       {% if WEBMAIL != 'none' %}
       location {{ WEB_WEBMAIL }} {
+        if ($is_bot) { return 403; }
         {% if WEB_WEBMAIL != '/' %}
         rewrite ^({{ WEB_WEBMAIL }})$ $1/ permanent;
         rewrite ^{{ WEB_WEBMAIL }}/(.*) /$1 break;
@@ -216,6 +231,7 @@ http {
       {% else %}
       location {{ WEB_WEBMAIL }}/sso.php {
       {% endif %}
+        if ($is_bot) { return 403; }
         {% if WEB_WEBMAIL != '/' %}
         rewrite ^({{ WEB_WEBMAIL }})$ $1/ permanent;
         rewrite ^{{ WEB_WEBMAIL }}/(.*) /$1 break;
@@ -232,12 +248,14 @@ http {
       {% endif %}
       {% if ADMIN %}
        location {{ WEB_ADMIN }} {
+         if ($is_bot) { return 403; }
          include /etc/nginx/proxy.conf;
          proxy_pass http://$admin;
          expires $expires;
        }
 
       location {{ WEB_ADMIN }}/antispam {
+        if ($is_bot) { return 403; }
         rewrite ^{{ WEB_ADMIN }}/antispam/(.*) /$1 break;
         auth_request /internal/auth/admin;
         proxy_set_header X-Real-IP "";
@@ -250,6 +268,7 @@ http {
 
       {% if WEBDAV != 'none' %}
       location /webdav {
+        if ($is_bot) { return 403; }
         rewrite ^/webdav/(.*) /$1 break;
         auth_request /internal/auth/basic;
         auth_request_set $user $upstream_http_x_user;

--- a/towncrier/newsfragments/3923.misc
+++ b/towncrier/newsfragments/3923.misc
@@ -1,0 +1,2 @@
+Ban all user-agents that contain "bot"; this may help against the smartscreen false positives
+Add a /ads.txt to prevent ads from being bought for the FQDN


### PR DESCRIPTION
## What type of PR?

enhancement

## What does this PR do?

Disallow bots and ads against the Mailu FQDNs; This may help against smartscreen false positives.

See section 3.2.1 of https://iabtechlab.com/wp-content/uploads/2022/04/Ads.txt-1.1.pdf for ``/ads.txt``

I've left out ``/api`` and ``/.well-known`` on purpose

### Related issue(s)
- closes #3923 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
