### PR TITLE
Migrate dovecot auth from dict to lua

### DIFF
--- a/core/dovecot/Dockerfile
+++ b/core/dovecot/Dockerfile
@@ -7,7 +7,7 @@ ARG VERSION
 LABEL version=$VERSION
 
 RUN set -euxo pipefail \
-  ; apk add --no-cache 'dovecot<2.4' dovecot-lmtpd dovecot-pigeonhole-plugin dovecot-pop3d dovecot-submissiond rspamd-client dovecot-fts-flatcurve \
+  ; apk add --no-cache 'dovecot<2.4' dovecot-lua dovecot-lmtpd dovecot-pigeonhole-plugin dovecot-pop3d dovecot-submissiond rspamd-client dovecot-fts-flatcurve lua-json4 \
   ; mkdir /var/lib/dovecot
 
 COPY conf/ /conf/

--- a/core/dovecot/conf/auth.conf
+++ b/core/dovecot/conf/auth.conf
@@ -1,6 +1,0 @@
-uri = proxy:/tmp/podop.socket:auth
-iterate_disable = yes
-iterate_prefix = 'userdb/'
-default_pass_scheme = plain
-password_key = passdb/%u
-user_key = userdb/%u

--- a/core/dovecot/conf/dovecot.conf
+++ b/core/dovecot/conf/dovecot.conf
@@ -101,13 +101,13 @@ auth_mechanisms = plain login
 disable_plaintext_auth = no
 
 passdb {
-  driver = dict
-  args = /etc/dovecot/auth.conf
+  driver = lua
+  args = file=/etc/dovecot/login.lua blocking=yes
 }
 
 userdb {
-  driver = dict
-  args = /etc/dovecot/auth.conf
+  driver = lua
+  args = file=/etc/dovecot/login.lua blocking=yes
 }
 
 service auth {

--- a/core/dovecot/conf/login.lua
+++ b/core/dovecot/conf/login.lua
@@ -1,0 +1,97 @@
+json = require('json')
+
+function script_init()
+    return 0
+end
+
+function script_deinit()
+end
+
+local http_client = dovecot.http.client {
+    timeout = 2000;
+    max_attempts = 3;
+}
+
+function urlEncode(str)
+    return str:gsub("[^%w_.-~]", function(c)
+        return string.format("%%%02X", string.byte(c))
+    end)
+end
+
+function setRequestHeadersFromDovecotRequest(auth_request, req)
+    auth_request:add_header('Auth-Port', req.local_port)
+    local user = urlEncode(req.user)
+    auth_request:add_header('Auth-User', user)
+    if req.password ~= nil
+    then
+        local password = urlEncode(req.password)
+        auth_request:add_header('Auth-Pass', password)
+    end
+    auth_request:add_header('Auth-Protocol', req.service)
+    local client_ip = urlEncode(req.remote_ip)
+    auth_request:add_header('Client-Ip', client_ip)
+    auth_request:add_header('Client-Port', req.remote_port)
+    auth_request:add_header('Auth-SSL', req.secured)
+    auth_request:add_header('Auth-Method', req.mechanism)
+end
+
+function formatJsonToKeyValueString(json_str)
+    local data = json.decode(json_str)
+    local result = {}
+
+    for key, value in pairs(data) do
+        local formatted_value
+        if value == nil then
+            formatted_value = ""
+        else
+            formatted_value = tostring(value)
+        end
+        table.insert(result, key .. "=" .. formatted_value)
+    end
+
+    return table.concat(result, " ")
+end
+
+function auth_passdb_lookup(req)
+    local auth_request = http_client:request {
+        url = "http://{{ ADMIN_ADDRESS }}:8080/internal/dovecot/passdb/" .. urlEncode(req.user);
+    }
+    setRequestHeadersFromDovecotRequest(auth_request, req)
+    local auth_response = auth_request:submit()
+    local resp_status = auth_response:status()
+
+    if resp_status == 200
+    then
+        return dovecot.auth.PASSDB_RESULT_OK, formatJsonToKeyValueString(auth_response:payload())
+    else
+        return dovecot.auth.PASSDB_RESULT_USER_UNKNOWN, ""
+    end
+end
+
+function auth_userdb_lookup(req)
+    local auth_request = http_client:request {
+        url = "http://{{ ADMIN_ADDRESS }}:8080/internal/dovecot/userdb/" .. urlEncode(req.user);
+    }
+    setRequestHeadersFromDovecotRequest(auth_request, req)
+    local auth_response = auth_request:submit()
+    local resp_status = auth_response:status()
+
+    if resp_status == 200
+    then
+        local json_body = auth_response:payload()
+        local result_str = formatJsonToKeyValueString(json_body)
+
+        return dovecot.auth.USERDB_RESULT_OK, result_str
+    else
+        return dovecot.auth.USERDB_RESULT_USER_UNKNOWN, ""
+    end
+end
+
+function auth_userdb_iterate()
+    local auth_request = http_client:request {
+        url = "http://{{ ADMIN_ADDRESS }}:8080/internal/dovecot/userdb/";
+    }
+    local auth_response = auth_request:submit()
+
+    return json.decode(auth_response:payload())
+end

--- a/core/dovecot/conf/login.lua
+++ b/core/dovecot/conf/login.lua
@@ -27,12 +27,29 @@ function setRequestHeadersFromDovecotRequest(auth_request, req)
         local password = urlEncode(req.password)
         auth_request:add_header('Auth-Pass', password)
     end
-    auth_request:add_header('Auth-Protocol', req.service)
-    local client_ip = urlEncode(req.remote_ip)
-    auth_request:add_header('Client-Ip', client_ip)
-    auth_request:add_header('Client-Port', req.remote_port)
-    auth_request:add_header('Auth-SSL', req.secured)
-    auth_request:add_header('Auth-Method', req.mechanism)
+    if req.service ~= nil
+    then
+        auth_request:add_header('Auth-Protocol', req.service)
+    end
+
+    if req.remote_ip ~= nil
+    then
+        local client_ip = urlEncode(req.remote_ip)
+        auth_request:add_header('Client-Ip', client_ip)
+    end
+    if req.remote_port ~= nil
+    then
+        auth_request:add_header('Client-Port', req.remote_port)
+    end
+
+    if req.secured ~= nil
+    then
+        auth_request:add_header('Auth-SSL', req.secured)
+    end
+    if req.mechanism ~= nil
+    then
+        auth_request:add_header('Auth-Method', req.mechanism)
+    end
 end
 
 function formatJsonToKeyValueString(json_str)

--- a/core/dovecot/start.py
+++ b/core/dovecot/start.py
@@ -23,6 +23,7 @@ def start_podop():
 # Actual startup script
 for dovecot_file in glob.glob("/conf/*.conf"):
     conf.jinja(dovecot_file, os.environ, os.path.join("/etc/dovecot", os.path.basename(dovecot_file)))
+conf.jinja("/conf/login.lua", os.environ, "/etc/dovecot/login.lua")
 
 os.makedirs("/conf/bin", exist_ok=True)
 for script_file in glob.glob("/conf/*.script"):


### PR DESCRIPTION
## What type of PR?
Enhancement

## What does this PR do?
Migrate dovecot passdb and userdb from podop dict to a lua script (required for dovecot 2.4 upgrade). This makes dovecot talk directly to the admin API.

### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
