### PR TITLE
fix: replace 17 bare except clauses with except Exception

### DIFF
--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -104,7 +104,7 @@ def handle_authentication(headers):
             user_email = urllib.parse.unquote(headers["Auth-User"])
             password = urllib.parse.unquote(headers["Auth-Pass"])
             ip = urllib.parse.unquote(headers["Client-Ip"])
-        except:
+        except Exception:
             app.logger.warn(f'Received undecodable user/password from front: {headers.get("Auth-User", "")!r}')
         else:
             try:
@@ -161,7 +161,7 @@ def get_server(protocol, authenticated=False):
     try:
         # test if hostname is already resolved to an ip address
         ipaddress.ip_address(hostname)
-    except:
+    except Exception:
         # hostname is not an ip address - so we need to resolve it
         hostname = system.resolve_hostname(hostname)
     return hostname, port

--- a/core/admin/mailu/internal/views/autoconfig.py
+++ b/core/admin/mailu/internal/views/autoconfig.py
@@ -90,7 +90,7 @@ def autoconfig_microsoft():
         </Response>
     </Autodiscover>'''
         return flask.Response(xml, mimetype='text/xml', status=200)
-    except:
+    except Exception:
         return flask.abort(400)
 
 @internal.route("/autoconfig/apple")

--- a/core/admin/mailu/limiter.py
+++ b/core/admin/mailu/limiter.py
@@ -86,7 +86,7 @@ class LimitWraperFactory(object):
             login, nonce, _ = cookie.split('$')
             if hmac.compare_digest(cookie, self.device_cookie(login, nonce)):
                 return nonce, login
-        except:
+        except Exception:
             pass
         return None, None
 

--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -173,7 +173,7 @@ class TokenForm(flask_wtf.FlaskForm):
         try:
             for candidate in field.data.replace(' ','').split(','):
                 ipaddress.ip_network(candidate, False)
-        except:
+        except Exception:
             raise validators.ValidationError('Not a valid list of CIDRs')
 
 class AliasForm(flask_wtf.FlaskForm):

--- a/core/admin/mailu/utils.py
+++ b/core/admin/mailu/utils.py
@@ -93,7 +93,7 @@ def is_ip_in_subnet(ip, subnets=[]):
     ip = ipaddress.ip_address(ip)
     try:
         return any(ip in cidr for cidr in [ipaddress.ip_network(subnet, strict=False) for subnet in subnets])
-    except:
+    except Exception:
         app.logger.debug(f'Unable to parse {subnets!r}, assuming {ip!r} is not in the set')
         return False
 
@@ -507,7 +507,7 @@ def verify_temp_token(email, token):
                 session = MailuSession(sessid, app)
                 if session.get('_user_id', '') == email:
                     return True
-    except:
+    except Exception:
         pass
 
 def gen_temp_token(email, session):

--- a/core/rspamd/start.py
+++ b/core/rspamd/start.py
@@ -30,7 +30,7 @@ while True:
     try:
         if requests.get(healthcheck,timeout=2).ok:
             break
-    except:
+    except Exception:
         pass
     log.warning("Admin is not up just yet, retrying in 1 second")
 

--- a/setup/server.py
+++ b/setup/server.py
@@ -97,22 +97,22 @@ def build_app(path):
         valid = True
         try:
             ipaddress.IPv4Address(data['bind4'])
-        except:
+        except Exception:
             flask.flash('Configured IPv4 address is invalid', 'error')
             valid = False
         try:
             ipaddress.IPv6Address(data['bind6'])
-        except:
+        except Exception:
             flask.flash('Configured IPv6 address is invalid', 'error')
             valid = False
         try:
             ipaddress.IPv4Network(data['subnet'])
-        except:
+        except Exception:
             flask.flash('Configured subnet(IPv4) is invalid', 'error')
             valid = False
         try:
             ipaddress.IPv6Network(data['subnet6'])
-        except:
+        except Exception:
             flask.flash('Configured subnet(IPv6) is invalid', 'error')
             valid = False
         try:

--- a/tests/alias_test.py
+++ b/tests/alias_test.py
@@ -22,7 +22,7 @@ try:
 
     smtp_server.sendmail("admin@mailu.io", "alltheusers@mailu.io", msg.as_string())
     smtp_server.quit()
-except:
+except Exception:
     sys.exit(25)
 
 time.sleep(30)

--- a/tests/email_test.py
+++ b/tests/email_test.py
@@ -43,7 +43,7 @@ for i in range(5):
         if e.smtp_code >= 500 and e.smtp_code <600:
             sys.exit(25)
         sys.exit(2525)
-    except:
+    except Exception:
         sys.exit(2525)
     break
 
@@ -52,7 +52,7 @@ time.sleep(30)
 try:
     imap_server = imaplib.IMAP4_SSL('localhost')
     imap_server.login('user@mailu.io', 'password')
-except:
+except Exception:
     sys.exit(110)
 
 stat, count = imap_server.select('inbox')

--- a/tests/forward_test.py
+++ b/tests/forward_test.py
@@ -22,7 +22,7 @@ try:
 
     smtp_server.sendmail("admin@mailu.io", "forwardinguser@mailu.io", msg.as_string())
     smtp_server.quit()
-except:
+except Exception:
     sys.exit(25)
 
 time.sleep(30)

--- a/tests/reply_test.py
+++ b/tests/reply_test.py
@@ -22,7 +22,7 @@ try:
 
     smtp_server.sendmail("admin@mailu.io", "replyuser@mailu.io", msg.as_string())
     smtp_server.quit()
-except:
+except Exception:
     sys.exit(25)
 
 time.sleep(30)


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance. Bare except catches SystemExit, KeyboardInterrupt, and GeneratorExit which is rarely intended.