### PR TITLE
feat: native TOTP two-factor authentication (#783)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pip-selfcheck.json
 /.idea
 /.vscode
 qemu-arm-static
+local-test/

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -20,6 +20,10 @@ import smtplib
 import idna
 import dns.resolver
 import dns.exception
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet, InvalidToken
 
 from flask import current_app as app
 from sqlalchemy.ext import declarative
@@ -589,6 +593,10 @@ class User(Base, Email):
     spam_threshold = db.Column(db.Integer, nullable=False, default=lambda:int(app.config.get("DEFAULT_SPAM_THRESHOLD", 80)))
     change_pw_next_login = db.Column(db.Boolean, nullable=False, default=False)
 
+    # TOTP two-factor authentication
+    totp_secret = db.Column(db.String(255), nullable=True, default=None)
+    totp_enabled = db.Column(db.Boolean, nullable=False, default=False)
+
     # Flask-login attributes
     is_authenticated = True
     is_active = True
@@ -697,6 +705,43 @@ set() containing the sessions to keep
         self.password = password if raw else User.get_password_context().hash(password)
         if keep_sessions is not True and self.email is not None:
             utils.MailuSessionExtension.prune_sessions(uid=self.email, keep=keep_sessions)
+
+    @staticmethod
+    def _get_fernet():
+        """ derive a Fernet key from SECRET_KEY for encrypting TOTP secrets """
+        key = hashlib.sha256(app.config['SECRET_KEY'].encode()).digest()
+        return Fernet(base64.urlsafe_b64encode(key))
+
+    def get_totp_secret(self):
+        """ decrypt and return the TOTP shared secret, or None """
+        if not self.totp_secret:
+            return None
+        try:
+            return User._get_fernet().decrypt(self.totp_secret.encode()).decode()
+        except InvalidToken:
+            return None
+
+    def set_totp_secret(self, secret):
+        """ encrypt and store a TOTP shared secret """
+        if secret is None:
+            self.totp_secret = None
+        else:
+            self.totp_secret = User._get_fernet().encrypt(secret.encode()).decode()
+
+    def verify_totp(self, code):
+        """ verify a 6-digit TOTP code against the stored secret """
+        import pyotp
+        secret = self.get_totp_secret()
+        if not secret:
+            return False
+        return pyotp.TOTP(secret).verify(code, valid_window=1)
+
+    def disable_2fa(self):
+        """ disable TOTP 2FA and remove all backup codes """
+        self.totp_secret = None
+        self.totp_enabled = False
+        for code in list(self.backup_codes):
+            db.session.delete(code)
 
     def get_managed_domains(self):
         """ return list of domains this user can manage """
@@ -823,6 +868,40 @@ class Token(Base):
 
     def __repr__(self):
         return f'<Token #{self.id}: {self.comment or self.ip or self.password}>'
+
+
+class BackupCode(Base):
+    """ A single-use backup code for TOTP 2FA recovery.
+    """
+
+    __tablename__ = 'backup_code'
+
+    id = db.Column(db.Integer, primary_key=True)
+    user_email = db.Column(db.String(255), db.ForeignKey(User.email),
+        nullable=False)
+    user = db.relationship(User,
+        backref=db.backref('backup_codes', cascade='all, delete-orphan'))
+    code_hash = db.Column(db.String(255), nullable=False)
+
+    def check_code(self, code):
+        """ verify a backup code against the stored hash """
+        return passlib.hash.pbkdf2_sha256.verify(code, self.code_hash)
+
+    @staticmethod
+    def generate_codes(user, count=10):
+        """ generate backup codes, store hashed, return plaintext list """
+        import secrets
+        codes = []
+        for _ in range(count):
+            raw = secrets.token_hex(4)
+            code = f'{raw[:4]}-{raw[4:]}'
+            backup = BackupCode(
+                user_email=user.email,
+                code_hash=passlib.hash.pbkdf2_sha256.using(rounds=1).hash(code)
+            )
+            db.session.add(backup)
+            codes.append(code)
+        return codes
 
 
 class Fetch(Base):

--- a/core/admin/mailu/sso/forms.py
+++ b/core/admin/mailu/sso/forms.py
@@ -11,6 +11,13 @@ class LoginForm(flask_wtf.FlaskForm):
     submitWebmail = fields.SubmitField(_('Sign in'))
     submitAdmin = fields.SubmitField(_('Sign in'))
 
+class TOTPVerifyForm(flask_wtf.FlaskForm):
+    class Meta:
+        csrf = False
+    code = fields.StringField(_('Authentication code'), [validators.DataRequired(), validators.Length(min=6, max=12)], render_kw={'autofocus': True, 'autocomplete': 'one-time-code', 'inputmode': 'numeric', 'pattern': '[0-9]*', 'maxlength': '9'})
+    submitCode = fields.SubmitField(_('Verify'))
+    submitBackup = fields.SubmitField(_('Use backup code'))
+
 class PWChangeForm(flask_wtf.FlaskForm):
     oldpw = fields.PasswordField(_('Current password'), [validators.DataRequired()])
     pw = fields.PasswordField(_('New password'), [validators.DataRequired()])

--- a/core/admin/mailu/sso/templates/2fa_verify.html
+++ b/core/admin/mailu/sso/templates/2fa_verify.html
@@ -1,0 +1,25 @@
+{%- extends "base_sso.html" %}
+
+{%- block title %}
+{% trans %}Two-factor authentication{% endtrans %}
+{%- endblock %}
+
+{%- block content %}
+{%- call macros.card() %}
+<form class="form" method="post" role="form">
+  {{ form.hidden_tag() }}
+  <p>{% trans %}Enter the 6-digit code from your authenticator app.{% endtrans %}</p>
+  {{ macros.form_field(form.code) }}
+  <div class="form-group">
+    <div class="row">
+      <div class="col-6">
+        {{ form.submitCode(class_="btn btn-primary btn-block") }}
+      </div>
+      <div class="col-6">
+        {{ form.submitBackup(class_="btn btn-outline-secondary btn-block") }}
+      </div>
+    </div>
+  </div>
+</form>
+{%- endcall %}
+{%- endblock %}

--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -9,6 +9,7 @@ import flask
 import flask_login
 import secrets
 import ipaddress
+import time
 from urllib.parse import urlparse, urljoin, unquote
 
 @sso.route('/login', methods=['GET', 'POST'])
@@ -52,6 +53,15 @@ def login():
                 return flask.render_template('login.html', form=form, fields=fields)
         user = models.User.login(username, form.pw.data)
         if user:
+            # check if 2FA is enabled — defer full login until TOTP verified
+            if user.totp_enabled:
+                flask.session.regenerate()
+                flask.session['pending_2fa_user'] = user.email
+                flask.session['pending_2fa_destination'] = destination
+                flask.session['pending_2fa_time'] = time.time()
+                flask.session['pending_2fa_pwned'] = form.pwned.data
+                flask.current_app.logger.info(f'Login attempt for: {username}/sso/{flask.request.headers.get("X-Forwarded-Proto")} from: {client_ip}/{client_port}: success: password, pending 2FA')
+                return flask.redirect(flask.url_for('sso.login_2fa'))
             flask.session.regenerate()
             flask_login.login_user(user)
             if user.change_pw_next_login:
@@ -68,6 +78,77 @@ def login():
             flask.current_app.logger.info(f'Login attempt for: {username}/sso/{flask.request.headers.get("X-Forwarded-Proto")} from: {client_ip}/{client_port}: failed: badauth: {utils.truncated_pw_hash(form.pw.data)}')
             flask.flash(_('Wrong e-mail or password'), 'error')
     return flask.render_template('login.html', form=form, fields=fields)
+
+@sso.route('/2fa', methods=['GET', 'POST'])
+def login_2fa():
+    """ Verify TOTP code or backup code after successful password authentication. """
+    client_ip = flask.request.headers.get('X-Real-IP', flask.request.remote_addr)
+    client_port = flask.request.headers.get('X-Real-Port', None)
+
+    # validate pending 2FA session
+    pending_email = flask.session.get('pending_2fa_user')
+    pending_time = flask.session.get('pending_2fa_time', 0)
+    if not pending_email or (time.time() - pending_time) > 300:
+        flask.session.pop('pending_2fa_user', None)
+        flask.session.pop('pending_2fa_destination', None)
+        flask.session.pop('pending_2fa_time', None)
+        flask.session.pop('pending_2fa_pwned', None)
+        flask.session.pop('totp_setup_secret', None)
+        flask.flash(_('Session expired, please sign in again'), 'error')
+        return flask.redirect(flask.url_for('sso.login'))
+
+    user = models.User.query.get(pending_email)
+    if not user or not user.enabled:
+        flask.session.pop('pending_2fa_user', None)
+        return flask.redirect(flask.url_for('sso.login'))
+
+    # rate limiting on 2FA attempts (reuse existing limiter)
+    device_cookie, device_cookie_username = utils.limiter.parse_device_cookie(flask.request.cookies.get('rate_limit'))
+    if utils.limiter.should_rate_limit_ip(client_ip):
+        flask.flash(_('Too many attempts from your IP (rate-limit)'), 'error')
+        return flask.render_template('2fa_verify.html', form=forms.TOTPVerifyForm())
+
+    form = forms.TOTPVerifyForm()
+
+    if form.validate_on_submit():
+        code = form.code.data.strip().replace('-', '')
+        verified = False
+
+        if form.submitCode.data:
+            # TOTP code verification
+            verified = user.verify_totp(code)
+        elif form.submitBackup.data:
+            # backup code verification — constant-time loop (no early break)
+            matched_backup = None
+            for backup in user.backup_codes:
+                if backup.check_code(code):
+                    matched_backup = backup
+            if matched_backup:
+                models.db.session.delete(matched_backup)
+                verified = True
+                flask.current_app.logger.info(f'2FA backup code used for: {pending_email} from: {client_ip}/{client_port}')
+
+        if verified:
+            destination = flask.session.pop('pending_2fa_destination', app.config['WEB_ADMIN'])
+            pwned_data = flask.session.pop('pending_2fa_pwned', -1)
+            flask.session.pop('pending_2fa_user', None)
+            flask.session.pop('pending_2fa_time', None)
+            flask.session.regenerate()
+            flask_login.login_user(user)
+            if user.change_pw_next_login:
+                flask.session['redirect_to'] = destination
+                destination = flask.url_for('sso.pw_change')
+            response = flask.redirect(destination)
+            response.set_cookie('rate_limit', utils.limiter.device_cookie(pending_email), max_age=31536000, path=flask.url_for('sso.login'), secure=app.config['SESSION_COOKIE_SECURE'], httponly=True)
+            flask.current_app.logger.info(f'Login attempt for: {pending_email}/sso/{flask.request.headers.get("X-Forwarded-Proto")} from: {client_ip}/{client_port}: success: 2FA verified: password: {pwned_data}')
+            models.db.session.commit()
+            return response
+        else:
+            utils.limiter.rate_limit_ip(client_ip, pending_email)
+            flask.current_app.logger.info(f'2FA attempt for: {pending_email}/sso from: {client_ip}/{client_port}: failed: bad code')
+            flask.flash(_('Invalid authentication code'), 'error')
+
+    return flask.render_template('2fa_verify.html', form=form)
 
 @sso.route('/pw_change', methods=['GET', 'POST'])
 @access.authenticated

--- a/core/admin/mailu/translations/be_BY/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/be_BY/LC_MESSAGES/messages.po
@@ -1,34 +1,76 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: Mailu\n"
+"Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2024-03-30 12:18+0100\n"
 "Last-Translator: spoooyders <tech+translate@i2p.cc>\n"
-"Language-Team: \n"
 "Language: be_BY\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && "
-"(n%100<12 || n%100>14) ? 1 : 2);\n"
-"Generated-By: Babel 2.3.4\n"
-"X-Generator: Poedit 3.4.2\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "Электронная пошта"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93 mailu/ui/forms.py:112
-#: mailu/ui/forms.py:166 mailu/ui/templates/client.html:32
-#: mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Пароль"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Увайсьці"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Аўтэнтыфікацыйныя токены"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+msgid "Current password"
+msgstr "Бягучы пароль"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Пароль адміністратара"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Абнавіць пароль"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -42,251 +84,338 @@ msgstr "уключыць бакавую панэль"
 msgid "change language"
 msgstr "зьмяніць мову"
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Перайсьці да"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Налады кліента"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Сайт"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Дапамога"
 
-#: mailu/sso/templates/sidebar_sso.html:35 mailu/ui/templates/domain/signup.html:4
-#: mailu/ui/templates/sidebar.html:127
+#: mailu/sso/templates/sidebar_sso.html:35
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Зарэгістраваць дамен"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Рэгістрацыя"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Пацьвердзіць пароль"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Стварыць аўтэнтыфікацыйны токен"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+#, fuzzy
+msgid "The current password is incorrect!"
+msgstr "Бягучы пароль"
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Няправільны адрас электроннай пошты."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Пацвердзіць"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58 mailu/ui/templates/domain/details.html:26
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
+#: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Даменнае імя"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Максымальная колькасьць карыстальнікаў"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Максымальная колькасьць псеўданімаў"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Максымальная квота карыстальніка"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Дазволіць рэгістрацыю"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86 mailu/ui/forms.py:132
-#: mailu/ui/forms.py:144 mailu/ui/templates/alias/list.html:22
-#: mailu/ui/templates/domain/list.html:22 mailu/ui/templates/relay/list.html:20
-#: mailu/ui/templates/token/list.html:20 mailu/ui/templates/user/list.html:24
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
+#: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Камэнтары"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75 mailu/ui/forms.py:88
-#: mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Захаваць"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Пачатковы адміністратар"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Пароль адміністратара"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Пацьвердзіць пароль"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Стварыць"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Імя альтэрнатыўнага дамену"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Імя рэлейнага дамену"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Аддалены хост"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Квота"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Дазволіць доступ праз IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Дазволіць доступ праз POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101 mailu/ui/templates/user/settings.html:15
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+"Дазволіць карыстальніку падрабляць адпраўшчыка (адсылаць пошту як хто "
+"заўгодна)"
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
+#: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Паказваць імя"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Уключана"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr "Прымусова зьмяніць пароль пры наступным уваходзе"
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Паштовы адрас"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Уключыць спам-фільтар"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "Пазначаць спам паведамленьні як прачытаныя"
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Парог спам-фільтру"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Уключыць пераадрасацыю"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Захоўваць копіі лістоў"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143 mailu/ui/templates/alias/list.html:21
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
+#: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Адрас атрымальніка"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Захаваць налады"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Праверка пароля"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Абнавіць пароль"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Уключыць аўтаадказчык"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Загаловак адказу"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Зьмест адказу"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "Пачатак водпуску"
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Канец водпуску"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Абнавіць"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Ваш токен (запішыце яго, бо ён больш не будзе паказвацца)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Аўтарызаваныя IP-адрасы"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Псэўданім"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
-msgstr "Выкарыстоўваць SQL-падобны сынтаксіс (напрылкад, для ўсеагульных псэўданімаў)"
+msgstr ""
+"Выкарыстоўваць SQL-падобны сынтаксіс (напрылкад, для ўсеагульных "
+"псэўданімаў)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Адрас адміністратара"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Прыняць"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Адрас мэнэджэра"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Пратакол"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Імя хосту альбо IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Порт TCP"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Уключыць TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Імя карыстальніка"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Захоўваць лісты на сэрвэры"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Стварыць аўтэнтыфікацыйны токен"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Стварыць аўтэнтыфікацыйны токен"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Тэма абвесткі"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Зьмест абвесткі"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Адаслаць"
 
@@ -294,7 +423,7 @@ msgstr "Адаслаць"
 msgid "Public announcement"
 msgstr "Публічная аб'ява"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Антыспам"
@@ -307,21 +436,29 @@ msgstr "Старонка статусу RSPAMD"
 msgid "configure your email client"
 msgstr "наладзьце свой паштовы кліент"
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr "Уваходная пошта"
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Паштовы пратакол"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Імя сэрвэру"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
 msgstr "Выходная пошта"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "Калі вы выкарыстоўваеце прыладу Apple,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "націсьніце сюды каб аўтаматычна наладзіць яе."
 
 #: mailu/ui/templates/confirm.html:4
 msgid "Confirm action"
@@ -330,7 +467,9 @@ msgstr "Пацьвердзіце дзеяньне"
 #: mailu/ui/templates/confirm.html:13
 #, python-format
 msgid "You are about to %(action)s. Please confirm your action."
-msgstr "Вы зьбіраецеся зьдзейсьніць %(action)s. Калі ласка пацьвердзіце ваша дзеяньне."
+msgstr ""
+"Вы зьбіраецеся зьдзейсьніць %(action)s. Калі ласка пацьвердзіце ваша "
+"дзеяньне."
 
 #: mailu/ui/templates/docker-error.html:4
 msgid "Docker error"
@@ -340,7 +479,7 @@ msgstr "Памылка Docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Адбылася памылка пры зьвяртаньні да сэрвэру Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr "скапіраваць у буфэр абмену"
 
@@ -348,48 +487,48 @@ msgstr "скапіраваць у буфэр абмену"
 msgid "My account"
 msgstr "Мой уліковы запіс"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Налады"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Аўтаматычны адказ"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Уліковая запісы пабочных сэрвэраў"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Аўтэнтыфікацыйныя токены"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Адміністраваньне"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Абвестка"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Адміністратары"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Рэлейныя дамены"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Паштовыя дамены"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Электронная пошта"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Выйсьці"
 
@@ -410,8 +549,9 @@ msgid "Add administrator"
 msgstr "Дадаць адміністратара"
 
 #: mailu/ui/templates/admin/list.html:17 mailu/ui/templates/alias/list.html:19
-#: mailu/ui/templates/alternative/list.html:19 mailu/ui/templates/domain/list.html:17
-#: mailu/ui/templates/fetch/list.html:19 mailu/ui/templates/manager/list.html:19
+#: mailu/ui/templates/alternative/list.html:19
+#: mailu/ui/templates/domain/list.html:17 mailu/ui/templates/fetch/list.html:19
+#: mailu/ui/templates/manager/list.html:19
 #: mailu/ui/templates/relay/list.html:17 mailu/ui/templates/token/list.html:19
 #: mailu/ui/templates/user/list.html:19
 msgid "Actions"
@@ -422,11 +562,18 @@ msgstr "Дзеяньні"
 msgid "Email"
 msgstr "Электронная пошта"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29 mailu/ui/templates/domain/list.html:34
-#: mailu/ui/templates/fetch/list.html:34 mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
+#: mailu/ui/templates/manager/list.html:27
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Зьмяніць"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Выдаліць"
 
@@ -446,25 +593,21 @@ msgstr "Сьпіс псэўданімаў"
 msgid "Add alias"
 msgstr "Дадаць псэўданім"
 
-#: mailu/ui/templates/alias/list.html:23 mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/alias/list.html:23
+#: mailu/ui/templates/alternative/list.html:21
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Створана"
 
-#: mailu/ui/templates/alias/list.html:24 mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/alias/list.html:24
+#: mailu/ui/templates/alternative/list.html:22
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Апошняя зьмена"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Зьмяніць"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -482,7 +625,8 @@ msgstr "Дадаць альтэрнатыўны дамен"
 msgid "Name"
 msgstr "Імя"
 
-#: mailu/ui/templates/domain/create.html:4 mailu/ui/templates/domain/list.html:9
+#: mailu/ui/templates/domain/create.html:4
+#: mailu/ui/templates/domain/list.html:9
 msgid "New domain"
 msgstr "Новы дамен"
 
@@ -498,33 +642,42 @@ msgstr "Згенерыраваць ключы нанова"
 msgid "Generate keys"
 msgstr "Згенерыраваць ключы"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr "Спампаваць файл зоны"
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Запіс DNS MX"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Запісы DNS SPF"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Публічны ключ DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Запіс DNS DKIM"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Запіс DNS DMARC"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "Запіс DNS TLSA"
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "Запісы аўтаканфігурацыі DNS"
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Сьпіс альтэрнатыўных даменаў"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -546,46 +699,61 @@ msgstr "Колькасьць паштовых скрынь"
 msgid "Alias count"
 msgstr "Колькасьць псэўданімаў"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Падрабязна"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Карыстальнікі"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Псэўданімы"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Мэнэджэры"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Альтэрнатыўныя дамены"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "так"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "не"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr ""
 "Каб зарэгістраваць новы дамен, вы мусіце спачатку наладзіць\n"
-"    даменная зона, так каб дамен <code> MX </ code> паказваў на гэты сэрвэр"
+"    даменная зона, так каб дамен <code> MX </ code> паказваў на гэты "
+"сэрвэр"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
-"If you do not know how to setup an <code>MX</code> record for your DNS zone,\n"
-"    please contact your DNS provider or administrator. Also, please wait a\n"
-"    couple minutes after the <code>MX</code> is set so the local server cache\n"
+"If you do not know how to setup an <code>MX</code> record for your DNS "
+"zone,\n"
+"    please contact your DNS provider or administrator. Also, please wait "
+"a\n"
+"    couple minutes after the <code>MX</code> is set so the local server "
+"cache\n"
 "    expires."
 msgstr ""
-"Калі вы не ведаеце як наладзіць запіс <code> MX </ code> для сваёй зоны DNS,\n"
-"    калі ласка, зьвяжыцеся з вашым пастаўшчыком DNS альбо адміністратарам. Таксама, "
-"калі ласка, пачакайце\n"
-"    некалькі хвілін пасьля таго як запіс <code> MX </ code> быў зададзены, каб "
-"скончыўся тэрмін дзеяньня кэшу\n"
+"Калі вы не ведаеце як наладзіць запіс <code> MX </ code> для сваёй зоны "
+"DNS,\n"
+"    калі ласка, зьвяжыцеся з вашым пастаўшчыком DNS альбо "
+"адміністратарам. Таксама, калі ласка, пачакайце\n"
+"    некалькі хвілін пасьля таго як запіс <code> MX </ code> быў "
+"зададзены, каб скончыўся тэрмін дзеяньня кэшу\n"
 "    лякальнага сэрвэру."
 
 #: mailu/ui/templates/fetch/create.html:4
@@ -609,20 +777,21 @@ msgid "Keep emails"
 msgstr "Захоўваць лісты"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Захоўваць лісты"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Апошняя праверка"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Статус"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "так"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "не"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -660,6 +829,60 @@ msgstr "Стварыць аўтэнтыфікацыйны токен"
 msgid "New token"
 msgstr "Новы токен"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Стварыць аўтэнтыфікацыйны токен"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Новы карыстальнік"
@@ -668,13 +891,30 @@ msgstr "Новы карыстальнік"
 msgid "General"
 msgstr "Агульныя"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Функцыі і квоты"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Зьмяніць карыстальніка"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Стварыць аўтэнтыфікацыйны токен"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -704,38 +944,50 @@ msgstr "Аўтаматычны адказ"
 msgid "Auto-forward"
 msgstr "Аўтаматычная перасылка"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Стварыць аўтэнтыфікацыйны токен"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "выбраць дамен для новага ўліковага запісу"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Дамен"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Наяўныя адтуліны"
 
-#: mailu/ui/templates/client.html:62
-msgid "If you use an Apple device,"
-msgstr "Калі вы выкарыстоўваеце прыладу Apple,"
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
 
-#: mailu/ui/templates/client.html:63
-msgid "click here to auto-configure it."
-msgstr "націсьніце сюды каб аўтаматычна наладзіць яе."
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
 
-#: mailu/ui/templates/domain/details.html:19
-msgid "Download zonefile"
-msgstr "Спампаваць файл зоны"
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
 
-#: mailu/ui/forms.py:134
-msgid "Current password"
-msgstr "Бягучы пароль"
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
-#: mailu/ui/forms.py:102
-msgid "Force password change at next login"
-msgstr "Прымусова зьмяніць пароль пры наступным уваходзе"
+#~ msgid "DKIM public key"
+#~ msgstr "Публічны ключ DKIM"
 
-#: mailu/ui/forms.py:98
-msgid "Allow the user to spoof the sender (send email as anyone)"
-msgstr "Дазволіць карыстальніку падрабляць адпраўшчыка (адсылаць пошту як хто заўгодна)"

--- a/core/admin/mailu/translations/ca/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/ca/LC_MESSAGES/messages.po
@@ -7,32 +7,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Jaume Barber <jaumebarber@gmail.com>\n"
 "Language: ca\n"
 "Language-Team: Catalan "
 "<https://translate.tedomum.net/projects/mailu/admin/ca/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "Correu"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Contrasenya"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Entreu"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Tokens d'autenticació"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Contrasenya d'admin"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Contrasenya d'admin"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Canvieu la contrasenya"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -46,257 +89,335 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Aneu a"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Ajustos del client"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Lloc web"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Ajuda"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Registreu un domini"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Registreu-vos"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Confirmeu la contrasenya"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Creeu un token d'autenticació"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr ""
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Confirmeu"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Nom de domini"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Nombre màxim d'usuaris"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Nombre màxim d'àlies"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Espai màxim per usuari"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Activeu el registre"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Comentari"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Desa"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Admin inicial"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Contrasenya d'admin"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Confirmeu la contrasenya"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Creeu"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Nom alternatiu"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Nom de domini llegat (relayed)"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Amfitrió remot"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Espai"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Permeteu accés IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Permeteu accés POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Nom per mostrar"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Activat"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Adreça email"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Activeu filtre spam"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Tolerància del filtre d'spam"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Activeu el reenviament"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Mantigueu una còpia dels correus"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destinació"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Desa ajustos"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Comproveu la contrasenya"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Canvieu la contrasenya"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Activeu la resposta automàtica"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Tema de la resposta"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Missatge de resposta"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Tornada de vacances"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Actualitzeu"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Token personal (apunteu-lo perquè no es mostrarà de nou)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "IP autoritzada"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Àlies"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr ""
 "Feu servir sintaxi tipus SQL (ex. per seleccionar tots els àlies catch-"
 "all)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Adreça d'admin"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Envia"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Adreça de gestor"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protocol"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Nom d'amfitrio o IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Port TCP"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Activeu TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Nom d'usuari"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Mantén els correus al servidor"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Creeu un token d'autenticació"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Creeu un token d'autenticació"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Tema de la notificació"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Missatge de la notificació"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Envia"
 
@@ -304,7 +425,7 @@ msgstr "Envia"
 msgid "Public announcement"
 msgstr "Notificació pública"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Antispam"
@@ -317,20 +438,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Protocol de correu"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Nom de servidor"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -350,7 +479,7 @@ msgstr "Error de Docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Hi ha hagut un error de comunicació amb el servidor Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -358,48 +487,48 @@ msgstr ""
 msgid "My account"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Ajustos"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Resposta automàtica"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Comptes vinculats"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Tokens d'autenticació"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Administració"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Notificació"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Administradors"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Dominis traspassats"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Dominis de correu"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Correu web"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Eixiu"
 
@@ -433,12 +562,18 @@ msgstr "Accions"
 msgid "Email"
 msgstr "Correu"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Edita"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Esborra"
 
@@ -460,25 +595,19 @@ msgstr "Afegiu àlies"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Creat"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Última edició"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Edita"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -513,33 +642,42 @@ msgstr "Regenereu les claus"
 msgid "Generate keys"
 msgstr "Genereu claus"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Entrada DNS MX"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Entrada DNS SPF"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Clau pública DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Entrada DNS DKIM"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Entrada DNS DMARC"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Llista de dominis alternatius"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -561,27 +699,37 @@ msgstr "Nombre de bústies"
 msgid "Alias count"
 msgstr "Nombre d'àlies"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Detalls"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Usuaris"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Àlies"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Gestors"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternatives"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "sí"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "no"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -590,7 +738,7 @@ msgstr ""
 "    zona de dominis per tal que el domini <code>MX</code> apunte a aquest"
 " servidor"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -628,20 +776,21 @@ msgid "Keep emails"
 msgstr "Mantingueu els correus"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Mantingueu els correus"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Última comprovació"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "sí"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "no"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -679,6 +828,60 @@ msgstr "Creeu un token d'autenticació"
 msgid "New token"
 msgstr "Nou token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Creeu un token d'autenticació"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Nou usuari"
@@ -687,13 +890,30 @@ msgstr "Nou usuari"
 msgid "General"
 msgstr "General"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Funcions i espai"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Edita usuari"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Creeu un token d'autenticació"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -723,21 +943,56 @@ msgstr "Resposta automàtica"
 msgid "Auto-forward"
 msgstr "Auto-reenviament"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Creeu un token d'autenticació"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "trieu un domini per al compte nou"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Nom de domini"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Ranures lliures"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "to access the administration tools"
 #~ msgstr "per accedir a les eines d'administració"
 
 #~ msgid "Forward emails"
 #~ msgstr "Reenvia correus"
+
+#~ msgid "DKIM public key"
+#~ msgstr "Clau pública DKIM"
 

--- a/core/admin/mailu/translations/cs/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/cs/LC_MESSAGES/messages.po
@@ -1,30 +1,29 @@
 # Czech translations for Mailu.io.
 # Copyright (C) 2023 S474N
-# This file is distributed under the same license as the PROJECT project.
+# This file is distributed under the same license as the Mailu project.
 # S474N <translate@s474n.com>, 2023.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Mailu 2024.06\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-06-20 12:30+0000\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2024-09-10 17:16+0200\n"
 "Last-Translator: kunago <miris@kunago.com>\n"
-"Language-Team: Czech\n"
 "Language: cs_CZ\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Czech\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n>=2 && n<=4 ? 1 : 2);\n"
-"Generated-By: Babel 2.3.4\n"
-"X-Generator: Poedit 3.5\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:91
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:92 mailu/ui/forms.py:108
-#: mailu/ui/forms.py:128 mailu/ui/forms.py:135 mailu/ui/forms.py:197
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
 #: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Heslo"
@@ -34,21 +33,45 @@ msgstr "Heslo"
 msgid "Sign in"
 msgstr "Přihlásit se"
 
-#: mailu/sso/forms.py:15 mailu/ui/forms.py:134
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Autentizační tokeny"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
 msgid "Current password"
 msgstr "Současné heslo"
 
-#: mailu/sso/forms.py:16
+#: mailu/sso/forms.py:23
 msgid "New password"
 msgstr "Nové heslo"
 
-#: mailu/sso/forms.py:17
+#: mailu/sso/forms.py:24
 msgid "New password (again)"
 msgstr "Nové heslo (znovu)"
 
-#: mailu/sso/forms.py:19
+#: mailu/sso/forms.py:26
 msgid "Change password"
 msgstr "Změnit heslo"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -84,279 +107,310 @@ msgstr "Pomoc"
 msgid "Register a domain"
 msgstr "Registrovat doménu"
 
-#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:111
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
 #: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Registrovat se"
 
-#: mailu/sso/views/base.py:48
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
 msgid "Too many attempts from your IP (rate-limit)"
 msgstr "Příliš mnoho pokusů z vaší IP adresy (omezení rychlosti)"
 
-#: mailu/sso/views/base.py:51
+#: mailu/sso/views/base.py:52
 msgid "Too many attempts for this user (rate-limit)"
 msgstr "Příliš mnoho pokusů tohoto uživatele (omezení rychlosti)"
 
-#: mailu/sso/views/base.py:69
+#: mailu/sso/views/base.py:79
 msgid "Wrong e-mail or password"
 msgstr "Chybný e-mail nebo heslo"
 
-#: mailu/sso/views/base.py:85
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Vytvořit ověřovací token"
+
+#: mailu/sso/views/base.py:166
 msgid "The new password can't be the same as the old password"
 msgstr "Nové heslo nemůže být shodné s původním"
 
-#: mailu/sso/views/base.py:88
+#: mailu/sso/views/base.py:169
 msgid "The new passwords don't match"
 msgstr "Nová hesla se neshodují"
 
-#: mailu/sso/views/base.py:100
+#: mailu/sso/views/base.py:181
 msgid "The current password is incorrect!"
 msgstr "Současné heslo není správné!"
 
-#: mailu/ui/forms.py:34 mailu/ui/forms.py:37
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Neplatná e-mailová adresa."
 
-#: mailu/ui/forms.py:47
+#: mailu/ui/forms.py:56
 msgid "Invalid list of folders."
 msgstr "Neplatný seznam složek."
 
-#: mailu/ui/forms.py:56
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Potvrdit"
 
-#: mailu/ui/forms.py:59 mailu/ui/forms.py:69
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Název domény"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Maximální počet uživatelů"
 
-#: mailu/ui/forms.py:61
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Maximální počet aliasů"
 
-#: mailu/ui/forms.py:62
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Maximální kvóta uživatele"
 
-#: mailu/ui/forms.py:63 mailu/ui/templates/domain/list.html:24
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Povolit registraci"
 
-#: mailu/ui/forms.py:64 mailu/ui/forms.py:86 mailu/ui/forms.py:100
-#: mailu/ui/forms.py:155 mailu/ui/forms.py:175
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
 #: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
 #: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Komentář"
 
-#: mailu/ui/forms.py:65 mailu/ui/forms.py:80 mailu/ui/forms.py:87
-#: mailu/ui/forms.py:103 mailu/ui/forms.py:159 mailu/ui/forms.py:176
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Uložit"
 
-#: mailu/ui/forms.py:70
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Výchozí admin"
 
-#: mailu/ui/forms.py:71
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Heslo admina"
 
-#: mailu/ui/forms.py:72 mailu/ui/forms.py:93 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Potvrdit heslo"
 
-#: mailu/ui/forms.py:75
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Vytvořit"
 
-#: mailu/ui/forms.py:79
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Alternativní jméno"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Seznam předávaných domén"
 
-#: mailu/ui/forms.py:85 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Vzdálený hostitel"
 
-#: mailu/ui/forms.py:95 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
 #: mailu/ui/templates/user/list.html:23
 #: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Kvóta"
 
-#: mailu/ui/forms.py:96
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Povolit přístup IMAP"
 
-#: mailu/ui/forms.py:97
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Povolit přístup POP3"
 
-#: mailu/ui/forms.py:98
+#: mailu/ui/forms.py:107
 msgid "Allow the user to spoof the sender (send email as anyone)"
 msgstr "Povolit uživateli napodobit odesílatele (odeslat e-mail jako kdokoli)"
 
-#: mailu/ui/forms.py:99 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Zobrazené jméno"
 
-#: mailu/ui/forms.py:101
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Povoleno"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:111
 msgid "Force password change at next login"
 msgstr "Vynutit změnu hesla při příštím přihlášení"
 
-#: mailu/ui/forms.py:107
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "E-mailová adresa"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Povolit filtr spamu"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "Povolit označování spamových e-mailů jako přečtených"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Tolerance spamového filtru"
 
-#: mailu/ui/forms.py:121
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Povolit přeposílání"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Zachovat kopii e-mailů"
 
-#: mailu/ui/forms.py:123 mailu/ui/forms.py:174
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Cíl"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Uložit nastavení"
 
-#: mailu/ui/forms.py:129 mailu/ui/forms.py:136
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Kontrola hesla"
 
-#: mailu/ui/forms.py:131 mailu/ui/forms.py:138
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
 #: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Aktualizovat heslo"
 
-#: mailu/ui/forms.py:141
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Povolit automatickou odpověď"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Předmět odpovědi"
 
-#: mailu/ui/forms.py:143
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Tělo odpovědi"
 
-#: mailu/ui/forms.py:145
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "Začátek dovolené"
 
-#: mailu/ui/forms.py:146
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Konec dovolené"
 
-#: mailu/ui/forms.py:147
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Aktualizovat"
 
-#: mailu/ui/forms.py:152
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Váš token (zapište si ho, protože se již nikdy nezobrazí)"
 
-#: mailu/ui/forms.py:157 mailu/ui/templates/token/list.html:22
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Autorizovaná IP"
 
-#: mailu/ui/forms.py:171
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:173
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Použít syntaxi SQL LIKE (např. pro doménové koše)"
 
-#: mailu/ui/forms.py:180
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "E-mail admina"
 
-#: mailu/ui/forms.py:181 mailu/ui/forms.py:186 mailu/ui/forms.py:201
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Odeslat"
 
-#: mailu/ui/forms.py:185
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "E-mail manažera"
 
-#: mailu/ui/forms.py:190
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protokol"
 
-#: mailu/ui/forms.py:193
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Hostitel nebo IP"
 
-#: mailu/ui/forms.py:194 mailu/ui/templates/client.html:19
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
 #: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP port"
 
-#: mailu/ui/forms.py:195
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Povolit TLS"
 
-#: mailu/ui/forms.py:196 mailu/ui/templates/client.html:27
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
 #: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Uživatelské jméno"
 
-#: mailu/ui/forms.py:198
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Ponechat e-maily na serveru"
 
-#: mailu/ui/forms.py:199
+#: mailu/ui/forms.py:208
 msgid "Rescan emails locally"
 msgstr "Přeskenovat e-maily lokálně"
 
-#: mailu/ui/forms.py:200
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
 msgid "Folders to fetch on the server"
 msgstr "Složky na serveru určené ke stažení"
 
-#: mailu/ui/forms.py:205
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Vytvořit ověřovací token"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Vytvořit ověřovací token"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Předmět oznámení"
 
-#: mailu/ui/forms.py:207
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Tělo oznámení"
 
-#: mailu/ui/forms.py:209
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Poslat"
 
@@ -586,28 +640,37 @@ msgid "Download zonefile"
 msgstr "Stáhnout zonefile"
 
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Záznam DNS MX"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Záznamy DNS SPF"
 
 #: mailu/ui/templates/domain/details.html:40
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Záznam DNS DKIM"
 
 #: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Záznam DNS DMARC"
 
-#: mailu/ui/templates/domain/details.html:53
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "Záznam DNS TLSA"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "Položky automatického nastavení klienta DNS"
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Seznam alternativních domén"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -659,28 +722,30 @@ msgstr "ano"
 msgid "no"
 msgstr "ne"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr ""
 "Chcete-li zaregistrovat novou doménu, musíte nejprve nastavit\n"
-"     zónu domény tak, aby doménový <code>MX</code> záznam odkazoval na tento "
-"server"
+"     zónu domény tak, aby doménový <code>MX</code> záznam odkazoval na "
+"tento server"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
-"    please contact your DNS provider or administrator. Also, please wait a\n"
+"    please contact your DNS provider or administrator. Also, please wait "
+"a\n"
 "    couple minutes after the <code>MX</code> is set so the local server "
 "cache\n"
 "    expires."
 msgstr ""
 "Pokud nevíte, jak nastavit <code>MX</code> záznam pro zónu DNS,\n"
-"     kontaktujte svého poskytovatele DNS nebo správce. Dále prosím počkejte\n"
-"     několik minut po nastavení <code>MX</code> záznamu, aby se vymazal z "
-"mezipaměti\n"
+"     kontaktujte svého poskytovatele DNS nebo správce. Dále prosím "
+"počkejte\n"
+"     několik minut po nastavení <code>MX</code> záznamu, aby se vymazal z"
+" mezipaměti\n"
 "     místního serveru."
 
 #: mailu/ui/templates/fetch/create.html:4
@@ -759,6 +824,56 @@ msgstr "Nový token"
 msgid "ID"
 msgstr "ID"
 
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Vytvořit ověřovací token"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Nový uživatel"
@@ -774,6 +889,23 @@ msgstr "Funkce a kvóty"
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Upravit uživatele"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Vytvořit ověřovací token"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -803,6 +935,21 @@ msgstr "Automatická odpověď"
 msgid "Auto-forward"
 msgstr "Automatické přeposlání"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Vytvořit ověřovací token"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "vybrat doménu pro nový účet"
@@ -815,5 +962,23 @@ msgstr "Doména"
 msgid "Available slots"
 msgstr "Dostupné sloty"
 
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
+
 #~ msgid "DKIM public key"
 #~ msgstr "Veřejný klíč DKIM"
+

--- a/core/admin/mailu/translations/da/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/da/LC_MESSAGES/messages.po
@@ -7,32 +7,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2020-01-14 18:22+0000\n"
 "Last-Translator: Torben Jensen <tedomum@tjb.dk>\n"
 "Language: da\n"
 "Language-Team: Danish "
 "<https://translate.tedomum.net/projects/mailu/admin/da/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Adgangskode"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Log ind"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Godkendelsestokens"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Administrator adgangskode"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Administrator adgangskode"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Opdatér adgangskode"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -46,255 +89,331 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Gå til"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Klient opsætning"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Webside"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Hjælp"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Registrer et domæne"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Tilmeld"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Gentag adgangskode"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Godkendelsestokens"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Ugyldig email adresse."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Godkend"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Domænenavn"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Maksimum antal brugere"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Maksimum antal aliaser"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Maksimum bruger kvota"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Tillad brugeroprettelse"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Kommentér"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Gem"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Initiél administrator"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Administrator adgangskode"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Gentag adgangskode"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Opret"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Alternativt navn"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr ""
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Fjernhost"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Kvota"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Tillad IMAP adgang"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Tillad POP3 adgang"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Vist navn"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Aktiveret"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "E-mail adresse"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Aktivér spamfilter"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Spamfilter følsomhed"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Aktiver videresendelse"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Behold kopi af e-mailsne"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Modtager"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Gem indstillinger"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Adgangskode tjek"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Opdatér adgangskode"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Aktivér automatisk svar"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Svaremne"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Svartekst"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Sidste feriedag"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Opdater"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Din token (skriv den ned, da den ikke bliver vist igen)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Godkendt IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Brug SQL LIKE syntaks (f.eks. til catch-all aliaser)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Administrator e-mail"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Send"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Manager e-mail"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protokol"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Værtsnavn eller IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP port"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Aktivér TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Brugernavn"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Gem e-mails på serveren"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+msgid "Enable two-factor authentication"
+msgstr ""
+
+#: mailu/ui/forms.py:221
+msgid "Disable two-factor authentication"
+msgstr ""
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr ""
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr ""
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Send"
 
@@ -302,7 +421,7 @@ msgstr "Send"
 msgid "Public announcement"
 msgstr ""
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Antispam"
@@ -315,20 +434,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Mail protokol"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Servernavn"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -348,7 +475,7 @@ msgstr "Docker fejl"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Der opstod en fejl i kommunikationen med Docker serveren."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -356,48 +483,48 @@ msgstr ""
 msgid "My account"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Indstillinger"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Auto-svar"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Hentede konti"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Godkendelsestokens"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Administration"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Administratorer"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Uddelegerede domæner"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Maildomæner"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Webmail"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Log ud"
 
@@ -431,12 +558,18 @@ msgstr "Handlinger"
 msgid "Email"
 msgstr "E-mail"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Rediger"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Slet"
 
@@ -458,25 +591,19 @@ msgstr "Tilføj alias"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Oprettet"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Sidst redigeret"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Rediger"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -511,33 +638,42 @@ msgstr "Forny nøgler"
 msgid "Generate keys"
 msgstr "Opret nøgler"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "MX DNS post"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "SPF DNS poster"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "DKIM offentlig nøgle"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DKIM DNS post"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DMARC DNS post"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Alternativ domæneliste"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -559,33 +695,43 @@ msgstr "Antal mailkonti"
 msgid "Alias count"
 msgstr "Antal alias"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Detaljer"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Brugere"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Alias"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Bestyrere"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternativer"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "ja"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "nej"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr ""
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -617,20 +763,21 @@ msgid "Keep emails"
 msgstr "Behold e-mails"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Behold e-mails"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Sidst tjekket"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "ja"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "nej"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -668,6 +815,59 @@ msgstr ""
 msgid "New token"
 msgstr ""
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+msgid "Two-factor authentication enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr ""
@@ -676,12 +876,28 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr ""
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+msgid "Reset two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
 msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
@@ -712,21 +928,55 @@ msgstr ""
 msgid "Auto-forward"
 msgstr ""
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+msgid "Manage two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr ""
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr ""
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Tilgængelige pladser"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "to access the administration tools"
 #~ msgstr "for at tilgå de administrative værktøjer"
 
 #~ msgid "Forward emails"
 #~ msgstr ""
+
+#~ msgid "DKIM public key"
+#~ msgstr "DKIM offentlig nøgle"
 

--- a/core/admin/mailu/translations/de/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/de/LC_MESSAGES/messages.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-06-20 12:30+0000\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language: de\n"
@@ -13,14 +13,14 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.15.0\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:91
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-Mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:92 mailu/ui/forms.py:108
-#: mailu/ui/forms.py:128 mailu/ui/forms.py:135 mailu/ui/forms.py:197
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
 #: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Passwort"
@@ -30,21 +30,45 @@ msgstr "Passwort"
 msgid "Sign in"
 msgstr "Anmelden"
 
-#: mailu/sso/forms.py:15 mailu/ui/forms.py:134
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Authentifizierungs-Tokens"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
 msgid "Current password"
 msgstr "Aktuelles Passwort"
 
-#: mailu/sso/forms.py:16
+#: mailu/sso/forms.py:23
 msgid "New password"
 msgstr "Neues Passwort"
 
-#: mailu/sso/forms.py:17
+#: mailu/sso/forms.py:24
 msgid "New password (again)"
 msgstr "Passwort wiederholen"
 
-#: mailu/sso/forms.py:19
+#: mailu/sso/forms.py:26
 msgid "Change password"
 msgstr "Passwort ändern"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -80,279 +104,312 @@ msgstr "Hilfe"
 msgid "Register a domain"
 msgstr "Regestrieren Sie eine Domain"
 
-#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:111
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
 #: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Registrieren"
 
-#: mailu/sso/views/base.py:48
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
 msgid "Too many attempts from your IP (rate-limit)"
 msgstr "Zu viele Versuche von Ihrer IP (Rate-Limit)"
 
-#: mailu/sso/views/base.py:51
+#: mailu/sso/views/base.py:52
 msgid "Too many attempts for this user (rate-limit)"
 msgstr "Zu viele Versuche für diesen Benutzer (Rate-Limit)"
 
-#: mailu/sso/views/base.py:69
+#: mailu/sso/views/base.py:79
 msgid "Wrong e-mail or password"
 msgstr "Falsche E-Mail oder Passwort"
 
-#: mailu/sso/views/base.py:85
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Authentifizierungs-Token erstellen"
+
+#: mailu/sso/views/base.py:166
 msgid "The new password can't be the same as the old password"
 msgstr "Das neue Passwort darf nicht mit dem alten Passwort übereinstimmen"
 
-#: mailu/sso/views/base.py:88
+#: mailu/sso/views/base.py:169
 msgid "The new passwords don't match"
 msgstr "Die neuen Passwörter stimmen nicht überein"
 
-#: mailu/sso/views/base.py:100
+#: mailu/sso/views/base.py:181
 msgid "The current password is incorrect!"
 msgstr "Das aktuelle Passwort ist falsch!"
 
-#: mailu/ui/forms.py:34 mailu/ui/forms.py:37
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Ungültige E-Mail-Adresse."
 
-#: mailu/ui/forms.py:47
+#: mailu/ui/forms.py:56
 msgid "Invalid list of folders."
 msgstr "Ungültige Ordnerliste."
 
-#: mailu/ui/forms.py:56
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Bestätigen"
 
-#: mailu/ui/forms.py:59 mailu/ui/forms.py:69
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Domain-Name"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Maximale Anzahl Benutzer"
 
-#: mailu/ui/forms.py:61
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Maximale Anzahl Aliase"
 
-#: mailu/ui/forms.py:62
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Maximale Quota pro Benutzer"
 
-#: mailu/ui/forms.py:63 mailu/ui/templates/domain/list.html:24
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Neuanmeldung erlauben"
 
-#: mailu/ui/forms.py:64 mailu/ui/forms.py:86 mailu/ui/forms.py:100
-#: mailu/ui/forms.py:155 mailu/ui/forms.py:175
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
 #: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
 #: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Kommentar"
 
-#: mailu/ui/forms.py:65 mailu/ui/forms.py:80 mailu/ui/forms.py:87
-#: mailu/ui/forms.py:103 mailu/ui/forms.py:159 mailu/ui/forms.py:176
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Speichern"
 
-#: mailu/ui/forms.py:70
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Initiale Admin-Adresse"
 
-#: mailu/ui/forms.py:71
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Administrator Passwort"
 
-#: mailu/ui/forms.py:72 mailu/ui/forms.py:93 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Passwort bestätigen"
 
-#: mailu/ui/forms.py:75
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Erstellen"
 
-#: mailu/ui/forms.py:79
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Alternativer Name"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Relay-Domain-Name"
 
-#: mailu/ui/forms.py:85 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Entfernter Host"
 
-#: mailu/ui/forms.py:95 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
 #: mailu/ui/templates/user/list.html:23
 #: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Kontingent"
 
-#: mailu/ui/forms.py:96
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Zugriff via IMAP erlauben"
 
-#: mailu/ui/forms.py:97
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Zugriff via POP3 erlauben"
 
-#: mailu/ui/forms.py:98
+#: mailu/ui/forms.py:107
 msgid "Allow the user to spoof the sender (send email as anyone)"
-msgstr "Dem Benutzer ermöglichen, den Absender zu fälschen (E-Mail als jedermann senden)"
+msgstr ""
+"Dem Benutzer ermöglichen, den Absender zu fälschen (E-Mail als jedermann "
+"senden)"
 
-#: mailu/ui/forms.py:99 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Angezeigter Name"
 
-#: mailu/ui/forms.py:101
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Aktiv"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:111
 msgid "Force password change at next login"
 msgstr "Kennwortänderung bei der nächsten Anmeldung erzwingen"
 
-#: mailu/ui/forms.py:107
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "E-Mail-Adresse"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Spamfilter aktivieren"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "Spam automatisch als gelesen markieren"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Spamfilter-Grenzwert"
 
-#: mailu/ui/forms.py:121
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Weiterleitung aktivieren"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Kopie der E-Mails behalten"
 
-#: mailu/ui/forms.py:123 mailu/ui/forms.py:174
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Ziel"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Einstellungen speichern"
 
-#: mailu/ui/forms.py:129 mailu/ui/forms.py:136
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Passwort wiederholen"
 
-#: mailu/ui/forms.py:131 mailu/ui/forms.py:138
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
 #: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Passwort aktualisieren"
 
-#: mailu/ui/forms.py:141
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Automatische Antwort aktivieren"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Betreff"
 
-#: mailu/ui/forms.py:143
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Text"
 
-#: mailu/ui/forms.py:145
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "Beginn der Abwesenheit"
 
-#: mailu/ui/forms.py:146
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Ende der Abwesenheit"
 
-#: mailu/ui/forms.py:147
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: mailu/ui/forms.py:152
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Token (bitte speichern, da er später nicht mehr angezeigt wird)"
 
-#: mailu/ui/forms.py:157 mailu/ui/templates/token/list.html:22
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Authorisierte IP-Adresse"
 
-#: mailu/ui/forms.py:171
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:173
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "SQL LIKE Syntax nutzen (z.B. für Catch-All-Aliase)"
 
-#: mailu/ui/forms.py:180
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Administrator E-Mail"
 
-#: mailu/ui/forms.py:181 mailu/ui/forms.py:186 mailu/ui/forms.py:201
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Absenden"
 
-#: mailu/ui/forms.py:185
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Manager E-Mail"
 
-#: mailu/ui/forms.py:190
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: mailu/ui/forms.py:193
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Hostname oder IP"
 
-#: mailu/ui/forms.py:194 mailu/ui/templates/client.html:19
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
 #: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP Port"
 
-#: mailu/ui/forms.py:195
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Verschlüsselung aktivieren (TLS)"
 
-#: mailu/ui/forms.py:196 mailu/ui/templates/client.html:27
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
 #: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Benutzername"
 
-#: mailu/ui/forms.py:198
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "E-Mails auf dem Server belassen"
 
-#: mailu/ui/forms.py:199
+#: mailu/ui/forms.py:208
 msgid "Rescan emails locally"
 msgstr "E-Mails lokal erneut scannen"
 
-#: mailu/ui/forms.py:200
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
 msgid "Folders to fetch on the server"
 msgstr "Auf dem Server abzurufende Ordner"
 
-#: mailu/ui/forms.py:205
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Authentifizierungs-Token erstellen"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Authentifizierungs-Token erstellen"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Betreff"
 
-#: mailu/ui/forms.py:207
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Text"
 
-#: mailu/ui/forms.py:209
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Absenden"
 
@@ -584,30 +641,34 @@ msgid "Download zonefile"
 msgstr "Zonefile herunterladen"
 
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX Eintrag"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF Einträge"
 
 #: mailu/ui/templates/domain/details.html:40
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM Eintrag"
 
 #: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC Eintrag"
 
-#: mailu/ui/templates/domain/details.html:53
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "DNS TLSA Eintrag"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "DNS Einträge für die automatische Client-Konfiguration"
 
-#: mailu/ui/templates/domain/details.html:71
+#: mailu/ui/templates/domain/details.html:73
 msgid "Alternative Domain name"
 msgstr "Alternativer Domain Name"
 
@@ -661,7 +722,7 @@ msgstr "ja"
 msgid "no"
 msgstr "nein"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -670,7 +731,7 @@ msgstr ""
 "<code>MX Resource Record</code> der neuen Domäne konfigurieren. Dieser "
 "muss auf den aktuellen Mail-Server verweisen."
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -762,6 +823,56 @@ msgstr "Neuer Token"
 msgid "ID"
 msgstr "ID"
 
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Authentifizierungs-Token erstellen"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Neuer Benutzer"
@@ -777,6 +888,23 @@ msgstr "Funktionen und Quotas"
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Benutzer bearbeiten"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Authentifizierungs-Token erstellen"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -806,6 +934,21 @@ msgstr "Automatische Antwort"
 msgid "Auto-forward"
 msgstr "Auto-Weiterleitung"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Authentifizierungs-Token erstellen"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "Wählen Sie eine Domain für das neue Benutzerkonto"
@@ -817,3 +960,21 @@ msgstr "Domain"
 #: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Verfügbare Plätze"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
+

--- a/core/admin/mailu/translations/en/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/en/LC_MESSAGES/messages.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2024-06-20 12:30+0000\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Jaume Barber <jaumebarber@gmail.com>\n"
 "Language: en\n"
@@ -17,14 +17,14 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.15.0\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:91
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:92 mailu/ui/forms.py:108
-#: mailu/ui/forms.py:128 mailu/ui/forms.py:135 mailu/ui/forms.py:197
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
 #: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Password"
@@ -34,20 +34,43 @@ msgstr "Password"
 msgid "Sign in"
 msgstr ""
 
-#: mailu/sso/forms.py:15 mailu/ui/forms.py:134
-msgid "Current password"
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+msgid "Authentication code"
 msgstr ""
 
-#: mailu/sso/forms.py:16
-msgid "New password"
-msgstr ""
-
-#: mailu/sso/forms.py:17
-msgid "New password (again)"
+#: mailu/sso/forms.py:18
+msgid "Verify"
 msgstr ""
 
 #: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+msgid "Current password"
+msgstr ""
+
+#: mailu/sso/forms.py:23
+msgid "New password"
+msgstr ""
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
 msgid "Change password"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
 msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
@@ -84,279 +107,307 @@ msgstr ""
 msgid "Register a domain"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:111
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
 #: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Sign up"
 
-#: mailu/sso/views/base.py:48
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
 msgid "Too many attempts from your IP (rate-limit)"
 msgstr ""
 
-#: mailu/sso/views/base.py:51
+#: mailu/sso/views/base.py:52
 msgid "Too many attempts for this user (rate-limit)"
 msgstr ""
 
-#: mailu/sso/views/base.py:69
+#: mailu/sso/views/base.py:79
 msgid "Wrong e-mail or password"
 msgstr ""
 
-#: mailu/sso/views/base.py:85
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+msgid "Invalid authentication code"
+msgstr ""
+
+#: mailu/sso/views/base.py:166
 msgid "The new password can't be the same as the old password"
 msgstr ""
 
-#: mailu/sso/views/base.py:88
+#: mailu/sso/views/base.py:169
 msgid "The new passwords don't match"
 msgstr ""
 
-#: mailu/sso/views/base.py:100
+#: mailu/sso/views/base.py:181
 msgid "The current password is incorrect!"
 msgstr ""
 
-#: mailu/ui/forms.py:34 mailu/ui/forms.py:37
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr ""
 
-#: mailu/ui/forms.py:47
+#: mailu/ui/forms.py:56
 msgid "Invalid list of folders."
 msgstr ""
 
-#: mailu/ui/forms.py:56
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Confirm"
 
-#: mailu/ui/forms.py:59 mailu/ui/forms.py:69
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr ""
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Maximum user count"
 
-#: mailu/ui/forms.py:61
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr ""
 
-#: mailu/ui/forms.py:62
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Maximum user quota"
 
-#: mailu/ui/forms.py:63 mailu/ui/templates/domain/list.html:24
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Enable sign-up"
 
-#: mailu/ui/forms.py:64 mailu/ui/forms.py:86 mailu/ui/forms.py:100
-#: mailu/ui/forms.py:155 mailu/ui/forms.py:175
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
 #: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
 #: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Comment"
 
-#: mailu/ui/forms.py:65 mailu/ui/forms.py:80 mailu/ui/forms.py:87
-#: mailu/ui/forms.py:103 mailu/ui/forms.py:159 mailu/ui/forms.py:176
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Save"
 
-#: mailu/ui/forms.py:70
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Initial admin"
 
-#: mailu/ui/forms.py:71
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Admin password"
 
-#: mailu/ui/forms.py:72 mailu/ui/forms.py:93 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Confirm password"
 
-#: mailu/ui/forms.py:75
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Create"
 
-#: mailu/ui/forms.py:79
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Alternative name"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr ""
 
-#: mailu/ui/forms.py:85 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr ""
 
-#: mailu/ui/forms.py:95 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
 #: mailu/ui/templates/user/list.html:23
 #: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Quota"
 
-#: mailu/ui/forms.py:96
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Allow IMAP access"
 
-#: mailu/ui/forms.py:97
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Allow POP3 access"
 
-#: mailu/ui/forms.py:98
+#: mailu/ui/forms.py:107
 msgid "Allow the user to spoof the sender (send email as anyone)"
 msgstr ""
 
-#: mailu/ui/forms.py:99 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr ""
 
-#: mailu/ui/forms.py:101
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Enabled"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:111
 msgid "Force password change at next login"
 msgstr ""
 
-#: mailu/ui/forms.py:107
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr ""
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Enable spam filter"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Spam filter tolerance"
 
-#: mailu/ui/forms.py:121
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Enable forwarding"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr ""
 
-#: mailu/ui/forms.py:123 mailu/ui/forms.py:174
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr ""
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Save settings"
 
-#: mailu/ui/forms.py:129 mailu/ui/forms.py:136
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr ""
 
-#: mailu/ui/forms.py:131 mailu/ui/forms.py:138
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
 #: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr ""
 
-#: mailu/ui/forms.py:141
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr ""
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr ""
 
-#: mailu/ui/forms.py:143
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr ""
 
-#: mailu/ui/forms.py:145
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:146
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "End of vacation"
 
-#: mailu/ui/forms.py:147
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Update"
 
-#: mailu/ui/forms.py:152
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr ""
 
-#: mailu/ui/forms.py:157 mailu/ui/templates/token/list.html:22
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Authorized IP"
 
-#: mailu/ui/forms.py:171
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:173
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr ""
 
-#: mailu/ui/forms.py:180
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr ""
 
-#: mailu/ui/forms.py:181 mailu/ui/forms.py:186 mailu/ui/forms.py:201
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr ""
 
-#: mailu/ui/forms.py:185
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr ""
 
-#: mailu/ui/forms.py:190
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr ""
 
-#: mailu/ui/forms.py:193
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr ""
 
-#: mailu/ui/forms.py:194 mailu/ui/templates/client.html:19
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
 #: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP port"
 
-#: mailu/ui/forms.py:195
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr ""
 
-#: mailu/ui/forms.py:196 mailu/ui/templates/client.html:27
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
 #: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr ""
 
-#: mailu/ui/forms.py:198
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr ""
 
-#: mailu/ui/forms.py:199
+#: mailu/ui/forms.py:208
 msgid "Rescan emails locally"
 msgstr ""
 
-#: mailu/ui/forms.py:200
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
 msgid "Folders to fetch on the server"
 msgstr ""
 
-#: mailu/ui/forms.py:205
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+msgid "Enable two-factor authentication"
+msgstr ""
+
+#: mailu/ui/forms.py:221
+msgid "Disable two-factor authentication"
+msgstr ""
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr ""
 
-#: mailu/ui/forms.py:207
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr ""
 
-#: mailu/ui/forms.py:209
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr ""
 
@@ -586,28 +637,37 @@ msgid "Download zonefile"
 msgstr ""
 
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr ""
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr ""
 
 #: mailu/ui/templates/domain/details.html:40
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr ""
 
 #: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:53
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Alternative name"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -659,13 +719,13 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr ""
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -752,6 +812,55 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+msgid "Two-factor authentication enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr ""
@@ -766,6 +875,22 @@ msgstr ""
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+msgid "Reset two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
 msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
@@ -796,6 +921,20 @@ msgstr ""
 msgid "Auto-forward"
 msgstr ""
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+msgid "Manage two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr ""
@@ -806,5 +945,22 @@ msgstr "Domain"
 
 #: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
+msgstr ""
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
 msgstr ""
 

--- a/core/admin/mailu/translations/es/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/es/LC_MESSAGES/messages.po
@@ -3,32 +3,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Jaume Barber <jaumebarber@gmail.com>\n"
 "Language: es\n"
 "Language-Team: Spanish "
 "<https://translate.tedomum.net/projects/mailu/admin/es/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "Dirección de correo"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Contraseña"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Entrar"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Tokens de autenticación"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Contraseña del administrador"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Contraseña del administrador"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Actualizar contraseña"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -42,255 +85,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Ir a"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Configuración del cliente"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Sitio web"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Ayuda"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Registrar un dominio"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Registrarse"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Confirmar contraseña"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Crear un token de autenticación"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Dirección de correo inválida."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Nombre de dominio"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Máximo número de usuarios"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Máximo número de alias"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Límite de cuota de usuario"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Permitir registros"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Comentario"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Guardar"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Administrador inicial"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Contraseña del administrador"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Confirmar contraseña"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Crear"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Nombre alternativo"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Nombre de dominio a recepcionar"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Servidor remoto"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Espacio"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Permitir acceso IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Permitir acceso POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Nombre a mostrar"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Direcciones de correo"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Habilitar filtro de spam"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "Habilitar marcado de correos spam como leídos"
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Tolerancia del filtro de spam"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Habilitar reenvío"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Mantener una copia de los correos"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destino"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Guardar configuración"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Revisar contraseña"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Actualizar contraseña"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Habilitar respuesta automática"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Título de la respuesta"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Texto de la respuesta"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "Comienzo de las vacaciones"
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Fin de las vacaciones"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Actualizar"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Su token (anótelo, ya que no se mostrará nunca más)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "IP autorizada"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Usar sintaxis SQL (p.ej. para abarcar todos los alias)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Correo del administrador"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Enviar"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Correo del gestor"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Nombre o IP del servidor"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Puerto TCP"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Habilitar TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Nombre de usuario"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Mantener los correos en el servidor"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Crear un token de autenticación"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Crear un token de autenticación"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Título del anuncio"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Texto del anuncio"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Enviar"
 
@@ -298,7 +419,7 @@ msgstr "Enviar"
 msgid "Public announcement"
 msgstr "Anuncio público"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Antispam"
@@ -311,20 +432,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Protocolo de correo"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Nombre del servidor"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -344,7 +473,7 @@ msgstr "Error de Docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Ocurrió un error en la comunicación con el servidor Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr "copiar en portapapeles"
 
@@ -352,48 +481,48 @@ msgstr "copiar en portapapeles"
 msgid "My account"
 msgstr "Mi cuenta"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Configuración"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Auto-respuesta"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Cuentas recogidas"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Tokens de autenticación"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Administración"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Anuncio"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Administradores"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Dominios recepcionados (relayed)"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Dominios de correo"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Correo web"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Salir"
 
@@ -427,12 +556,18 @@ msgstr "Acciones"
 msgid "Email"
 msgstr "Correo"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Editar"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Eliminar"
 
@@ -454,25 +589,19 @@ msgstr "Añadir alias"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Creado"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Última edición"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Editar"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -507,33 +636,42 @@ msgstr "Regenerar llaves"
 msgid "Generate keys"
 msgstr "Generar llaves"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Entrada MX del DNS"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Entradas SPF del DNS"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Llave pública DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Entrada DKIM en DNS"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Registro DMARC en DNS"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Lista de dominios alternativos"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -555,27 +693,37 @@ msgstr "Contar buzones"
 msgid "Alias count"
 msgstr "Contar alias"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Detalles"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Usuarios"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Alias"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Gestores"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternativas"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "sí"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "no"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -583,7 +731,7 @@ msgstr ""
 "Para registrar un nuevo dominio primero debe configurar la zona DNS de "
 "modo que los registros <code>MX</code> apunten a este servidor"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -619,20 +767,21 @@ msgid "Keep emails"
 msgstr "Mantener los correos"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Mantener los correos"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Última comprobación"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Estado"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "sí"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "no"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -670,6 +819,60 @@ msgstr "Crear un token de autenticación"
 msgid "New token"
 msgstr "Nuevo token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Crear un token de autenticación"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Nuevo usuario"
@@ -678,13 +881,30 @@ msgstr "Nuevo usuario"
 msgid "General"
 msgstr "General"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Funcionalidades y cuotas"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Editar usuario"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Crear un token de autenticación"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -714,17 +934,49 @@ msgstr "Respuesta automática"
 msgid "Auto-forward"
 msgstr "Auto-reenvío"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Crear un token de autenticación"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "Seleccione un dominio para la nueva cuenta"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Dominio"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Slots disponibles"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "Límite del filtro de spam"
@@ -761,4 +1013,7 @@ msgstr "Slots disponibles"
 
 #~ msgid "General settings"
 #~ msgstr "Configuración general"
+
+#~ msgid "DKIM public key"
+#~ msgstr "Llave pública DKIM"
 

--- a/core/admin/mailu/translations/eu/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/eu/LC_MESSAGES/messages.po
@@ -7,31 +7,73 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Jaume Barber <jaumebarber@gmail.com>\n"
 "Language: eu\n"
 "Language-Team: Basque "
 "<https://translate.tedomum.net/projects/mailu/admin/eu/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Pasahitza"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
+msgstr ""
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+msgid "Authentication code"
+msgstr ""
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Administratzaileko pasahitza"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Administratzaileko pasahitza"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Administratzaileko pasahitza"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
 msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
@@ -46,255 +88,330 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr ""
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr ""
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Erregistratu"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Berretsi pasahitza"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+msgid "Invalid authentication code"
+msgstr ""
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "baliogabeko helbide elektronikoa."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Ados"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr ""
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Erabiltzaileen gehieneko kopurua"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr ""
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Erabiltzaile bakoitzeko gehieneko espazioa"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Gaitu erregistroa"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Iruzkindua"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Gorde"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Administratzailea"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Administratzaileko pasahitza"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Berretsi pasahitza"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Sortu"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Izen alternatiboa"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Igorritako domeinu izena"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Urruneko ostalaria"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Espazioa"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Baimendu IMAP sarbidea"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Baimendu POP3 sarbidea"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr ""
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Gaituta"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr ""
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Gaitu spam iragazkia"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Spam iragazkiaren tolerantzia"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Gaitu birbidaltzea"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr ""
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr ""
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Gorde ezarpenak"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr ""
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr ""
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr ""
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr ""
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr ""
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Oporren amaiera"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Eguneratu"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr ""
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Baimendutako IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Ezizenza"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr ""
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr ""
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr ""
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr ""
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr ""
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr ""
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP ataka"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr ""
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr ""
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr ""
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+msgid "Enable two-factor authentication"
+msgstr ""
+
+#: mailu/ui/forms.py:221
+msgid "Disable two-factor authentication"
+msgstr ""
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr ""
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr ""
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr ""
 
@@ -302,7 +419,7 @@ msgstr ""
 msgid "Public announcement"
 msgstr ""
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Antispam"
@@ -315,20 +432,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr ""
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr ""
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -348,7 +473,7 @@ msgstr "Docker-en errorea"
 msgid "An error occurred while talking to the Docker server."
 msgstr ""
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -356,48 +481,48 @@ msgstr ""
 msgid "My account"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr ""
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Igorritako domeinuak"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr ""
 
@@ -431,12 +556,18 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr ""
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr ""
 
@@ -458,24 +589,18 @@ msgstr ""
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr ""
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
-msgstr ""
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
 msgstr ""
 
 #: mailu/ui/templates/alternative/create.html:4
@@ -511,33 +636,42 @@ msgstr ""
 msgid "Generate keys"
 msgstr ""
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr ""
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr ""
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr ""
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Izen alternatiboa"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -559,33 +693,43 @@ msgstr ""
 msgid "Alias count"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr ""
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr ""
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr ""
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr ""
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -617,19 +761,19 @@ msgid "Keep emails"
 msgstr ""
 
 #: mailu/ui/templates/fetch/list.html:23
-msgid "Last check"
+msgid "Rescan emails"
 msgstr ""
 
 #: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
+msgid "Last check"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
-msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
 msgstr ""
 
 #: mailu/ui/templates/manager/create.html:4
@@ -668,6 +812,59 @@ msgstr ""
 msgid "New token"
 msgstr ""
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+msgid "Two-factor authentication enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr ""
@@ -676,12 +873,28 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr ""
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+msgid "Reset two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
 msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
@@ -712,21 +925,55 @@ msgstr ""
 msgid "Auto-forward"
 msgstr ""
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+msgid "Manage two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr ""
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Domeinu izena"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
+msgstr ""
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
 msgstr ""
 
 #~ msgid "to access the administration tools"
 #~ msgstr ""
 
 #~ msgid "Forward emails"
+#~ msgstr ""
+
+#~ msgid "DKIM public key"
 #~ msgstr ""
 

--- a/core/admin/mailu/translations/fa/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/fa/LC_MESSAGES/messages.po
@@ -7,33 +7,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: hosni.hossein@gmail.com\n"
-"POT-Creation-Date: 2023-09-09 00:33+0330\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2023-09-09 01:21+0330\n"
 "Last-Translator: Hossein Hosni <hosni.hossein@gmail.com>\n"
-"Language-Team: Persian <https://translate.tedomum.net/projects/mailu/admin/"
-"en/>\n"
 "Language: fa\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Persian "
+"<https://translate.tedomum.net/projects/mailu/admin/en/>\n"
 "Plural-Forms: nplurals=2; plural=(n==0 || n==1);\n"
-"Generated-By: Babel 2.3.4\n"
-"X-Generator: Poedit 3.3.2\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "پست الکترونیک"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "گذرواژه"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "ورود"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "کلیدهای احراز هویت"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "گذرواژه مدیریت"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "گذرواژه مدیریت"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "بروزرسانی گذرواژه"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -47,255 +89,333 @@ msgstr "نوار کناری را تغییر دهید"
 msgid "change language"
 msgstr "تغییر زبان"
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "برو به"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "تنظیمات سرویس‌گیرنده"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "وب سایت"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "راهنما"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "ثبت دامنه"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "ثبت‌نام"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "تایید گذرواژه"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "ایجاد کلید احراز هویت"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "پست‌الکترونیک اشتباه است."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "تایید"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "آدرس دامنه"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "حداکثر تعداد کاربر"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "حداکثر تعداد نام مستعار"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "حداکثر سهمیه کاربر"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "فعال کردن ثبت نام"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "یادداشت"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "ذخیره"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "مدیر نخستین"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "گذرواژه مدیریت"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "تایید گذرواژه"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "ایجاد"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "نام جایگزین"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "نام دامنه میانجی"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "میزبان راه‌دور"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "سهمیه"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "دسترسی IMAP مجاز باشد"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "دسترسی POP3 مجاز باشد"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "نام نمایشی"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "فعال"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "پست الکترونیکی"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "فعال‌کردن پایش هرزنامه"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "فعال‌سازی علامت‌زدن هرزنامه به عنوان خوانده‌شده"
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "بازه تحمل هرزنامه"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "فعال‌سازی بازارسال"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "نگهداری رونوشت از پست‌الکترونیک"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "مقصد"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "ذخیره تنظیمات"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "بررسی گذرواژه"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "بروزرسانی گذرواژه"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "فعال‌سازی پاسخگوی‌خودکار"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "موضوع پاسخگویی"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "متن پاسخگویی"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "شروع استراحت"
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "پایان استراحت"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "بروزرسانی"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "کلید شما (کلید را یادداشت کنید، چرا که دوباره نمایش داده نخواهد شد)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Authorized IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "استفاده از قواعد اس‌کیو‌ال (برای پوشش الایس‌ها)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "افزودن پست‌الکترونیکی"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "ثبت"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "مدیریت پست‌الکترونیک"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "پرتکل"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "نشانی یا آی‌پی"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "پورت تی‌سی‌پی"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "فعال‌سازی TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "نام‌کاربری"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "نگهداری ایمیل در سرور"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "ایجاد کلید احراز هویت"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "ایجاد کلید احراز هویت"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "موضوع آگهی"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "متن آگهی"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "ارسال"
 
@@ -303,7 +423,7 @@ msgstr "ارسال"
 msgid "Public announcement"
 msgstr "آگهی عمومی"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "ضدهرزنامه"
@@ -316,21 +436,29 @@ msgstr "صفحه گزارش وضعیت RSPAMD"
 msgid "configure your email client"
 msgstr "تنظیمات کاربر پست‌الکترونیک"
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr "ایمیل ورودی"
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "پرتکل ایمیل"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "نام سرور"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
 msgstr "ایمیل خروجی"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
 msgid "Confirm action"
@@ -349,7 +477,7 @@ msgstr "خطای داکر"
 msgid "An error occurred while talking to the Docker server."
 msgstr "خطایی در هنگام ارتباط با سرور داکر به وجود آمده است."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr "کپی در حافظه"
 
@@ -357,48 +485,48 @@ msgstr "کپی در حافظه"
 msgid "My account"
 msgstr "حساب من"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "تنظیمات"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "پاسخ‌گوی خودکار"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "اکانت‌ها واکشی‌شده"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "کلیدهای احراز هویت"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "مدیریت"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "آگهی"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "مدیران"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "دامنه‌های میانجی"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "دامنه‌های ایمیل"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "پنل‌وب‌ایمیل"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "خروج"
 
@@ -432,12 +560,18 @@ msgstr "عملیات"
 msgid "Email"
 msgstr "پست‌الکترونیک"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "ویرایش"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "حذف"
 
@@ -459,25 +593,19 @@ msgstr "افزودن الایس"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "ایجاد شد"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "آخرین ویرایش"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "ویرایش"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -512,33 +640,42 @@ msgstr "ایجاد مجدد کلید‌ها"
 msgid "Generate keys"
 msgstr "ایجاد کلید‌ها"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "کلید عمومی DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "DNS TLSA"
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "DNS client auto-configuration"
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "لیست دامنه‌های دیگر"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -560,47 +697,58 @@ msgstr "تعداد جعبه ایمیل"
 msgid "Alias count"
 msgstr "تعداد الایس‌ها"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "جزئیات"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "کاربران"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "الایس‌ها"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "مدیران"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "جایگزین‌ها"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "بلی"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "خیر"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr ""
-"برای ثبت دامنه جدید، ابتدا می‌بایست تنظیمات DNS ٔدامنه را به گونه‌ای تنظیم کنید "
-"که رکورد <code>MX</code> آن به سرور ما اشاره کند"
+"برای ثبت دامنه جدید، ابتدا می‌بایست تنظیمات DNS ٔدامنه را به گونه‌ای "
+"تنظیم کنید که رکورد <code>MX</code> آن به سرور ما اشاره کند"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
-"    please contact your DNS provider or administrator. Also, please wait a\n"
+"    please contact your DNS provider or administrator. Also, please wait "
+"a\n"
 "    couple minutes after the <code>MX</code> is set so the local server "
 "cache\n"
 "    expires."
 msgstr ""
-"در صورتی که نمی‌دانید چگونه تنظیمات رکورد <code>MX</code> دامنه خود را انجام "
-"دهید، می‌بایست با فروشنده دامنه خود ارتباط برقرار کنید.\n"
-"همچنین بعد از تنظیم رکورد <code>MX</code> دقایقی را تا اعمال نتیجه آن منتظر "
-"بمانید."
+"در صورتی که نمی‌دانید چگونه تنظیمات رکورد <code>MX</code> دامنه خود را "
+"انجام دهید، می‌بایست با فروشنده دامنه خود ارتباط برقرار کنید.\n"
+"همچنین بعد از تنظیم رکورد <code>MX</code> دقایقی را تا اعمال نتیجه آن "
+"منتظر بمانید."
 
 #: mailu/ui/templates/fetch/create.html:4
 msgid "Add a fetched account"
@@ -623,20 +771,21 @@ msgid "Keep emails"
 msgstr "نگهداری ایمیل‌ها"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "نگهداری ایمیل‌ها"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "آخرین بررسی"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "وضعیت"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "بلی"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "خیر"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -674,6 +823,60 @@ msgstr "ایجاد کلید احراز هویت"
 msgid "New token"
 msgstr "کلید جدید"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "ایجاد کلید احراز هویت"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "کاربر جدید"
@@ -682,13 +885,30 @@ msgstr "کاربر جدید"
 msgid "General"
 msgstr "عمومی"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "قابلیت‌ها و سهمیه"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "ویرایش کاربر"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "ایجاد کلید احراز هویت"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -718,14 +938,50 @@ msgstr "پاسخگوی خودکار"
 msgid "Auto-forward"
 msgstr "بازارسال خودکار"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "ایجاد کلید احراز هویت"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "انتخاب دامنه برای حساب جدید"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "دامنه"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "جایگاه‌های موجود"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
+
+#~ msgid "DKIM public key"
+#~ msgstr "کلید عمومی DKIM"
+

--- a/core/admin/mailu/translations/fr/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/fr/LC_MESSAGES/messages.po
@@ -3,32 +3,74 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2020-01-06 12:22+0000\n"
 "Last-Translator: Angedestenebres <angedestenebres@tugaleres.com>\n"
 "Language: fr\n"
 "Language-Team: French "
 "<https://translate.tedomum.net/projects/mailu/admin/fr/>\n"
-"Plural-Forms: nplurals=2; plural=n > 1\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Mot de passe"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Se connecter"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Jetons d'authentification"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+msgid "Current password"
+msgstr "Mot de passe actuel"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Mot de passe administrateur"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Changer de mot de passe"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -42,279 +84,336 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Navigation"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Configuration client"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Site web"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Aide"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Inscrire un domaine"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "S'inscrire"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Confirmer le mot de passe"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Créer un jeton d'authentification"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+#, fuzzy
+msgid "The current password is incorrect!"
+msgstr "Mot de passe actuel"
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Adresse e-mail invalide."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Confirmer"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Nom de domaine"
 
-#: mailu/ui/forms.py:134
-msgid "Current password"
-msgstr "Mot de passe actuel"
-
-#: mailu/ui/forms.py:98
-msgid "Allow the user to spoof the sender (send email as anyone)"
-msgstr "Permettre à l'utilisateur de changer l'expéditeur (envoyer un e-mail en tant que n'importe qui)"
-
-#: mailu/ui/forms.py:102
-msgid "Force password change at next login"
-msgstr "Forcer le changement du mot de passe à la prochaine connexion"
-
-#: mailu/ui/templates/domain/details.html:19
-msgid "Download zonefile"
-msgstr "Télécharger le fichier de zone"
-
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Nombre maximum d'utilisateurs"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Nombre maximum d'alias"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Quota maximum par utilisateur"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Autoriser l'inscription"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Commentaire"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Enregistrer"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Administrateur initial"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Mot de passe administrateur"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Confirmer le mot de passe"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Créer"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Nom alternatif"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Nom du domaine relayé"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Hôte distant"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Quota"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Autoriser l'accès IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Autoriser l'accès POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+"Permettre à l'utilisateur de changer l'expéditeur (envoyer un e-mail en "
+"tant que n'importe qui)"
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Nom affiché"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Activé"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr "Forcer le changement du mot de passe à la prochaine connexion"
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Adresse e-mail"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Activer le filtre anti-spam"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Tolérance du filtre antispam"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Activer la redirection"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Conserver une copie des messages"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destination"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Enregistrer les préférences"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Vérifier le mot de passe"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Changer de mot de passe"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Activer les réponses automatique"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Sujet du message"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Corps de la réponse"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Fin du mode vacance"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Mettre à jour"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Votre jeton (à conserver, il ne sera plus affiché par la suite)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Adresse IP autorisée"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Utiliser la syntaxe SQL LIKE (par exemple pour les alias catch-all)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Email de l'administrateur"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Valider"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "E-mail du gérant"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protocole"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Nom d'hôte ou adresse IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Port TCP"
 
-#: mailu/ui/templates/client.html:62
-msgid "If you use an Apple device,"
-msgstr "Si vous utilisez un appareil Apple,"
-
-#: mailu/ui/templates/client.html:63
-msgid "click here to auto-configure it."
-msgstr "cliquez ici pour le configurer automatiquement."
-
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Activer TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Nom d'utilisateur"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Conserver les messages sur le serveur"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Créer un jeton d'authentification"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Créer un jeton d'authentification"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Sujet de l'annonce"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Corps de l'annonce"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Envoyer"
 
@@ -322,7 +421,7 @@ msgstr "Envoyer"
 msgid "Public announcement"
 msgstr "Annonce globale"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Antispam"
@@ -335,21 +434,29 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Protocole"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Nom du serveur"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
 msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "Si vous utilisez un appareil Apple,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "cliquez ici pour le configurer automatiquement."
 
 #: mailu/ui/templates/confirm.html:4
 msgid "Confirm action"
@@ -368,7 +475,7 @@ msgstr "Erreur Docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Une erreur s'est produite en communiquant avec le serveur Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -376,48 +483,48 @@ msgstr ""
 msgid "My account"
 msgstr "Mon compte"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Préférences"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Réponse automatique"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Comptes externes"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Jetons d'authentification"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Administration"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Annonce"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Administrateurs"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Domaines relayés"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Domaines"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Webmail"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Déconnexion"
 
@@ -451,12 +558,18 @@ msgstr "Actions"
 msgid "Email"
 msgstr "E-mail"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Modifier"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -478,25 +591,19 @@ msgstr "Ajouter un alias"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Création"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Dernière modification"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Modifier"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -531,33 +638,42 @@ msgstr "Regénérer les clés"
 msgid "Generate keys"
 msgstr "Générer les clés"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr "Télécharger le fichier de zone"
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Entrée DNS MX"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Entrées DNS SPF"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Clé publique DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Entrée DNS DKIM"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Entrée DNS DMARC"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "Entrée DNS TLSA"
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "Entrées DNS pour la configuration client automatique"
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Liste des domaines alternatifs"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -579,27 +695,37 @@ msgstr "Nombre de boîtes mail"
 msgid "Alias count"
 msgstr "Nombre d'alias"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Détails"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Utilisateurs"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Alias"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Gérants"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternatives"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "oui"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "non"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -608,7 +734,7 @@ msgstr ""
 "zone DNS de sorte que le <code>MX</code> du domaine pointe sur ce "
 "serveur."
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -645,20 +771,21 @@ msgid "Keep emails"
 msgstr "Conserver les messages"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Conserver les messages"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Dernier relevé"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "État"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "oui"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "non"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -696,6 +823,60 @@ msgstr "Créer un jeton d'authentification"
 msgid "New token"
 msgstr "Nouveau jeton"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Créer un jeton d'authentification"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Nouvel utilisateur"
@@ -704,13 +885,30 @@ msgstr "Nouvel utilisateur"
 msgid "General"
 msgstr "Général"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Fonctionnalités et quotas"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Modifier l'utilisateur"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Créer un jeton d'authentification"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -740,17 +938,49 @@ msgstr "Réponse automatique"
 msgid "Auto-forward"
 msgstr "Redirection"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Créer un jeton d'authentification"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "choix du domaine pour le compte"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Domaine"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Places disponibles"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "Seuil du filtre anti-spam"
@@ -787,4 +1017,7 @@ msgstr "Places disponibles"
 
 #~ msgid "General settings"
 #~ msgstr "Général"
+
+#~ msgid "DKIM public key"
+#~ msgstr "Clé publique DKIM"
 

--- a/core/admin/mailu/translations/he/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/he/LC_MESSAGES/messages.po
@@ -8,33 +8,76 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Mailu 1.5.1\n"
 "Report-Msgid-Bugs-To: heb-bugzap@projects.hamakor.org.il \n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-07-19 09:04+0300\n"
 "Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language: he\n"
 "Language-Team: Hebrew "
 "<https://translate.tedomum.net/projects/mailu/admin/he/>\n"
 "Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 "
-"&& n % 10 == 0) ? 2 : 3))\n"
+"&& n % 10 == 0) ? 2 : 3));\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "דוא״ל"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "סיסמה"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "כניסה"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "אסימוני אימות"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "סיסמת ניהול"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "סיסמת ניהול"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "עדכון סיסמה"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -48,255 +91,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "מעבר אל"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "הגדרת לקוח"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "אתר"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "עזרה"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "רישום שם תחום"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "הרשמה"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "אישור סיסמה"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "יצירת אסימון אימות"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "כתובת דוא״ל שגויה."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "אישור"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "שם תחום"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "כמות המשתמשים המרבית"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "כמות הכינויים המרבית"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "מיכסת המשתמשים המרבית"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "לאפשר הרשמה"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "תגובה"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "שמירה"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "מנהל ראשוני"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "סיסמת ניהול"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "אישור סיסמה"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "יצירה"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "שם חלופי"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "שם תחום מועבר"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "מארח מרוחק"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "מיכסה"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "לאפשר גישה ב־IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "לאפשר גישה ב־POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "שם מוצג"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "מופעל"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "כתובת דוא״ל"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "הפעלת מסנן ספאם"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "סובלנות מסנן הספאם"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "הפעלת העברה"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "להשאיר עותק מההודעות"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "יעד"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "שמירת הגדרות"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "בדיקת סיסמה"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "עדכון סיסמה"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "הפעלת תגובה אוטומטית"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "נושא התגובה"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "גוף התגובה"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "סוף החופשה"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "עדכון"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "האסימון שלך (כדאי לשמור עליו היטב כיוון שהוא לא יופיע פעם נוספת)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "כתובת IP מורשית"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "כינוי"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "להשתמש בתחביר דמוי SQL (למשל: catch-all aliases)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "דוא״ל ההנהלה"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "הגשה"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "דוא״ל המפקח"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "פרוטוקול"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "שם מארח או כתובת IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "פתחת TCP"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "הפעלת TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "שם משתמש"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "להשאיר את ההודעות על השרת"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "יצירת אסימון אימות"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "יצירת אסימון אימות"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "נושא ההכרזה"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "גוף ההכרזה"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "שליחה"
 
@@ -304,7 +425,7 @@ msgstr "שליחה"
 msgid "Public announcement"
 msgstr "הכרזה פומבית"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "מניעת ספאם"
@@ -317,20 +438,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "פרוטוקול דוא״ל"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "שם שרת"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -350,7 +479,7 @@ msgstr "שגיאת Docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "אירעה שגיאה בעת החיבור לשרת ה־Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -358,48 +487,48 @@ msgstr ""
 msgid "My account"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "הגדרות"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "מענה אוטומטית"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "חשבונות נמשכים"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "אסימוני אימות"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "ניהול"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "הכרזה"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "מנהלים"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "שמות תחום מועברים"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "דמות תחום לדוא״ל"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "דוא״ל בדפדפן"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "יציאה"
 
@@ -433,12 +562,18 @@ msgstr "פעולות"
 msgid "Email"
 msgstr "דוא״ל"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "עריכה"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "מחיקה"
 
@@ -460,25 +595,19 @@ msgstr "הוספת כינוי"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "נוצר"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "עריכה אחרונה"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "עריכה"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -513,33 +642,42 @@ msgstr "יצירת מפתחות מחדש"
 msgid "Generate keys"
 msgstr "יצירת מפתחות"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "רשומת MX ב־DNS"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "רשומות SPF ב־DNS"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "מפתח DKIM ציבורי"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "רשומת DKIM ב־DNS"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "רשומת DMARC ב־DNS"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "רשימת שמות תחום חלופיים"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -561,27 +699,37 @@ msgstr "כמות תיבות דוא״ל"
 msgid "Alias count"
 msgstr "כמות כינויים"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "פרטים"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "משתמשים"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "כינויים"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "מפקחים"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "חלופות"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "כן"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "לא"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -589,7 +737,7 @@ msgstr ""
 "כדי לרשום שם תחום חדש, תחילה עליך להקים את אזור התחום\n"
 "    ‏(domain zone) כדי שה־<code>MX</code> של שם התחום יפנה לשרת הזה"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -626,20 +774,21 @@ msgid "Keep emails"
 msgstr "לשמור על ההודעות"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "לשמור על ההודעות"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "בדיקה אחרונה"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "כן"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "לא"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -677,6 +826,60 @@ msgstr "יצירת אסימון אימות"
 msgid "New token"
 msgstr "אסימון חדש"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "יצירת אסימון אימות"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "משתמש חדש"
@@ -685,13 +888,30 @@ msgstr "משתמש חדש"
 msgid "General"
 msgstr "כללי"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "יכולות ומיכסות"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "עריכת משתמש"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "יצירת אסימון אימות"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -721,21 +941,56 @@ msgstr "מענה אוטומטי"
 msgid "Auto-forward"
 msgstr "העברה אוטומטית"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "יצירת אסימון אימות"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "נא לבחור שם תחום לחשבון החדש"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "שם תחום"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "מקומות פנויים"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "to access the administration tools"
 #~ msgstr "כדי לגשת לכלי הניהול"
 
 #~ msgid "Forward emails"
 #~ msgstr "העברת הודעות"
+
+#~ msgid "DKIM public key"
+#~ msgstr "מפתח DKIM ציבורי"
 

--- a/core/admin/mailu/translations/hu/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/hu/LC_MESSAGES/messages.po
@@ -3,32 +3,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2020-01-31 01:22+0000\n"
 "Last-Translator: Andrási István <isiandrasi@gmail.com>\n"
 "Language: hu\n"
 "Language-Team: Hungarian "
 "<https://translate.tedomum.net/projects/mailu/admin/hu/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Jelszó"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Belépés"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Belépési tokenek"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Adminisztrátor jelszó"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Adminisztrátor jelszó"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Jelszó frissítése"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -42,255 +85,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Ugrás"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Kliens beállítás"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Weboldal"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Súgó"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Tartomány regisztrálása"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Feliratkozás"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Jelszó megerősítése"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Belépési token létrehozása"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Érvénytelen levelezési cím."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Megerősít"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Tartomány"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Maximális felhasználók száma"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Maximális álnevek száma"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Maximális felhasználói kvóta"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Feliratkozás engedélyezése"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Megjegyzés"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Mentés"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Kezdeti adminisztrátor"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Adminisztrátor jelszó"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Jelszó megerősítése"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Létrehoz"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Alternatív név"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Továbbított tartomány neve"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Távoli hoszt"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Kvóta"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "IMAP hozzáférés engedélyezése"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "POP3 hozzáférés engedélyezéseq"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Megjelenő név"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Engedélyezve"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Email cím"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Levélszemét szűrő engedélyezése"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Szűrő tolerancia"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Továbbítás engedélyezése"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Levélmásolat megtartása"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Cél"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Beállítások mentése"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Jelszó ellenőrzése"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Jelszó frissítése"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Automatikus válasz engedélyezése"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Válasz tárgya"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Válasz levéltörzs"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Távollét vége"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Frissítés"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Token (írja le, többet nem jelenik meg a képernyőn)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Engedélyezett IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Álnév"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "SQL-szerű kifejezések használata (pl.: mint a catch-all álnevek)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Adminisztrátor címe"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Elküldés"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Menedzser címe"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Hosztnév vagy IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP port"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "TLS engedélyezése"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Felhasználó neve"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Levelek szerveren tartása"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Belépési token létrehozása"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Belépési token létrehozása"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Bejelentés tárgya"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Bejelentés levéltörzs"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Küldés"
 
@@ -298,7 +419,7 @@ msgstr "Küldés"
 msgid "Public announcement"
 msgstr "Nyilvános bejelentés"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Levélszemét szűrő"
@@ -311,20 +432,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Levél protokoll"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Kiszolgáló neve"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -344,7 +473,7 @@ msgstr "Docker hiba"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Hiba lépett fel a Docker kiszolgáló kommunikációjában."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -352,48 +481,48 @@ msgstr ""
 msgid "My account"
 msgstr "Saját fiók"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Beállítások"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Automatikus válasz"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Letöltött fiókok"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Belépési tokenek"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Adminisztrátor"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Bejelentés"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Adminisztrátorok"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Továbbított tartományok"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Levelezési tartomány"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Webmail"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Kilépés"
 
@@ -427,12 +556,18 @@ msgstr "Tevékenység"
 msgid "Email"
 msgstr "E-mail"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Szerkesztés"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Törlés"
 
@@ -454,25 +589,19 @@ msgstr "Álnév hozzáadása"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Létrehozva"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Utolsó szerkesztés"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Szerkesztés"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -507,33 +636,42 @@ msgstr "Kulcsok újragenerálása"
 msgid "Generate keys"
 msgstr "Kulcsok létrehozása"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX rekord"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF rekord"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "DKIM nyilvános kulcs"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM rekord"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC rekord"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Alternatív tartományok"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -555,27 +693,37 @@ msgstr "Postaládák száma"
 msgid "Alias count"
 msgstr "Álnevek száma"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Részletek"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Felhasználók"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Álnevek"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Kezelők"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternatívák"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "igen"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "nem"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -584,7 +732,7 @@ msgstr ""
 "zónát,\n"
 "  hogy a tartomány <code>MX</code> rekordja erre a kiszolgálóra mutasson."
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -620,20 +768,21 @@ msgid "Keep emails"
 msgstr "Levelek megtartása"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Levelek megtartása"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Utolsó ellenőrzés"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Állapot"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "igen"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "nem"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -671,6 +820,60 @@ msgstr "Belépési token létrehozása"
 msgid "New token"
 msgstr "Új token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Belépési token létrehozása"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Új felhasználó"
@@ -679,13 +882,30 @@ msgstr "Új felhasználó"
 msgid "General"
 msgstr "Általános"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Jellemzők és kvóták"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Felhasználó szerkesztése"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Belépési token létrehozása"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -715,17 +935,49 @@ msgstr "Automatikus válasz"
 msgid "Auto-forward"
 msgstr "Automatikus továbbítás"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Belépési token létrehozása"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "válasszon tartományt az új fiókhoz"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Tartomány"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Elérhető rekeszek"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "Levélszemét szűrő korlátja"
@@ -762,4 +1014,7 @@ msgstr "Elérhető rekeszek"
 
 #~ msgid "General settings"
 #~ msgstr "Általános beállítások"
+
+#~ msgid "DKIM public key"
+#~ msgstr "DKIM nyilvános kulcs"
 

--- a/core/admin/mailu/translations/is/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/is/LC_MESSAGES/messages.po
@@ -7,30 +7,69 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: is\n"
 "Language-Team: is <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr ""
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr ""
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
+msgstr ""
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+msgid "Authentication code"
+msgstr ""
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+msgid "Current password"
+msgstr ""
+
+#: mailu/sso/forms.py:23
+msgid "New password"
+msgstr ""
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+msgid "Change password"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
 msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
@@ -45,255 +84,329 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr ""
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr ""
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr ""
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+msgid "Wrong e-mail or password"
+msgstr ""
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+msgid "Invalid authentication code"
+msgstr ""
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr ""
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr ""
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr ""
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr ""
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr ""
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr ""
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr ""
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr ""
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr ""
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr ""
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr ""
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr ""
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr ""
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr ""
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr ""
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr ""
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr ""
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr ""
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr ""
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr ""
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr ""
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr ""
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr ""
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr ""
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr ""
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr ""
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr ""
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr ""
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr ""
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr ""
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr ""
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr ""
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr ""
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr ""
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr ""
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr ""
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr ""
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr ""
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr ""
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr ""
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr ""
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr ""
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr ""
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr ""
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr ""
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr ""
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr ""
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+msgid "Enable two-factor authentication"
+msgstr ""
+
+#: mailu/ui/forms.py:221
+msgid "Disable two-factor authentication"
+msgstr ""
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr ""
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr ""
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr ""
 
@@ -301,7 +414,7 @@ msgstr ""
 msgid "Public announcement"
 msgstr ""
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr ""
@@ -314,20 +427,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr ""
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr ""
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -347,7 +468,7 @@ msgstr ""
 msgid "An error occurred while talking to the Docker server."
 msgstr ""
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -355,48 +476,48 @@ msgstr ""
 msgid "My account"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr ""
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr ""
 
@@ -430,12 +551,18 @@ msgstr ""
 msgid "Email"
 msgstr ""
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr ""
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr ""
 
@@ -457,24 +584,18 @@ msgstr ""
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr ""
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
-msgstr ""
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
 msgstr ""
 
 #: mailu/ui/templates/alternative/create.html:4
@@ -510,32 +631,40 @@ msgstr ""
 msgid "Generate keys"
 msgstr ""
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr ""
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr ""
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr ""
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
+msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+msgid "Alternative Domain name"
 msgstr ""
 
 #: mailu/ui/templates/domain/edit.html:4
@@ -558,33 +687,43 @@ msgstr ""
 msgid "Alias count"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr ""
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr ""
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr ""
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr ""
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr ""
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -616,19 +755,19 @@ msgid "Keep emails"
 msgstr ""
 
 #: mailu/ui/templates/fetch/list.html:23
-msgid "Last check"
+msgid "Rescan emails"
 msgstr ""
 
 #: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
+msgid "Last check"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
-msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
 msgstr ""
 
 #: mailu/ui/templates/manager/create.html:4
@@ -667,6 +806,59 @@ msgstr ""
 msgid "New token"
 msgstr ""
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+msgid "Two-factor authentication enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr ""
@@ -675,12 +867,28 @@ msgstr ""
 msgid "General"
 msgstr ""
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr ""
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+msgid "Reset two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
 msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
@@ -711,21 +919,55 @@ msgstr ""
 msgid "Auto-forward"
 msgstr ""
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+msgid "Manage two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr ""
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr ""
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
+msgstr ""
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
 msgstr ""
 
 #~ msgid "to access the administration tools"
 #~ msgstr ""
 
 #~ msgid "Forward emails"
+#~ msgstr ""
+
+#~ msgid "DKIM public key"
 #~ msgstr ""
 

--- a/core/admin/mailu/translations/it/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/it/LC_MESSAGES/messages.po
@@ -3,32 +3,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Jaume Barber <jaumebarber@gmail.com>\n"
 "Language: it\n"
 "Language-Team: Italian "
 "<https://translate.tedomum.net/projects/mailu/admin/it/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Password"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Entra"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Token di autenticazione"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Admin password"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Admin password"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Aggiorna password"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -42,255 +85,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Vai a"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Impostazioni del cliente"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Sito web"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Aiuto"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Registrare un dominio"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Iscriversi"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Conferma pasword"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Crea un token di autenticazione"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Indirizzo email non valido."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Conferma"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Nome dominio"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Numero massimo utenti"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Numero massimo alias"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Spazio massimo per utente"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Avviare l'iscrizione"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Commento"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Salva"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Admin iniziale"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Admin password"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Conferma pasword"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Crea"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Nome alternativo"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Nome di dominio affidato"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Host remoto"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Quota"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Consenti accesso IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Consenti accesso POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Nome visualizzato"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Attivo"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Indirizzo email"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Abilita filtro antispam"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Tolleranza filtro spam"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Abilita inoltro"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Conserva una copia delle email"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destinazione"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Salva impostazioni"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Verifica la password"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Aggiorna password"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Abilita risposta automatica"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Soggetto risposta"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Corpo risposta"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Rientro delle vacanze"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Aggiorna"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Il suo token (dovrà annotarlo, dato che non verrà più mostrato)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "IP Autorizzato"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Usa sintassi SQL LIKE (es. per alias catch-all)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Email amministratore"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Invia"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Email manager"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protocollo"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Hostname o IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Porta TCP"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Abilita TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Nome utente"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Conserva email sul server"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Crea un token di autenticazione"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Crea un token di autenticazione"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Oggetto dell'avviso"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Corpo dell'annuncio"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Invia"
 
@@ -298,7 +419,7 @@ msgstr "Invia"
 msgid "Public announcement"
 msgstr "Annuncio pubblico"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Antispam"
@@ -311,20 +432,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Protocolo mail"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Nome del server"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -344,7 +473,7 @@ msgstr "Errore Docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "C'è stato un errore nel tentativo di connessione con il Docker server."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -352,48 +481,48 @@ msgstr ""
 msgid "My account"
 msgstr "Il mio account"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Auto-risponditore"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Conti ricuperati"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Token di autenticazione"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Amministrazione"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Annuncio"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Amministratori"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Domini affidati"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Domini mail"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Webmail"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Esci"
 
@@ -427,12 +556,18 @@ msgstr "Azioni"
 msgid "Email"
 msgstr "Email"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Modifica"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Elimina"
 
@@ -454,25 +589,19 @@ msgstr "Aggiungi alias"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Creato"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Ultima modifica"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Modifica"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -507,33 +636,42 @@ msgstr "Rigenera chiavi"
 msgid "Generate keys"
 msgstr "Generare chiavi"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Entrate DNS MX"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Entrate DNS SPF"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Chiave pubblica DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Entrata DNS DKIM"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Entrata DNS DMARC"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Elenco di domini alternativi"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -555,27 +693,37 @@ msgstr "Conteggio mailbox"
 msgid "Alias count"
 msgstr "Conteggio alias"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Dettagli"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Utenti"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Alias"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Manager"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternative"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "si"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "no"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -584,7 +732,7 @@ msgstr ""
 "domain zone affinché  il vostro dominio <code>MX</code> punti contro il "
 "server"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -623,20 +771,21 @@ msgid "Keep emails"
 msgstr "Conserva email"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Conserva email"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Ultimo controllo"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Stato"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "si"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "no"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -674,6 +823,60 @@ msgstr "Crea un token di autenticazione"
 msgid "New token"
 msgstr "Nuovo token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Crea un token di autenticazione"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Nuovo utente"
@@ -682,13 +885,30 @@ msgstr "Nuovo utente"
 msgid "General"
 msgstr "Generale"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Funzionalità e quota"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Modifica utente"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Crea un token di autenticazione"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -718,17 +938,49 @@ msgstr "Risposta automatica"
 msgid "Auto-forward"
 msgstr "Auto-inoltro"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Crea un token di autenticazione"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "scelga un dominio per il nuovo conto"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Dominio"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Slot disponibili"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "Soglia del filtro antispam"
@@ -765,4 +1017,7 @@ msgstr "Slot disponibili"
 
 #~ msgid "General settings"
 #~ msgstr "Impostazioni generali"
+
+#~ msgid "DKIM public key"
+#~ msgstr "Chiave pubblica DKIM"
 

--- a/core/admin/mailu/translations/ja/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/ja/LC_MESSAGES/messages.po
@@ -3,31 +3,74 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Ichikawa Yuriko <ichikawayuriko@yahoo.co.jp>\n"
 "Language: ja\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-Mailアドレス"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "パスワード"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "ログイン"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "認証トークン"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "管理パスワード"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "管理パスワード"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "パスワード変更"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -41,255 +84,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "リンク"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "クライアント設定"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Webサイト"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "ヘルプ"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "ドメインを登録"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "ユーザー登録"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "パスワード(再入力)"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "認証トークンを作成"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "無効なメールアドレスです"
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "確認"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "ドメイン名"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "最大ユーザー数"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "最大エイリアス数"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "ユーザーの最大容量"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "ユーザー登録を有効にする"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "コメント"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "保存"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "初期管理者アドレス"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "管理パスワード"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "パスワード(再入力)"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "作成"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "代替ドメイン名"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "リレードメイン名"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "サーバー"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "容量"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "IMAPアクセスを許可"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "POP3アクセスを許可"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "表示名"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "有効"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "E-Mailアドレス"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "スパムフィルターを有効"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "スパムフィルターの閾値"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "自動転送を有効"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "メールのコピーを残す"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "宛先"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "設定を保存"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "パスワード(再入力)"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "パスワード変更"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "自動返信を有効"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "返信件名"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "返信本文"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "自動返信終了日"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "更新"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "トークン (一度だけしか表示されません。書き留めてください。)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "認証するIPアドレス"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "エイリアス名"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "SQL LIKE構文を使う (例：Catch-All エイリアス)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "管理者のE-Mail"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "保存"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "管理者メールアドレス"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "プロトコル"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "ホスト名またはIPアドレス"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP ポート"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "TLSを有効にする"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "ユーザー名"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "サーバーにメールを残す"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "認証トークンを作成"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "認証トークンを作成"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "告知タイトル"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "告知本文"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "送信"
 
@@ -297,7 +418,7 @@ msgstr "送信"
 msgid "Public announcement"
 msgstr "一斉告知"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "スパムメール対策"
@@ -310,20 +431,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "メールプロトコル"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "サーバーアドレス"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -343,7 +472,7 @@ msgstr "Docker エラー"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Dockerサーバーと通信中にエラーが発生しました。"
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -351,48 +480,48 @@ msgstr ""
 msgid "My account"
 msgstr "アカウント設定"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "設定"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "自動返信"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "外部メールアカウント"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "認証トークン"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "サービス設定"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "告知"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "管理者"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "リレードメイン"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "メールドメイン"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Webメール"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "ログアウト"
 
@@ -426,12 +555,18 @@ msgstr "操作"
 msgid "Email"
 msgstr "メールアドレス"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "編集"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "削除"
 
@@ -453,25 +588,19 @@ msgstr "エイリアスを作成"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "作成日"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "最終更新日"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "編集"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -506,33 +635,42 @@ msgstr "鍵を再生成"
 msgid "Generate keys"
 msgstr "キーを生成"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MXエントリ"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPFエントリ"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "DKIM公開鍵"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIMエントリ"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARCエントリ"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "代替ドメイン名一覧"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -554,27 +692,37 @@ msgstr "メールボックス数"
 msgid "Alias count"
 msgstr "エイリアス数"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "詳細"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "ユーザー"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "エイリアス"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "管理者"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "代替ドメイン"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "はい"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "いいえ"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -582,7 +730,7 @@ msgstr ""
 "新しいドメインを登録するには、最初に<code>MX</code>レコードが\n"
 "このサーバーを指すようにDNSゾーンを設定する必要があります。"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -617,20 +765,21 @@ msgid "Keep emails"
 msgstr "メールを残す"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "メールを残す"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "最終確認"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "状態"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "はい"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "いいえ"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -668,6 +817,60 @@ msgstr "認証トークンを作成"
 msgid "New token"
 msgstr "トークンを作成"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "認証トークンを作成"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "ユーザーを作成"
@@ -676,13 +879,30 @@ msgstr "ユーザーを作成"
 msgid "General"
 msgstr "一般"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "サーバ機能と容量"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "ユーザーを編集"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "認証トークンを作成"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -712,17 +932,49 @@ msgstr "自動返信"
 msgid "Auto-forward"
 msgstr "自動転送"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "認証トークンを作成"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "新しいアカウントのドメインを選んでください"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "ドメイン名"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "空きメールボックス数"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "スパムフィルターの閾値"
@@ -759,4 +1011,7 @@ msgstr "空きメールボックス数"
 
 #~ msgid "General settings"
 #~ msgstr "一般設定"
+
+#~ msgid "DKIM public key"
+#~ msgstr "DKIM公開鍵"
 

--- a/core/admin/mailu/translations/nb_NO/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/nb_NO/LC_MESSAGES/messages.po
@@ -7,32 +7,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2019-10-21 20:13+0000\n"
 "Last-Translator: Simen Kildahl Eriksen <s@kildahl.cc>\n"
 "Language: nb_NO\n"
 "Language-Team: Norwegian Bokmål "
 "<https://translate.tedomum.net/projects/mailu/admin/nb_NO/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-post"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Passord"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Logg inn"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Autoriserings-token"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Admin passord"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Admin passord"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Oppdater passord"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -46,255 +89,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Gå til"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Oppsett av klienter"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Nettside"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Hjelp"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Registrer et domene"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Register deg"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Bekreft passord"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Lag en autentiserings-token"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Feil epostadresse."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Bekreft"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Domenenavn"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Maks antall brukere"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Maks antall alias"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Maksimal mengde brukere"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Tillat registrering"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Kommentar"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Lagre"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Første-admin"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Admin passord"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Bekreft passord"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Opprett"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Alternativt navn"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Videresendt domenenavn"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Ekstern vert"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Kvote"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Tillat IMAP tilgang"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Tillat POP3 tilgang"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Visningsnavn"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Aktivert"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Epostadresse"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Aktiver spamfilter"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Toleranse på spamfilter"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Aktiver videresending"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Behold en kopi av meldingene"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destinasjon"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Lagre innstillingene"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Bekreft passord"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Oppdater passord"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Aktiver automatisk svar"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Tittel på svar"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Svar-melding"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Ferieslutt"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Oppdater"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Din token (skriv denne ned, vil ikke kunne vises senere)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Autorisert IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Bruk SQL LIKE syntaks (eks. for å fange alle eposter)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Admin E-post"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Lagre"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Manager E-post"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Host eller IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP port"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Aktiver TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Brukernavn"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Behold E-post på serveren"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Lag en autentiserings-token"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Lag en autentiserings-token"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Tittel på kunngjøring"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Melding på kunngjøring"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Send"
 
@@ -302,7 +423,7 @@ msgstr "Send"
 msgid "Public announcement"
 msgstr "Offentlig kunngjøring"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Søppelfilter"
@@ -315,20 +436,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "E-post protokoll"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Servernavn"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -348,7 +477,7 @@ msgstr "Docker-feil"
 msgid "An error occurred while talking to the Docker server."
 msgstr "En feil oppstod ved kommunisering med docker serveren."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -356,48 +485,48 @@ msgstr ""
 msgid "My account"
 msgstr ""
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Innstillinger"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Automatisk svar"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Hentede kontoer"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Autoriserings-token"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Administrasjon"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Kunngjøring"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Administratorer"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Videresendt domene"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "E-post domener"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "E-post"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Logg ut"
 
@@ -431,12 +560,18 @@ msgstr "Handlinger"
 msgid "Email"
 msgstr "E-post"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Endre"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Slett"
 
@@ -458,25 +593,19 @@ msgstr "Legg til alias"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Opprettet"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Sist endret"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Endre"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -511,33 +640,42 @@ msgstr "Regenerer nøkler"
 msgid "Generate keys"
 msgstr "Generer nøkler"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX oppføring"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF oppføringer"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "DKIM offentlig nøkkel"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM oppføring"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC oppføring"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Alternative domener"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -559,27 +697,37 @@ msgstr "Antall mailkontoer"
 msgid "Alias count"
 msgstr "Antall alias"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Detaljer"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Brukere"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Alias"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Managere"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternativer"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "ja"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "nei"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -587,7 +735,7 @@ msgstr ""
 "For å kinne registrere et bytt domene, må du først sette opp\n"
 "domeneområdet slik at domenet <code>MX</code> peker til denne serveren"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -625,20 +773,21 @@ msgid "Keep emails"
 msgstr "Behold e-poster"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Behold e-poster"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Sist sjekk"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "ja"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "nei"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -676,6 +825,60 @@ msgstr "Lag en autentiserings-token"
 msgid "New token"
 msgstr "Ny token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Lag en autentiserings-token"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Ny bruker"
@@ -684,13 +887,30 @@ msgstr "Ny bruker"
 msgid "General"
 msgstr "Generelt"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Funksjoner og kvoter"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Endre bruker"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Lag en autentiserings-token"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -720,21 +940,56 @@ msgstr "Automatisk svar"
 msgid "Auto-forward"
 msgstr "Automatisk videresending"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Lag en autentiserings-token"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "velg et domene for den nye kontoen"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Domene"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Tilgjengelige plasser"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "to access the administration tools"
 #~ msgstr "gå inn på administrasjonssenter"
 
 #~ msgid "Forward emails"
 #~ msgstr "Videresend e-poster"
+
+#~ msgid "DKIM public key"
+#~ msgstr "DKIM offentlig nøkkel"
 

--- a/core/admin/mailu/translations/nl/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/nl/LC_MESSAGES/messages.po
@@ -3,31 +3,73 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl\n"
 "Language-Team: nl <LL@li.org>\n"
-"Plural-Forms: nplurals=2; plural=(n != 1)\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Wachtwoord"
 
 #: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Aanmelden"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Authenticatie tokens"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+msgid "Current password"
+msgstr "Huidig wachtwoord"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Beheerder wachtwoord"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Wachtwoord veranderen"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -41,279 +83,338 @@ msgstr "Zijbalk in/uitklappen"
 msgid "change language"
 msgstr "kies taal"
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Ga naar"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Client instellingen"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Website"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Help"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Registreer een domein"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Registreren"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Bevestig wachtwoord"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Authenticatie token aanmaken"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+#, fuzzy
+msgid "The current password is incorrect!"
+msgstr "Huidig wachtwoord"
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Ongeldig e-mailadres."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Bevestigen"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Domeinnaam"
 
-#: mailu/ui/templates/domain/details.html:19
-msgid "Download zonefile"
-msgstr "Download zone-bestand"
-
-#: mailu/ui/forms.py:98
-msgid "Allow the user to spoof the sender (send email as anyone)"
-msgstr "Sta toe dat de gebruiker de verzender kan vervalsen (namens iedereen email versturen)"
-
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Maximaal aantal gebruikers"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Maximaal aantal aliasen"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Maximum quotum gebruikers"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Schakel registreren in"
 
-#: mailu/ui/forms.py:102
-msgid "Force password change at next login"
-msgstr "Forceer dat bij de volgende aanmelding het wachtwoord veranderd moet worden"
-
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Opmerking"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Opslaan"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Eerste beheerder"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Beheerder wachtwoord"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Bevestig wachtwoord"
 
-#: mailu/ui/forms.py:134
-msgid "Current password"
-msgstr "Huidig wachtwoord"
-
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Aanmaken"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Alternatieve naam"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Relayed domeinnaam"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Externe host"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Quotum"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "IMAP toestaan"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "POP3 toestaan"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+"Sta toe dat de gebruiker de verzender kan vervalsen (namens iedereen "
+"email versturen)"
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Getoonde naam"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Ingeschakeld"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+"Forceer dat bij de volgende aanmelding het wachtwoord veranderd moet "
+"worden"
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "E-mailadres"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Spamfilter inschakelen"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "Markeer spam als gelezen"
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Spam filter toleratie"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Doorsturen inschakelen"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Behoud een kopie van de e-mails"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Bestemming"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Instellingen opslaan"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Wachtwoord controle"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Wachtwoord veranderen"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Automatisch antwoord inschakelen"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Antwoord onderwerp"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Antwoord bericht"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "Begin van vakantie"
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Einde van vakantie"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Bijwerken"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Uw token (bewaar hem goed, want hij wordt nooit meer getoond)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Toegestaan IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Gebruik SQL LIKE syntax (bijv. voor alles-afvangen aliasen)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Beheerder e-mail"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Verzenden"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Manager e-mail"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protocol"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Hostnaam of IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP poort"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "TLS inschakelen"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Gebruikersnaam"
 
-#: mailu/ui/templates/client.html:62
-msgid "If you use an Apple device,"
-msgstr "Indien u een Apple-apparaat gebruikt,"
-
-#: mailu/ui/templates/client.html:63
-msgid "click here to auto-configure it."
-msgstr "kunt u hier klikken om deze automatisch te configureren."
-
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Behoud de e-mails op de server"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Authenticatie token aanmaken"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Authenticatie token aanmaken"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Mededeling onderwerp"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Mededeling bericht"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Versturen"
 
@@ -321,7 +422,7 @@ msgstr "Versturen"
 msgid "Public announcement"
 msgstr "Publieke mededeling"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Anti-spam"
@@ -334,21 +435,29 @@ msgstr "RSPAMD status pagina"
 msgid "configure your email client"
 msgstr "configureer je email client"
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr "Inkomende mail"
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Mail protocol"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Server naam"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
 msgstr "Uitgaande mail"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "Indien u een Apple-apparaat gebruikt,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "kunt u hier klikken om deze automatisch te configureren."
 
 #: mailu/ui/templates/confirm.html:4
 msgid "Confirm action"
@@ -367,7 +476,7 @@ msgstr "Docker foutmelding"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Er is een fout opgetreden tijdens het communiceren met de Docker server."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr "kopieer naar klembord"
 
@@ -375,48 +484,48 @@ msgstr "kopieer naar klembord"
 msgid "My account"
 msgstr "Mijn account"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Instellingen"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Automatisch antwoorden"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Opgehaalde accounts"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Authenticatie tokens"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Beheer"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Mededeling"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Beheerders"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Relayed domeinen"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "E-mail domeinen"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Webmail"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Afmelden"
 
@@ -450,12 +559,18 @@ msgstr "Acties"
 msgid "Email"
 msgstr "E-mail"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Aanpassen"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -477,25 +592,19 @@ msgstr "Alias toevoegen"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Aangemaakt"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Laatste aanpassing"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Aanpassen"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -530,33 +639,42 @@ msgstr "Hergenereer sleutels"
 msgid "Generate keys"
 msgstr "Genereer sleutels"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr "Download zone-bestand"
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX-record"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF-records"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "DKIM publieke sleutel"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM-record"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC-record"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "DNS TLSA-record"
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "DNS client auto-configuratie records"
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Alternatieve domeinen overzicht"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -578,27 +696,37 @@ msgstr "Aantal mailboxen"
 msgid "Alias count"
 msgstr "Aantal aliasen"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Details"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Gebruikers"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Aliasen"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Managers"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternatieven"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "ja"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "nee"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -606,7 +734,7 @@ msgstr ""
 "Om een nieuw domein te kunnen registreren moet je eerst je domein zone "
 "instellen zodat het domein <code>MX</code> points to this server"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -642,20 +770,21 @@ msgid "Keep emails"
 msgstr "Behoud e-mails"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Behoud e-mails"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Laatste controle"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Status"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "ja"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "nee"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -693,6 +822,60 @@ msgstr "Authenticatie token aanmaken"
 msgid "New token"
 msgstr "Nieuw token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Authenticatie token aanmaken"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Nieuwe gebruiker"
@@ -701,13 +884,30 @@ msgstr "Nieuwe gebruiker"
 msgid "General"
 msgstr "Algemeen"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Functionaliteiten en quota"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Gebruiker aanpassen"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Authenticatie token aanmaken"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -737,17 +937,49 @@ msgstr "Automatisch antwoord"
 msgid "Auto-forward"
 msgstr "Automatisch doorsturen"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Authenticatie token aanmaken"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "kies een domein voor het nieuwe account"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Domein"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Vrije sloten"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "Spamfilter drempel"
@@ -784,4 +1016,7 @@ msgstr "Vrije sloten"
 
 #~ msgid "General settings"
 #~ msgstr "Algemene instellingen"
+
+#~ msgid "DKIM public key"
+#~ msgstr "DKIM publieke sleutel"
 

--- a/core/admin/mailu/translations/pl/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/pl/LC_MESSAGES/messages.po
@@ -3,33 +3,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2020-02-17 20:23+0000\n"
 "Last-Translator: Marcin Siennicki <marcin@siennicki.eu>\n"
 "Language: pl\n"
 "Language-Team: Polish "
 "<https://translate.tedomum.net/projects/mailu/admin/pl/>\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && "
-"(n%100<10 || n%100>=20) ? 1 : 2\n"
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Hasło"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Zaloguj"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Tokeny uwierzytelnienia"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+msgid "Current password"
+msgstr "Aktualne hasło"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Hasło administratora"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Zaktualizuj hasło"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -43,280 +85,337 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Przejdź do"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Konfiguracja klienta"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Strona internetowa"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Pomoc"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Zarejestruj domenę"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Utwórz konto"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Potwierdź hasło"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Utwórz token uwierzytelniający"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+#, fuzzy
+msgid "The current password is incorrect!"
+msgstr "Aktualne hasło"
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Nieprawidłowy adres e-mail."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Zatwierdź"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Nazwa domeny"
 
-#: mailu/ui/templates/domain/details.html:19
-msgid "Download zonefile"
-msgstr "Pobierz plik strefy DNS"
-
-#: mailu/ui/forms.py:134
-msgid "Current password"
-msgstr "Aktualne hasło"
-
-#: mailu/ui/forms.py:102
-msgid "Force password change at next login"
-msgstr "Wymuś zmianę hasła przy następnym logowaniu"
-
-#: mailu/ui/forms.py:98
-msgid "Allow the user to spoof the sender (send email as anyone)"
-msgstr "Zezwól użytkownikowi na podrobienie adresu nadawcy (wysłanie emaila w czyimkolwiek imieniu)"
-
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Maksymalna liczba użytkowników"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Maksymalna liczba aliasów"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Maksymalny przydział użytkownika"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Włącz rejestrację"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Komentarz"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Zapisz"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Początkowy administrator"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Hasło administratora"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Potwierdź hasło"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Utwórz"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Alternatywna nazwa"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Domeny przekierowywane"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Zdalny host"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Maksymalna przestrzeń na dysku"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Zezwalaj na dostęp przez protokół IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Zezwalaj na dostęp przez protokół POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+"Zezwól użytkownikowi na podrobienie adresu nadawcy (wysłanie emaila w "
+"czyimkolwiek imieniu)"
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Nazwa wyświetlana"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Włączone"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr "Wymuś zmianę hasła przy następnym logowaniu"
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Adres e-mail"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Włącz filtr antyspamowy"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Tolerancja filtra spamu"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Włącz przekierowanie poczty"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Przechowuj kopię wiadomości"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Adres docelowy"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Zapisz ustawienia"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Powtórz hasło"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Zaktualizuj hasło"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Włącz automatyczną odpowiedź"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Temat odpowiedzi"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Treść odpowiedzi"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 #, fuzzy
 msgid "Start of vacation"
 msgstr "Rozpoczęcie nieobecności"
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Koniec nieobecności"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Aktualizuj"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Twój token (zapisz go, ponieważ nigdy więcej nie będzie wyświetlany)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Autoryzowany adres IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Używaj składni SQL LIKE (np. do adresów catch-all)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "E-mail administratora"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Prześlij"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "E-mail menedżera"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protokół"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Nazwa hosta lub adres IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Port TCP"
 
-#: mailu/ui/templates/client.html:62
-msgid "If you use an Apple device,"
-msgstr "Jeśli używasz urządzenia firmy Apple,"
-
-#: mailu/ui/templates/client.html:63
-msgid "click here to auto-configure it."
-msgstr "kliknij tutaj by skonfigurować je automatycznie."
-
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Włącz TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Nazwa użytkownika"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Przechowuj wiadomości na serwerze"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Utwórz token uwierzytelniający"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Utwórz token uwierzytelniający"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Temat ogłoszenia"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Treść ogłoszenia"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Wyślij"
 
@@ -324,7 +423,7 @@ msgstr "Wyślij"
 msgid "Public announcement"
 msgstr "Publiczne ogłoszenie"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Filtr antyspamowy"
@@ -337,21 +436,29 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Protokół poczty"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Nazwa serwera"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
 msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr "Jeśli używasz urządzenia firmy Apple,"
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr "kliknij tutaj by skonfigurować je automatycznie."
 
 #: mailu/ui/templates/confirm.html:4
 msgid "Confirm action"
@@ -372,7 +479,7 @@ msgstr "Błąd Dockera"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Wystąpił błąd komunikacji z serwerem Dockera."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -381,48 +488,48 @@ msgstr ""
 msgid "My account"
 msgstr "Dodaj konto"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Ustawienia"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Automatyczna odpowiedź"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Zewnętrzne konta e-mail"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Tokeny uwierzytelnienia"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Administracja"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Ogłoszenie"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Administratorzy"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Domeny przekierowywane"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Domeny pocztowe"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Twoja poczta"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Wyloguj"
 
@@ -456,12 +563,18 @@ msgstr "Czynności"
 msgid "Email"
 msgstr "E-mail"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Edytuj"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Usuń"
 
@@ -483,25 +596,19 @@ msgstr "Dodaj alias"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Utworzono"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Ostatnia edycja"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Edytuj"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -536,33 +643,42 @@ msgstr "Wygeneruj ponownie klucze"
 msgid "Generate keys"
 msgstr "Wygeneruj klucze"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr "Pobierz plik strefy DNS"
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Wpis MX DNS"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Wpisy SPF DNS"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Publiczny klucz DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Wpis DKIM DNS"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Wpis DMARC DNS"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Alternatywna lista domen"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -584,27 +700,37 @@ msgstr "Liczba skrzynek pocztowych"
 msgid "Alias count"
 msgstr "Liczba aliasów"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Szczegóły"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Użytkownicy"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Aliasy"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Menedżerowie"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternatywy"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "Tak"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "Nie"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -612,7 +738,7 @@ msgstr ""
 "Aby zarejestrować nową domenę, musisz najpierw skonfigurować strefę "
 "domeny, aby domena <code> MX </code> wskazywała na ten serwer"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -650,20 +776,21 @@ msgid "Keep emails"
 msgstr "Przechowuj wiadomości"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Przechowuj wiadomości"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Ostatnie sprawdzenie"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Stan"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "Tak"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "Nie"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -702,6 +829,60 @@ msgstr "Utwórz token uwierzytelniający"
 msgid "New token"
 msgstr "Nowy token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Utwórz token uwierzytelniający"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Nowy użytkownik"
@@ -710,13 +891,30 @@ msgstr "Nowy użytkownik"
 msgid "General"
 msgstr "Ogólne"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Funkcje i limity"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Edytuj użytkownika"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Utwórz token uwierzytelniający"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -746,17 +944,49 @@ msgstr "Automatyczna odpowiedź"
 msgid "Auto-forward"
 msgstr "Automatyczne przekierowanie"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Utwórz token uwierzytelniający"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "wybierz domenę dla nowego konta"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Domena"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Dostępne miejsca"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "Próg filtra antyspamowego"
@@ -799,4 +1029,7 @@ msgstr "Dostępne miejsca"
 
 #~ msgid "Forward emails"
 #~ msgstr "Przekieruj wiadomości e-mail"
+
+#~ msgid "DKIM public key"
+#~ msgstr "Publiczny klucz DKIM"
 

--- a/core/admin/mailu/translations/pt/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/pt/LC_MESSAGES/messages.po
@@ -3,32 +3,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Jaume Barber <jaumebarber@gmail.com>\n"
 "Language: pt\n"
 "Language-Team: Portuguese "
 "<https://translate.tedomum.net/projects/mailu/admin/pt/>\n"
-"Plural-Forms: nplurals=2; plural=n > 1\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-mail"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Senha"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Entrar"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Tokens de autenticação"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Senha administrador"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Senha administrador"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Alterar senha"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -42,255 +85,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Ir para"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Configuração"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Website"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Ajuda"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Registrar domínio"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Acesso"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Confirmar senha"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Criar token de autenticação"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Endereço de e-mail inválido"
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Confirmar"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Domínio"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Quantidade máxima de usuários"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Quantidade máxima de alias"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Cota máxima por usuário"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Habilitar acesso"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Comentário"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Salvar"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Administrador"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Senha administrador"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Confirmar senha"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Criar"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Nome alternativo"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Nome de domínio para encaminhar"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Host remoto"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Quota"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Permitir acesso IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Permitir acesso POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Nome de exibição"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Habilitado"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Endereço de email"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Habilitar filtro de spam"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Filtro de tolerância de spam"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Habilitar encaminhamento"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Manter uma cópia dos emails"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destinatário"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Salvar configurações"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Confirmação de senha"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Alterar senha"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Habilitar resposta automática"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Assunto da resposta"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Corpo da resposta"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Conclusão das férias"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Atualizar"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Token (anote sem algum lugar pois não será mais exibido)\n"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "IP autorizado"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Usar sintaxe estilo SQL(ex: for catch-all aliases)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "E-mail do administrador"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Enviar"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "E-mail do gerente"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protocolo"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Hostname ou IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Porta TCP"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Habilitar TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Usuário"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Manter os e-mails no servidor"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Criar token de autenticação"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Criar token de autenticação"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Título do comunicado"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Corpo do comunicado"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Enviar"
 
@@ -298,7 +419,7 @@ msgstr "Enviar"
 msgid "Public announcement"
 msgstr "Comunicado geral"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Antispam"
@@ -311,20 +432,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Protocolo de e-mail"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Servidor"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -344,7 +473,7 @@ msgstr "Erro no docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Um erro foi encontrado na conexão com o servidor Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -352,48 +481,48 @@ msgstr ""
 msgid "My account"
 msgstr "Minha conta"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Configurações"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Resposta automática"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Contas importadas"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Tokens de autenticação"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Administração"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Comunicado"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Administradores"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Domínios para encaminhamento"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Domínios de e-mail"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Webmail"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Sair"
 
@@ -427,12 +556,18 @@ msgstr "Ações"
 msgid "Email"
 msgstr "Email"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Editar"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Deletar"
 
@@ -454,25 +589,19 @@ msgstr "Adicionar alias"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Criado"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Última edição"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Editar"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -507,33 +636,42 @@ msgstr "Gerar novas chaves"
 msgid "Generate keys"
 msgstr "Gerar chaves"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Entrada DNS MX"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Entrada DNS SPF"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Chave pública do DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Entrada DNS DKIM"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Entrada DNS DMARC"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Lista de domínios alternativos"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -555,27 +693,37 @@ msgstr "Quantidade de caixas de e-mail"
 msgid "Alias count"
 msgstr "Quantidade de aliases"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Detalhes"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Usuários"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Aliases"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Gerentes"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternativos"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "sim"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "não"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -583,7 +731,7 @@ msgstr ""
 "Para registar um novo domínio, e necessário configurar as entradas "
 "<code>MX</code> no DNS"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -618,20 +766,21 @@ msgid "Keep emails"
 msgstr "Manter emails"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Manter emails"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Última verificação"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Status"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "sim"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "não"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -669,6 +818,60 @@ msgstr "Criar token de autenticação"
 msgid "New token"
 msgstr "Novo token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Criar token de autenticação"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Novo usuário"
@@ -677,13 +880,30 @@ msgstr "Novo usuário"
 msgid "General"
 msgstr "Geral"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Recursos e quotas"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Editar usuário"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Criar token de autenticação"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -713,17 +933,49 @@ msgstr "Resposta automática"
 msgid "Auto-forward"
 msgstr "Encaminhamento automático"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Criar token de autenticação"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "Selecione o domínio da nova conta"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Domínio"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Slots disponíveis"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "Limite de filtro de spam"
@@ -760,4 +1012,7 @@ msgstr "Slots disponíveis"
 
 #~ msgid "General settings"
 #~ msgstr "Configurações"
+
+#~ msgid "DKIM public key"
+#~ msgstr "Chave pública do DKIM"
 

--- a/core/admin/mailu/translations/ru/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/ru/LC_MESSAGES/messages.po
@@ -3,33 +3,76 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Jaume Barber <jaumebarber@gmail.com>\n"
 "Language: ru\n"
 "Language-Team: Russian "
 "<https://translate.tedomum.net/projects/mailu/admin/ru/>\n"
 "Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2\n"
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "Электронная почта"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Пароль"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Войти"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Авторизационные токены"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Пароль администратора"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Пароль администратора"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Обновить пароль"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -43,255 +86,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Перейти к"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Настройка клиента"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Сайт"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Помощь"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Зарегистрировать домен"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Регистрация"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Подтвердить пароль"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Создать токен авторизации"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Неправильный адрес электронной почты"
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Подтвердить"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Доменное имя"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Максимальное число пользователей"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Максимальное число псевдонимов"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Квота на пользователя"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Разрешить регистрацию"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Комментарий"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Сохранить"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Начальный админ"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Пароль администратора"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Подтвердить пароль"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Создать"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Имя альтернативного домена"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Имя релейного домена"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Удаленный хост"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Квота"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Разрешить доступ через IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Разрешить доступ через POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Отображаемое имя"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Включено"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Почтовый адрес"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Включить спам-фильтр"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Порог спам-фильтра"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Включить переадресацию"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Хранить копии писем"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Адрес получателя"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Сохранить настройки"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Проверка пароля"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Обновить пароль"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Включить автоответчик"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Заголовок автоответа"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Сообщение автоответа"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Конец отпуска"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Обновить"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Ваш токен (перепишите его, больше он показываться не будет)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Авторизованные IP-адреса"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Псевдоним"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Использовать SQL-подобный синтаксис"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Адрес администратора"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Отправить"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Адрес менеджера"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Протокол"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Имя хоста или IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Порт TCP"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Включить TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Имя пользователя"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Хранить письма на сервере"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Создать токен авторизации"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Создать токен авторизации"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Тема объявления"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Содержание объявления"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Отправить"
 
@@ -299,7 +420,7 @@ msgstr "Отправить"
 msgid "Public announcement"
 msgstr "Публичное объявление"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Антиспам"
@@ -312,20 +433,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Почтовый протокол"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Имя сервера"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -345,7 +474,7 @@ msgstr "Ошибка Docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Произошла ошибка при обращении к серверу Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -353,48 +482,48 @@ msgstr ""
 msgid "My account"
 msgstr "Моя учетная запись"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Настройки"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Автоматический ответ"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Учетные записи сторонних серверов"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Авторизационные токены"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Администрирование"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Объявление"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Администраторы"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Релейные домены"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Почтовые домены"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Электронная почта"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Выйти"
 
@@ -428,12 +557,18 @@ msgstr "Действия"
 msgid "Email"
 msgstr "Электронная почта"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Изменить"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Удалить"
 
@@ -455,25 +590,19 @@ msgstr "Добавить псевдоним"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Создано"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Последнее изменение"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Изменить"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -508,33 +637,42 @@ msgstr "Перегенерировать ключи"
 msgid "Generate keys"
 msgstr "Сгенерировать ключи"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX запись"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF запись"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Публичный ключ DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM запись"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC запись"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Список альтернативных доменов"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -556,27 +694,37 @@ msgstr "Количество ящиков"
 msgid "Alias count"
 msgstr "Количество псевдонимов"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Подробно"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Пользователи"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Псевдонимы"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Менеджеры"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Альтернативные домены"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "да"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "нет"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -585,7 +733,7 @@ msgstr ""
 "    доменная зона, так что домен <code> MX </ code> указывает на этот "
 "сервер"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -624,20 +772,21 @@ msgid "Keep emails"
 msgstr "Сохранять письма"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Сохранять письма"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Последняя проверка"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Статус"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "да"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "нет"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -675,6 +824,60 @@ msgstr "Создать токен авторизации"
 msgid "New token"
 msgstr "Новый токен"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Создать токен авторизации"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Новый пользователь"
@@ -683,13 +886,30 @@ msgstr "Новый пользователь"
 msgid "General"
 msgstr "Общие"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Функции и квоты"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Изменить пользователя"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Создать токен авторизации"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -719,17 +939,49 @@ msgstr "Автоматический ответ"
 msgid "Auto-forward"
 msgstr "Автоматическая пересылка"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Создать токен авторизации"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "выбрать домен для новой учетной записи"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Домен"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Доступные слоты"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "Spam filter threshold"
 #~ msgstr "Порог чувствительности спам-фильтра"
@@ -766,4 +1018,7 @@ msgstr "Доступные слоты"
 
 #~ msgid "General settings"
 #~ msgstr "Общие настройки"
+
+#~ msgid "DKIM public key"
+#~ msgstr "Публичный ключ DKIM"
 

--- a/core/admin/mailu/translations/sv/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/sv/LC_MESSAGES/messages.po
@@ -3,32 +3,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2021-03-04 18:46+0000\n"
 "Last-Translator: Jaume Barber <jaumebarber@gmail.com>\n"
 "Language: sv\n"
 "Language-Team: Swedish "
 "<https://translate.tedomum.net/projects/mailu/admin/sv/>\n"
-"Plural-Forms: nplurals=2; plural=n != 1\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "E-post"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Lösenord"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Logga in"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Autentiserade tokens"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Uppdatera lösenord"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Uppdatera lösenord"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Uppdatera lösenord"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -42,255 +85,333 @@ msgstr ""
 msgid "change language"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Gå till"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Websida"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Hjälp"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr ""
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr ""
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Bekräfta lösenord"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Skapa en autentiseringstoken"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Ogiltig adress"
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Bekräfta"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Domännamn"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Max antal användare"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Max antal alias"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Max användar-quota"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr ""
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Kommentar"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Spara"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr ""
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr ""
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Bekräfta lösenord"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Skapa"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Aleternativt namn"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Reläade domännamn"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Server"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Quota"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Tillåt IMAP"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Tillåt POP3"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Visat namn"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr ""
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr ""
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Aktivera spamfilter"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr ""
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr ""
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Aktivera vidarebefordring"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Behåll en kopia av e-posten"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Destination"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Spara inställningar"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Lösenordskoll"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Uppdatera lösenord"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Aktivera autosvar"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Svar ämne"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Svar meddelande"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr ""
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Uppdatera"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "Din token (notera, eftersom den inte kommer att visas igen)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Autentiserat IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Alias"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "Använd SQL-liknande syntax (t.ex. för catch-all alias)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Admin e-post"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Skicka in"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Manager e-post"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Protokoll"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Hostnamn eller IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP port"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Aktivera TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Användarnamn"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Behåll e-post på servern"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Skapa en autentiseringstoken"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Skapa en autentiseringstoken"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Publikt meddelande ämne"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Publikt meddelande"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Skicka"
 
@@ -298,7 +419,7 @@ msgstr "Skicka"
 msgid "Public announcement"
 msgstr "Publikt meddelande"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Antispam"
@@ -311,20 +432,28 @@ msgstr ""
 msgid "configure your email client"
 msgstr ""
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr ""
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr ""
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr ""
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
+msgstr ""
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
 msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
@@ -344,7 +473,7 @@ msgstr "Docker fel"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Ett fel inträffade vid kommunikation med Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr ""
 
@@ -352,48 +481,48 @@ msgstr ""
 msgid "My account"
 msgstr "Mitt konto"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Inställningar"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Autosvar"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Hämtade konton"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Autentiserade tokens"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Administration"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Meddelande"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Administratörer"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Reläade domäner"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Domäner"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Webmail"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Logga ut"
 
@@ -427,12 +556,18 @@ msgstr "Handling"
 msgid "Email"
 msgstr "E-post"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Redigera"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Radera"
 
@@ -454,25 +589,19 @@ msgstr "Skapa alias"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Skapad"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Senast redigerad"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Redigera"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -507,33 +636,42 @@ msgstr "Generera nycklar"
 msgid "Generate keys"
 msgstr ""
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX post"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF post"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Publik DKIM-nyckel"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM post"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC post"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr ""
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr ""
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Alternativa domäner"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -555,33 +693,43 @@ msgstr "Antal mailboxar"
 msgid "Alias count"
 msgstr "Antal alias"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Detaljer"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Användare"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Alias"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Managers"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Alternativ"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "ja"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "nej"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr ""
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
@@ -613,20 +761,21 @@ msgid "Keep emails"
 msgstr "Behåll e-posten"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Behåll e-posten"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Senaste koll"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr ""
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "ja"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "nej"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -664,6 +813,60 @@ msgstr "Skapa en autentiseringstoken"
 msgid "New token"
 msgstr "Ny token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Skapa en autentiseringstoken"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Ny användare"
@@ -672,13 +875,30 @@ msgstr "Ny användare"
 msgid "General"
 msgstr "Allmänt"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Funktioner och quota"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Redigera användare"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Skapa en autentiseringstoken"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -708,16 +928,48 @@ msgstr "Automatiskt svar"
 msgid "Auto-forward"
 msgstr "Auto-forward"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Skapa en autentiseringstoken"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr ""
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr ""
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
+msgstr ""
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
 msgstr ""
 
 #~ msgid "Spam filter threshold"
@@ -755,4 +1007,7 @@ msgstr ""
 
 #~ msgid "General settings"
 #~ msgstr "Allmäna inställningar"
+
+#~ msgid "DKIM public key"
+#~ msgstr "Publik DKIM-nyckel"
 

--- a/core/admin/mailu/translations/uk/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/uk/LC_MESSAGES/messages.po
@@ -7,34 +7,76 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PROJECT VERSION\n"
 "Report-Msgid-Bugs-To: sydorenkodanylo2021@gmail.com\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2023-08-14 08:19+0300\n"
 "Last-Translator: Danylo Sydorenko <sydorenkodanylo2021@gmail.com>\n"
-"Language-Team: Ukrainian <https://translate.tedomum.net/projects/mailu/admin/"
-"uk/>\n"
 "Language: uk\n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Language-Team: Ukrainian "
+"<https://translate.tedomum.net/projects/mailu/admin/uk/>\n"
 "Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && "
-"(n%100<10 || n%100>=20) ? 1 : 2\n"
-"Generated-By: Babel 2.3.4\n"
-"X-Generator: Poedit 3.3.2\n"
+"(n%100<10 || n%100>=20) ? 1 : 2;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "Електронна пошта"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93
-#: mailu/ui/forms.py:112 mailu/ui/forms.py:166
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "Пароль"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "Увійти"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "Токени автентифікації"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "Пароль адміністратора"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "Пароль адміністратора"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "Оновити пароль"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -48,257 +90,335 @@ msgstr "переключити бічну панель"
 msgid "change language"
 msgstr "змінити мову"
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "Перейти до"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "Налаштування клієнта"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "Вебсайт"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "Довідка"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "Зареєструвати домен"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "Зареєструватися"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "Підтвердити пароль"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "Створити токен автентифікації"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "Недійсна електронна пошта."
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "Підтвердити"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "Ім'я домену"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "Максимальна кількість користувачів"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "Максимальна кількість скорочень"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "Максимальна квота користувачів"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "Увімкнути реєстрацію"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86
-#: mailu/ui/forms.py:132 mailu/ui/forms.py:144
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
-#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:20
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "Коментар"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75
-#: mailu/ui/forms.py:88 mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "Зберегти"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "Початковий адміністратор"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "Пароль адміністратора"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "Підтвердити пароль"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "Створити"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "Альтернативна назва"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "Ретрансльоване доменне ім'я"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "Віддалений хост"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "Квота"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "Дозволити IMAP-доступ"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "Дозволити POP3-доступ"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "Ім'я, що показується"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "Увімкнено"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "Електронна пошта"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "Увімкнути спам-фільтр"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "Позначити спам як прочитане"
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "Толерантність спам-фільтра до спаму"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "Увімкнути переадресацію"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "Зберігати копії електронних листів"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "Призначення"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "Зберегти налаштування"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "Перевірка пароля"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "Оновити пароль"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "Увімкнути автоматичну відповідь"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "Тема відповіді"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "Текст відповіді"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "Початок відпустки"
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "Кінець відпустки"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "Оновити"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr ""
-"Ваш токен (запишіть його, оскільки він більше ніколи не буде відображатися)"
+"Ваш токен (запишіть його, оскільки він більше ніколи не буде "
+"відображатися)"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "Дозволені IP-адреси"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "Псевдонім"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
-msgstr ""
-"Використовуйте синтаксис SQL LIKE (наприклад, для псевдонімів catch-all)"
+msgstr "Використовуйте синтаксис SQL LIKE (наприклад, для псевдонімів catch-all)"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "Пошта адміністратора"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "Надіслати"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "Електронна пошта менеджера"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "Протокол"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "Ім'я хоста або IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "Порт TCP"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "Увімкнути TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "Ім'я користувача"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "Зберігати копії електронних листів"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "Створити токен автентифікації"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "Створити токен автентифікації"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "Тема оголошення"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "Текст оголошення"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "Надіслати"
 
@@ -306,7 +426,7 @@ msgstr "Надіслати"
 msgid "Public announcement"
 msgstr "Публічне оголошення"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "Антиспам"
@@ -319,21 +439,29 @@ msgstr "Сторінка стану RSPAMD"
 msgid "configure your email client"
 msgstr "налаштуйте свій поштовий клієнт"
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr "Вхідна пошта"
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "Поштовий протокол"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "Назва серверу"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
 msgstr "Вихідна пошта"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
 msgid "Confirm action"
@@ -352,7 +480,7 @@ msgstr "Помилка Docker"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Виникла помилка при спілкуванні з сервером Docker."
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr "скопіювати в буфер обміну"
 
@@ -360,48 +488,48 @@ msgstr "скопіювати в буфер обміну"
 msgid "My account"
 msgstr "Мій обліковий запис"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "Налаштування"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "Автовідповідь"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "Отримані облікові записи"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "Токени автентифікації"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "Адміністрація"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "Оголошення"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "Адміністратори"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "Передані домени"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "Поштові домени"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "Вебпошта"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "Вийти"
 
@@ -435,12 +563,18 @@ msgstr "Дії"
 msgid "Email"
 msgstr "Електронна пошта"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "Редагувати"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "Видалити"
 
@@ -462,25 +596,19 @@ msgstr "Додати псевдонім"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "Створено"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "Останнє редагування від"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "Редагувати"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -515,33 +643,42 @@ msgstr "Регенерувати ключі"
 msgid "Generate keys"
 msgstr "Згенерувати ключі"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "Запис DNS MX"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "Записи DNS SPF"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "Відкритий ключ DKIM"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "Запис DNS DKIM"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "Запис DNS DMARC"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "Запис DNS TLSA"
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "Записи автоконфігурації DNS-клієнта"
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "Альтернативний список доменів"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -563,27 +700,37 @@ msgstr "Кількість поштових скриньок"
 msgid "Alias count"
 msgstr "Кількість псевдонімів"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "Подробиці"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "Користувачі"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "Скорочення"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "Менеджери"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "Альтернативи"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "так"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "ні"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
@@ -592,20 +739,22 @@ msgstr ""
 "    спочатку налаштувати доменну <code>MX</code> так,\n"
 "    щоб домен вказував на цей сервер"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
 "If you do not know how to setup an <code>MX</code> record for your DNS "
 "zone,\n"
-"    please contact your DNS provider or administrator. Also, please wait a\n"
+"    please contact your DNS provider or administrator. Also, please wait "
+"a\n"
 "    couple minutes after the <code>MX</code> is set so the local server "
 "cache\n"
 "    expires."
 msgstr ""
-"Якщо ви не знаєте, як налаштувати <code>MX</code>-запис для вашої DNS-зони,\n"
+"Якщо ви не знаєте, як налаштувати <code>MX</code>-запис для вашої "
+"DNS-зони,\n"
 "    зверніться до вашого DNS-провайдера або адміністратора. Також, будь "
 "ласка, \n"
-"    зачекайте кілька хвилин після встановлення MX, щоб закінчився термін дії "
-"кешу\n"
+"    зачекайте кілька хвилин після встановлення MX, щоб закінчився термін "
+"дії кешу\n"
 "    локального сервера."
 
 #: mailu/ui/templates/fetch/create.html:4
@@ -629,20 +778,21 @@ msgid "Keep emails"
 msgstr "Зберігати електронні листи"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "Зберігати електронні листи"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "Остання перевірка"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "Статус"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "так"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "ні"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -680,6 +830,60 @@ msgstr "Створити токен автентифікації"
 msgid "New token"
 msgstr "Новий токен"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "Створити токен автентифікації"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "Новий користувач"
@@ -688,13 +892,30 @@ msgstr "Новий користувач"
 msgid "General"
 msgstr "Основне"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "Можливості та квоти"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "Редагувати користувача"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "Створити токен автентифікації"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -724,14 +945,50 @@ msgstr "Увімкнути автоматичну відповідь"
 msgid "Auto-forward"
 msgstr "Автоматичне пересилання"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "Створити токен автентифікації"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "вибрати домен для нового облікового запису"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "Домен"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "Наявні слоти"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
+
+#~ msgid "DKIM public key"
+#~ msgstr "Відкритий ключ DKIM"
+

--- a/core/admin/mailu/translations/zh/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/zh/LC_MESSAGES/messages.po
@@ -3,43 +3,72 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2022-05-22 18:47+0200\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: darkclip <darkclip@gmail.com>\n"
 "Language: zh\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=1; plural=0\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.3.4\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:91
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "电子邮件"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:108 mailu/ui/forms.py:128
-#: mailu/ui/forms.py:135 mailu/ui/forms.py:197
-#: mailu/ui/templates/client.html:32 mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "密码"
 
 #: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "登录"
 
-#: mailu/sso/forms.py:15 mailu/ui/forms.py:134
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "认证令牌"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
 msgid "Current password"
 msgstr "当前密码"
 
-#: mailu/sso/forms.py:16
+#: mailu/sso/forms.py:23
 msgid "New password"
 msgstr "新密码"
 
-#: mailu/sso/forms.py:17
+#: mailu/sso/forms.py:24
 msgid "New password (again)"
 msgstr "新密码（重复）"
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "新密码"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -53,275 +82,334 @@ msgstr "切换侧边栏"
 msgid "change language"
 msgstr "更换语言"
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "转到"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "客户端设置"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "网站"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "帮助"
 
 #: mailu/sso/templates/sidebar_sso.html:35
-#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:127
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "注册域名"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:111
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "注册"
 
-#: mailu/ui/forms.py:34 mailu/ui/forms.py:37
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "确认密码"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "创建一个认证令牌"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+#, fuzzy
+msgid "The current password is incorrect!"
+msgstr "当前密码"
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "无效的邮件地址"
 
-#: mailu/ui/forms.py:47
+#: mailu/ui/forms.py:56
 msgid "Invalid list of folders."
 msgstr "无效的文件夹列表"
 
-#: mailu/ui/forms.py:56
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "确认"
 
-#: mailu/ui/forms.py:59 mailu/ui/forms.py:69
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
 #: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "域名"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "最大用户数"
 
-#: mailu/ui/forms.py:61
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "最大别名数"
 
-#: mailu/ui/forms.py:62
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "最大用户配额"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "启用注册"
 
-#: mailu/ui/forms.py:64 mailu/ui/forms.py:86 mailu/ui/forms.py:100
-#: mailu/ui/forms.py:155 mailu/ui/forms.py:175
-#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
 #: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
 #: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "说明"
 
-#: mailu/ui/forms.py:65 mailu/ui/forms.py:80 mailu/ui/forms.py:87
-#: mailu/ui/forms.py:103 mailu/ui/forms.py:159 mailu/ui/forms.py:176
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "保存"
 
-#: mailu/ui/forms.py:70
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "初始管理员"
 
-#: mailu/ui/forms.py:71
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "管理员密码"
 
-#: mailu/ui/forms.py:72 mailu/ui/forms.py:93 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "确认密码"
 
-#: mailu/ui/forms.py:75
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "创建"
 
-#: mailu/ui/forms.py:79
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "替代域名"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "中继域域名"
 
-#: mailu/ui/forms.py:85 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "远程主机"
 
-#: mailu/ui/forms.py:95 mailu/ui/templates/user/list.html:23
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
 #: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "配额"
 
-#: mailu/ui/forms.py:96
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "允许IMAP访问"
 
-#: mailu/ui/forms.py:97
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "允许POP3访问"
 
-#: mailu/ui/forms.py:98
+#: mailu/ui/forms.py:107
 msgid "Allow the user to spoof the sender (send email as anyone)"
 msgstr "允许用户仿冒发件人（以任何人发件）"
 
-#: mailu/ui/forms.py:99 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
 #: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "显示名称"
 
-#: mailu/ui/forms.py:101
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "启用"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:111
 msgid "Force password change at next login"
 msgstr "强制下次登录时更改密码"
 
-#: mailu/ui/forms.py:107
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "邮件地址"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "启用垃圾邮件过滤"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "启用标记垃圾邮件已读"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "垃圾邮件过滤器阈值"
 
-#: mailu/ui/forms.py:121
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "启用转发"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "保留电子邮件副本"
 
-#: mailu/ui/forms.py:123 mailu/ui/forms.py:174
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
 #: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "目的地址"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "保存设置"
 
-#: mailu/ui/forms.py:129 mailu/ui/forms.py:136
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "检查密码"
 
-#: mailu/ui/forms.py:131 mailu/ui/forms.py:138 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "更新密码"
 
-#: mailu/ui/forms.py:141
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "启用自动回复"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "回复主题"
 
-#: mailu/ui/forms.py:143
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "回复正文"
 
-#: mailu/ui/forms.py:145
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "假期开始"
 
-#: mailu/ui/forms.py:146
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "假期结束"
 
-#: mailu/ui/forms.py:147
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "更新"
 
-#: mailu/ui/forms.py:152
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "您的令牌（请记录，它只显示这一次）"
 
-#: mailu/ui/forms.py:157 mailu/ui/templates/token/list.html:22
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "授权IP"
 
-#: mailu/ui/forms.py:171
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "别名"
 
-#: mailu/ui/forms.py:173
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "使用SQL LIKE语法（例如，用于全部别名）"
 
-#: mailu/ui/forms.py:180
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "管理员邮箱"
 
-#: mailu/ui/forms.py:181 mailu/ui/forms.py:186 mailu/ui/forms.py:201
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "提交"
 
-#: mailu/ui/forms.py:185
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "管理员邮箱"
 
-#: mailu/ui/forms.py:190
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "协议"
 
-#: mailu/ui/forms.py:193
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "主机名或IP"
 
-#: mailu/ui/forms.py:194 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP端口"
 
-#: mailu/ui/forms.py:195
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "启用TLS"
 
-#: mailu/ui/forms.py:196 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "用户名"
 
-#: mailu/ui/forms.py:198
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "在服务器上保留邮件"
 
-#: mailu/ui/forms.py:199
+#: mailu/ui/forms.py:208
 msgid "Rescan emails locally"
 msgstr "本地重扫描邮件"
 
-#: mailu/ui/forms.py:200
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
 msgid "Folders to fetch on the server"
 msgstr "服务器收取文件夹"
 
-#: mailu/ui/forms.py:205
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "创建一个认证令牌"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "创建一个认证令牌"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "公告主题"
 
-#: mailu/ui/forms.py:207
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "公告正文"
 
-#: mailu/ui/forms.py:209
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "发送"
 
@@ -329,7 +417,7 @@ msgstr "发送"
 msgid "Public announcement"
 msgstr "公开公告"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "反垃圾邮件"
@@ -342,21 +430,29 @@ msgstr "RSPAMD状态页"
 msgid "configure your email client"
 msgstr "设置邮件客户端"
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr "接收邮件"
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "邮件协议"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "服务器名称"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
 msgstr "发送邮件"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
 msgid "Confirm action"
@@ -375,7 +471,7 @@ msgstr "Docker错误"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Docker服务器通信出错"
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr "复制到剪贴板"
 
@@ -391,40 +487,40 @@ msgstr "设置"
 msgid "Auto-reply"
 msgstr "自动回复"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:39
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "代收账户"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "认证令牌"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "管理"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "公告"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "管理员"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "中继域"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "邮件域"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "网页邮箱"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "登出"
 
@@ -458,12 +554,18 @@ msgstr "操作"
 msgid "Email"
 msgstr "电子邮件"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29
-#: mailu/ui/templates/domain/list.html:34 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
 #: mailu/ui/templates/manager/list.html:27
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "编辑"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
 #: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
-#: mailu/ui/templates/user/list.html:34
 msgid "Delete"
 msgstr "删除"
 
@@ -485,7 +587,7 @@ msgstr "添加别名"
 
 #: mailu/ui/templates/alias/list.html:23
 #: mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
 #: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
@@ -493,17 +595,11 @@ msgstr "已创建"
 
 #: mailu/ui/templates/alias/list.html:24
 #: mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
 #: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "上次编辑"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:35 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "编辑"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -538,33 +634,42 @@ msgstr "重新生成秘钥"
 msgid "Generate keys"
 msgstr "生成秘钥"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX条目"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF条目"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "DKIM公钥"
-
-#: mailu/ui/templates/domain/details.html:40
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM条目"
 
 #: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC条目"
 
-#: mailu/ui/templates/domain/details.html:54
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "DNS TLSA条目"
 
-#: mailu/ui/templates/domain/details.html:59
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "DNS客户端自动设置条目"
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "替代域列表"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -606,21 +711,34 @@ msgstr "管理员"
 msgid "Alternatives"
 msgstr "替代域"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "是"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "否"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr "在注册一个新的域名前，您必须先为该域名设置 <code>MX</code> 记录，并使其指向本服务器"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
-"If you do not know how to setup an <code>MX</code> record for your DNS zone,\n"
-"    please contact your DNS provider or administrator. Also, please wait a\n"
-"    couple minutes after the <code>MX</code> is set so the local server cache\n"
+"If you do not know how to setup an <code>MX</code> record for your DNS "
+"zone,\n"
+"    please contact your DNS provider or administrator. Also, please wait "
+"a\n"
+"    couple minutes after the <code>MX</code> is set so the local server "
+"cache\n"
 "    expires."
 msgstr ""
-"如果您不知道如何为域名设置 <code>MX</code> 记录，请联系你的DNS提供商或者系统管理员。"
-"在设置完成 <code>MX</code> 记录后，请等待本地域名服务器的缓存过期。"
+"如果您不知道如何为域名设置 <code>MX</code> 记录，请联系你的DNS提供商或者系统管理员。在设置完成 <code>MX</code>"
+" 记录后，请等待本地域名服务器的缓存过期。"
 
 #: mailu/ui/templates/fetch/create.html:4
 msgid "Add a fetched account"
@@ -657,14 +775,6 @@ msgstr "上次检查"
 #: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "状态"
-
-#: mailu/ui/templates/fetch/list.html:40
-msgid "yes"
-msgstr "是"
-
-#: mailu/ui/templates/fetch/list.html:40
-msgid "no"
-msgstr "否"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -706,6 +816,56 @@ msgstr "新令牌"
 msgid "ID"
 msgstr "ID"
 
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "创建一个认证令牌"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "新用户"
@@ -714,13 +874,30 @@ msgstr "新用户"
 msgid "General"
 msgstr "通用"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "功能和配额"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "编辑用户"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "创建一个认证令牌"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -750,6 +927,21 @@ msgstr "自动回复"
 msgid "Auto-forward"
 msgstr "自动转发"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "创建一个认证令牌"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "为新用户选择一个域名"
@@ -761,4 +953,24 @@ msgstr "域名"
 #: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "可用"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
+
+#~ msgid "DKIM public key"
+#~ msgstr "DKIM公钥"
 

--- a/core/admin/mailu/translations/zh_TW/LC_MESSAGES/messages.po
+++ b/core/admin/mailu/translations/zh_TW/LC_MESSAGES/messages.po
@@ -1,33 +1,76 @@
+
 msgid ""
 msgstr ""
-"Project-Id-Version: Mailu\n"
+"Project-Id-Version:  Mailu\n"
 "Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
-"POT-Creation-Date: 2023-09-13 15:04+0800\n"
+"POT-Creation-Date: 2026-04-02 21:31+0100\n"
 "PO-Revision-Date: 2023-09-19 13:48+0800\n"
 "Last-Translator: Jonathan Tsai <tryweb@ichiayi.com>\n"
-"Language-Team: \n"
 "Language: zh_TW\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=1; plural=0;\n"
-"Generated-By: Babel 2.3.4\n"
-"X-Generator: Poedit 3.3.2\n"
+"Generated-By: Babel 2.10.3\n"
 
-#: mailu/sso/forms.py:8 mailu/ui/forms.py:79
+#: mailu/sso/forms.py:8 mailu/ui/forms.py:100
 msgid "E-mail"
 msgstr "電子郵件"
 
-#: mailu/sso/forms.py:9 mailu/ui/forms.py:80 mailu/ui/forms.py:93 mailu/ui/forms.py:112
-#: mailu/ui/forms.py:166 mailu/ui/templates/client.html:32
-#: mailu/ui/templates/client.html:57
+#: mailu/sso/forms.py:9 mailu/ui/forms.py:101 mailu/ui/forms.py:117
+#: mailu/ui/forms.py:137 mailu/ui/forms.py:144 mailu/ui/forms.py:206
+#: mailu/ui/templates/client.html:31 mailu/ui/templates/client.html:56
 msgid "Password"
 msgstr "密碼"
 
-#: mailu/sso/forms.py:10 mailu/sso/forms.py:11 mailu/sso/templates/login.html:4
-#: mailu/ui/templates/sidebar.html:142
+#: mailu/sso/forms.py:11 mailu/sso/forms.py:12 mailu/sso/templates/login.html:4
+#: mailu/sso/templates/sidebar_sso.html:42 mailu/ui/templates/sidebar.html:144
 msgid "Sign in"
 msgstr "登入"
+
+#: mailu/sso/forms.py:17 mailu/ui/forms.py:220
+#, fuzzy
+msgid "Authentication code"
+msgstr "認證Token"
+
+#: mailu/sso/forms.py:18
+msgid "Verify"
+msgstr ""
+
+#: mailu/sso/forms.py:19
+msgid "Use backup code"
+msgstr ""
+
+#: mailu/sso/forms.py:22 mailu/ui/forms.py:143 mailu/ui/forms.py:219
+#, fuzzy
+msgid "Current password"
+msgstr "管理員密碼"
+
+#: mailu/sso/forms.py:23
+#, fuzzy
+msgid "New password"
+msgstr "管理員密碼"
+
+#: mailu/sso/forms.py:24
+msgid "New password (again)"
+msgstr ""
+
+#: mailu/sso/forms.py:26
+#, fuzzy
+msgid "Change password"
+msgstr "修改密碼"
+
+#: mailu/sso/templates/2fa_verify.html:4
+#: mailu/ui/templates/user/2fa_setup.html:4
+#: mailu/ui/templates/user/edit.html:14
+#: mailu/ui/templates/user/settings.html:35
+msgid "Two-factor authentication"
+msgstr ""
+
+#: mailu/sso/templates/2fa_verify.html:11
+msgid "Enter the 6-digit code from your authenticator app."
+msgstr ""
 
 #: mailu/sso/templates/base_sso.html:8 mailu/ui/templates/base.html:8
 msgid "Admin page for"
@@ -41,251 +84,333 @@ msgstr "切換側邊欄"
 msgid "change language"
 msgstr "切換語言"
 
-#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:94
+#: mailu/sso/templates/sidebar_sso.html:4 mailu/ui/templates/sidebar.html:96
 msgid "Go to"
 msgstr "跳至"
 
 #: mailu/sso/templates/sidebar_sso.html:9 mailu/ui/templates/client.html:4
-#: mailu/ui/templates/sidebar.html:50 mailu/ui/templates/sidebar.html:107
+#: mailu/ui/templates/sidebar.html:52 mailu/ui/templates/sidebar.html:109
 msgid "Client setup"
 msgstr "用戶端設定"
 
-#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:114
+#: mailu/sso/templates/sidebar_sso.html:16 mailu/ui/templates/sidebar.html:116
 msgid "Website"
 msgstr "網站"
 
-#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:120
+#: mailu/sso/templates/sidebar_sso.html:22 mailu/ui/templates/sidebar.html:122
 msgid "Help"
 msgstr "輔助"
 
-#: mailu/sso/templates/sidebar_sso.html:35 mailu/ui/templates/domain/signup.html:4
-#: mailu/ui/templates/sidebar.html:127
+#: mailu/sso/templates/sidebar_sso.html:35
+#: mailu/ui/templates/domain/signup.html:4 mailu/ui/templates/sidebar.html:129
 msgid "Register a domain"
 msgstr "註冊網域"
 
-#: mailu/sso/templates/sidebar_sso.html:49 mailu/ui/forms.py:95
-#: mailu/ui/templates/sidebar.html:149 mailu/ui/templates/user/signup.html:4
+#: mailu/sso/templates/sidebar_sso.html:55 mailu/ui/forms.py:120
+#: mailu/ui/templates/sidebar.html:151 mailu/ui/templates/user/signup.html:4
 #: mailu/ui/templates/user/signup_domain.html:4
 msgid "Sign up"
 msgstr "註冊"
 
-#: mailu/ui/forms.py:33 mailu/ui/forms.py:36
+#: mailu/sso/views/base.py:49 mailu/sso/views/base.py:108
+msgid "Too many attempts from your IP (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:52
+msgid "Too many attempts for this user (rate-limit)"
+msgstr ""
+
+#: mailu/sso/views/base.py:79
+#, fuzzy
+msgid "Wrong e-mail or password"
+msgstr "確認密碼"
+
+#: mailu/sso/views/base.py:97
+msgid "Session expired, please sign in again"
+msgstr ""
+
+#: mailu/sso/views/base.py:149
+#, fuzzy
+msgid "Invalid authentication code"
+msgstr "建立一個認證Token"
+
+#: mailu/sso/views/base.py:166
+msgid "The new password can't be the same as the old password"
+msgstr ""
+
+#: mailu/sso/views/base.py:169
+msgid "The new passwords don't match"
+msgstr ""
+
+#: mailu/sso/views/base.py:181
+msgid "The current password is incorrect!"
+msgstr ""
+
+#: mailu/ui/forms.py:16
+msgid "Passwords should not start or end with whitespaces"
+msgstr ""
+
+#: mailu/ui/forms.py:43 mailu/ui/forms.py:46
 msgid "Invalid email address."
 msgstr "電子郵件格式錯誤"
 
-#: mailu/ui/forms.py:45
+#: mailu/ui/forms.py:56
+msgid "Invalid list of folders."
+msgstr ""
+
+#: mailu/ui/forms.py:65
 msgid "Confirm"
 msgstr "確定"
 
-#: mailu/ui/forms.py:48 mailu/ui/forms.py:58 mailu/ui/templates/domain/details.html:26
+#: mailu/ui/forms.py:68 mailu/ui/forms.py:78
+#: mailu/ui/templates/domain/details.html:26
 #: mailu/ui/templates/domain/list.html:19 mailu/ui/templates/relay/list.html:18
 msgid "Domain name"
 msgstr "網域"
 
-#: mailu/ui/forms.py:49
+#: mailu/ui/forms.py:69
 msgid "Maximum user count"
 msgstr "最大用戶數"
 
-#: mailu/ui/forms.py:50
+#: mailu/ui/forms.py:70
 msgid "Maximum alias count"
 msgstr "最大別名數"
 
-#: mailu/ui/forms.py:51
+#: mailu/ui/forms.py:71
 msgid "Maximum user quota"
 msgstr "最大用戶配額"
 
-#: mailu/ui/forms.py:52
+#: mailu/ui/forms.py:72 mailu/ui/templates/domain/list.html:24
 msgid "Enable sign-up"
 msgstr "啟用註冊"
 
-#: mailu/ui/forms.py:53 mailu/ui/forms.py:74 mailu/ui/forms.py:86 mailu/ui/forms.py:132
-#: mailu/ui/forms.py:144 mailu/ui/templates/alias/list.html:22
-#: mailu/ui/templates/domain/list.html:22 mailu/ui/templates/relay/list.html:20
-#: mailu/ui/templates/token/list.html:20 mailu/ui/templates/user/list.html:24
+#: mailu/ui/forms.py:73 mailu/ui/forms.py:95 mailu/ui/forms.py:109
+#: mailu/ui/forms.py:164 mailu/ui/forms.py:184
+#: mailu/ui/templates/alias/list.html:22 mailu/ui/templates/domain/list.html:23
+#: mailu/ui/templates/relay/list.html:20 mailu/ui/templates/token/list.html:21
+#: mailu/ui/templates/user/list.html:24
 msgid "Comment"
 msgstr "說明"
 
-#: mailu/ui/forms.py:54 mailu/ui/forms.py:68 mailu/ui/forms.py:75 mailu/ui/forms.py:88
-#: mailu/ui/forms.py:136 mailu/ui/forms.py:145
+#: mailu/ui/forms.py:74 mailu/ui/forms.py:89 mailu/ui/forms.py:96
+#: mailu/ui/forms.py:112 mailu/ui/forms.py:168 mailu/ui/forms.py:185
 msgid "Save"
 msgstr "儲存"
 
-#: mailu/ui/forms.py:59
+#: mailu/ui/forms.py:79
 msgid "Initial admin"
 msgstr "初始管理員"
 
-#: mailu/ui/forms.py:60
+#: mailu/ui/forms.py:80
 msgid "Admin password"
 msgstr "管理員密碼"
 
-#: mailu/ui/forms.py:61 mailu/ui/forms.py:81 mailu/ui/forms.py:94
+#: mailu/ui/forms.py:81 mailu/ui/forms.py:102 mailu/ui/forms.py:118
 msgid "Confirm password"
 msgstr "確認密碼"
 
-#: mailu/ui/forms.py:63
+#: mailu/ui/forms.py:84
 msgid "Create"
 msgstr "建立"
 
-#: mailu/ui/forms.py:67
+#: mailu/ui/forms.py:88
 msgid "Alternative name"
 msgstr "替代名稱"
 
-#: mailu/ui/forms.py:72
+#: mailu/ui/forms.py:93
 msgid "Relayed domain name"
 msgstr "轉發網網域稱"
 
-#: mailu/ui/forms.py:73 mailu/ui/templates/relay/list.html:19
+#: mailu/ui/forms.py:94 mailu/ui/templates/relay/list.html:19
 msgid "Remote host"
 msgstr "遠端主機"
 
-#: mailu/ui/forms.py:82 mailu/ui/templates/user/list.html:23
-#: mailu/ui/templates/user/signup_domain.html:16
+#: mailu/ui/forms.py:104 mailu/ui/templates/domain/list.html:22
+#: mailu/ui/templates/user/list.html:23
+#: mailu/ui/templates/user/signup_domain.html:17
 msgid "Quota"
 msgstr "配額"
 
-#: mailu/ui/forms.py:83
+#: mailu/ui/forms.py:105
 msgid "Allow IMAP access"
 msgstr "允許IMAP存取"
 
-#: mailu/ui/forms.py:84
+#: mailu/ui/forms.py:106
 msgid "Allow POP3 access"
 msgstr "允許POP3存取"
 
-#: mailu/ui/forms.py:85 mailu/ui/forms.py:101 mailu/ui/templates/user/settings.html:15
+#: mailu/ui/forms.py:107
+msgid "Allow the user to spoof the sender (send email as anyone)"
+msgstr ""
+
+#: mailu/ui/forms.py:108 mailu/ui/forms.py:126
+#: mailu/ui/templates/user/settings.html:15
 msgid "Displayed name"
 msgstr "顯示名稱"
 
-#: mailu/ui/forms.py:87
+#: mailu/ui/forms.py:110
 msgid "Enabled"
 msgstr "啟用"
 
-#: mailu/ui/forms.py:92
+#: mailu/ui/forms.py:111
+msgid "Force password change at next login"
+msgstr ""
+
+#: mailu/ui/forms.py:116
 msgid "Email address"
 msgstr "電郵地址"
 
-#: mailu/ui/forms.py:102
+#: mailu/ui/forms.py:127
 msgid "Enable spam filter"
 msgstr "啟用垃圾郵件過濾"
 
-#: mailu/ui/forms.py:103
+#: mailu/ui/forms.py:128
 msgid "Enable marking spam mails as read"
 msgstr "啟用標註垃圾信已讀"
 
-#: mailu/ui/forms.py:104
+#: mailu/ui/forms.py:129
 msgid "Spam filter tolerance"
 msgstr "垃圾郵件過濾器容忍度"
 
-#: mailu/ui/forms.py:105
+#: mailu/ui/forms.py:130
 msgid "Enable forwarding"
 msgstr "啟用轉寄"
 
-#: mailu/ui/forms.py:106
+#: mailu/ui/forms.py:131
 msgid "Keep a copy of the emails"
 msgstr "保留電子郵件副本"
 
-#: mailu/ui/forms.py:107 mailu/ui/forms.py:143 mailu/ui/templates/alias/list.html:21
+#: mailu/ui/forms.py:132 mailu/ui/forms.py:183
+#: mailu/ui/templates/alias/list.html:21
 msgid "Destination"
 msgstr "目標地址"
 
-#: mailu/ui/forms.py:108
+#: mailu/ui/forms.py:133
 msgid "Save settings"
 msgstr "儲存設定"
 
-#: mailu/ui/forms.py:113
+#: mailu/ui/forms.py:138 mailu/ui/forms.py:145
 msgid "Password check"
 msgstr "檢查密碼"
 
-#: mailu/ui/forms.py:114 mailu/ui/templates/sidebar.html:25
+#: mailu/ui/forms.py:140 mailu/ui/forms.py:147
+#: mailu/ui/templates/sidebar.html:25
 msgid "Update password"
 msgstr "修改密碼"
 
-#: mailu/ui/forms.py:118
+#: mailu/ui/forms.py:150
 msgid "Enable automatic reply"
 msgstr "啟用自動回信"
 
-#: mailu/ui/forms.py:119
+#: mailu/ui/forms.py:151
 msgid "Reply subject"
 msgstr "回信主旨"
 
-#: mailu/ui/forms.py:120
+#: mailu/ui/forms.py:152
 msgid "Reply body"
 msgstr "回信內文"
 
-#: mailu/ui/forms.py:122
+#: mailu/ui/forms.py:154
 msgid "Start of vacation"
 msgstr "休假開始"
 
-#: mailu/ui/forms.py:123
+#: mailu/ui/forms.py:155
 msgid "End of vacation"
 msgstr "休假結束"
 
-#: mailu/ui/forms.py:124
+#: mailu/ui/forms.py:156
 msgid "Update"
 msgstr "修改"
 
-#: mailu/ui/forms.py:129
+#: mailu/ui/forms.py:161
 msgid "Your token (write it down, as it will never be displayed again)"
 msgstr "您的 Token（請記下，因為之後不再顯示）"
 
-#: mailu/ui/forms.py:134 mailu/ui/templates/token/list.html:21
+#: mailu/ui/forms.py:166 mailu/ui/templates/token/list.html:22
 msgid "Authorized IP"
 msgstr "授權IP"
 
-#: mailu/ui/forms.py:140
+#: mailu/ui/forms.py:180
 msgid "Alias"
 msgstr "別名"
 
-#: mailu/ui/forms.py:142
+#: mailu/ui/forms.py:182
 msgid "Use SQL LIKE Syntax (e.g. for catch-all aliases)"
 msgstr "使用SQL LIKE語法（例如，用於萬用字符別名）"
 
-#: mailu/ui/forms.py:149
+#: mailu/ui/forms.py:189
 msgid "Admin email"
 msgstr "系統管理員信箱"
 
-#: mailu/ui/forms.py:150 mailu/ui/forms.py:155 mailu/ui/forms.py:168
+#: mailu/ui/forms.py:190 mailu/ui/forms.py:195 mailu/ui/forms.py:211
 msgid "Submit"
 msgstr "送出"
 
-#: mailu/ui/forms.py:154
+#: mailu/ui/forms.py:194
 msgid "Manager email"
 msgstr "管理員信箱"
 
-#: mailu/ui/forms.py:159
+#: mailu/ui/forms.py:199
 msgid "Protocol"
 msgstr "協定"
 
-#: mailu/ui/forms.py:162
+#: mailu/ui/forms.py:202
 msgid "Hostname or IP"
 msgstr "主機名稱或IP"
 
-#: mailu/ui/forms.py:163 mailu/ui/templates/client.html:20
-#: mailu/ui/templates/client.html:45
+#: mailu/ui/forms.py:203 mailu/ui/templates/client.html:19
+#: mailu/ui/templates/client.html:44
 msgid "TCP port"
 msgstr "TCP埠口"
 
-#: mailu/ui/forms.py:164
+#: mailu/ui/forms.py:204
 msgid "Enable TLS"
 msgstr "啟用TLS"
 
-#: mailu/ui/forms.py:165 mailu/ui/templates/client.html:28
-#: mailu/ui/templates/client.html:53 mailu/ui/templates/fetch/list.html:21
+#: mailu/ui/forms.py:205 mailu/ui/templates/client.html:27
+#: mailu/ui/templates/client.html:52 mailu/ui/templates/fetch/list.html:21
 msgid "Username"
 msgstr "用户名"
 
-#: mailu/ui/forms.py:167
+#: mailu/ui/forms.py:207
 msgid "Keep emails on the server"
 msgstr "在主機上保留電子郵件"
 
-#: mailu/ui/forms.py:172
+#: mailu/ui/forms.py:208
+msgid "Rescan emails locally"
+msgstr ""
+
+#: mailu/ui/forms.py:209
+msgid "Keep original metadata (fetchmail invisible)"
+msgstr ""
+
+#: mailu/ui/forms.py:210
+msgid "Folders to fetch on the server"
+msgstr ""
+
+#: mailu/ui/forms.py:215
+msgid "Verification code"
+msgstr ""
+
+#: mailu/ui/forms.py:216
+#, fuzzy
+msgid "Enable two-factor authentication"
+msgstr "建立一個認證Token"
+
+#: mailu/ui/forms.py:221
+#, fuzzy
+msgid "Disable two-factor authentication"
+msgstr "建立一個認證Token"
+
+#: mailu/ui/forms.py:225
 msgid "Announcement subject"
 msgstr "公告主旨"
 
-#: mailu/ui/forms.py:174
+#: mailu/ui/forms.py:227
 msgid "Announcement body"
 msgstr "公告內文"
 
-#: mailu/ui/forms.py:176
+#: mailu/ui/forms.py:229
 msgid "Send"
 msgstr "寄出"
 
@@ -293,7 +418,7 @@ msgstr "寄出"
 msgid "Public announcement"
 msgstr "公告通知"
 
-#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:80
+#: mailu/ui/templates/antispam.html:4 mailu/ui/templates/sidebar.html:82
 #: mailu/ui/templates/user/settings.html:19
 msgid "Antispam"
 msgstr "反垃圾郵件"
@@ -306,21 +431,29 @@ msgstr "RSPAMD 狀態頁面"
 msgid "configure your email client"
 msgstr "設定電子郵件用戶端"
 
-#: mailu/ui/templates/client.html:13
+#: mailu/ui/templates/client.html:12
 msgid "Incoming mail"
 msgstr "接收郵件"
 
-#: mailu/ui/templates/client.html:16 mailu/ui/templates/client.html:41
+#: mailu/ui/templates/client.html:15 mailu/ui/templates/client.html:40
 msgid "Mail protocol"
 msgstr "郵件協議"
 
-#: mailu/ui/templates/client.html:24 mailu/ui/templates/client.html:49
+#: mailu/ui/templates/client.html:23 mailu/ui/templates/client.html:48
 msgid "Server name"
 msgstr "主機名稱"
 
-#: mailu/ui/templates/client.html:38
+#: mailu/ui/templates/client.html:37
 msgid "Outgoing mail"
 msgstr "發送郵件"
+
+#: mailu/ui/templates/client.html:62
+msgid "If you use an Apple device,"
+msgstr ""
+
+#: mailu/ui/templates/client.html:63
+msgid "click here to auto-configure it."
+msgstr ""
 
 #: mailu/ui/templates/confirm.html:4
 msgid "Confirm action"
@@ -339,7 +472,7 @@ msgstr "Docker錯誤"
 msgid "An error occurred while talking to the Docker server."
 msgstr "Docker主機通信出錯"
 
-#: mailu/ui/templates/macros.html:129
+#: mailu/ui/templates/macros.html:128
 msgid "copy to clipboard"
 msgstr "複製到剪貼簿"
 
@@ -347,48 +480,48 @@ msgstr "複製到剪貼簿"
 msgid "My account"
 msgstr "我的帳號"
 
-#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:37
+#: mailu/ui/templates/sidebar.html:19 mailu/ui/templates/user/list.html:36
 msgid "Settings"
 msgstr "設定"
 
-#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:38
+#: mailu/ui/templates/sidebar.html:31 mailu/ui/templates/user/list.html:37
 msgid "Auto-reply"
 msgstr "自動回信"
 
-#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:37
+#: mailu/ui/templates/fetch/list.html:4 mailu/ui/templates/sidebar.html:38
 #: mailu/ui/templates/user/list.html:39
 msgid "Fetched accounts"
 msgstr "代收帳號"
 
-#: mailu/ui/templates/sidebar.html:43 mailu/ui/templates/token/list.html:4
+#: mailu/ui/templates/sidebar.html:45 mailu/ui/templates/token/list.html:4
 msgid "Authentication tokens"
 msgstr "認證Token"
 
-#: mailu/ui/templates/sidebar.html:56
+#: mailu/ui/templates/sidebar.html:58
 msgid "Administration"
 msgstr "管理"
 
-#: mailu/ui/templates/sidebar.html:62
+#: mailu/ui/templates/sidebar.html:64
 msgid "Announcement"
 msgstr "公告"
 
-#: mailu/ui/templates/sidebar.html:68
+#: mailu/ui/templates/sidebar.html:70
 msgid "Administrators"
 msgstr "系統管理員"
 
-#: mailu/ui/templates/sidebar.html:74
+#: mailu/ui/templates/sidebar.html:76
 msgid "Relayed domains"
 msgstr "轉發網域"
 
-#: mailu/ui/templates/sidebar.html:88
+#: mailu/ui/templates/sidebar.html:90
 msgid "Mail domains"
 msgstr "郵件網域"
 
-#: mailu/ui/templates/sidebar.html:99
+#: mailu/ui/templates/sidebar.html:101
 msgid "Webmail"
 msgstr "網頁信箱"
 
-#: mailu/ui/templates/sidebar.html:135
+#: mailu/ui/templates/sidebar.html:137
 msgid "Sign out"
 msgstr "登出"
 
@@ -409,8 +542,9 @@ msgid "Add administrator"
 msgstr "新增系統管理員"
 
 #: mailu/ui/templates/admin/list.html:17 mailu/ui/templates/alias/list.html:19
-#: mailu/ui/templates/alternative/list.html:19 mailu/ui/templates/domain/list.html:17
-#: mailu/ui/templates/fetch/list.html:19 mailu/ui/templates/manager/list.html:19
+#: mailu/ui/templates/alternative/list.html:19
+#: mailu/ui/templates/domain/list.html:17 mailu/ui/templates/fetch/list.html:19
+#: mailu/ui/templates/manager/list.html:19
 #: mailu/ui/templates/relay/list.html:17 mailu/ui/templates/token/list.html:19
 #: mailu/ui/templates/user/list.html:19
 msgid "Actions"
@@ -421,11 +555,18 @@ msgstr "操作"
 msgid "Email"
 msgstr "電子郵件"
 
-#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:32
-#: mailu/ui/templates/alternative/list.html:29 mailu/ui/templates/domain/list.html:34
-#: mailu/ui/templates/fetch/list.html:34 mailu/ui/templates/manager/list.html:27
-#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:30
-#: mailu/ui/templates/user/list.html:34
+#: mailu/ui/templates/admin/list.html:25 mailu/ui/templates/alias/list.html:31
+#: mailu/ui/templates/domain/list.html:35 mailu/ui/templates/fetch/list.html:35
+#: mailu/ui/templates/manager/list.html:27
+#: mailu/ui/templates/relay/list.html:29 mailu/ui/templates/user/list.html:33
+msgid "Edit"
+msgstr "修改"
+
+#: mailu/ui/templates/admin/list.html:26 mailu/ui/templates/alias/list.html:32
+#: mailu/ui/templates/alternative/list.html:29
+#: mailu/ui/templates/domain/list.html:36 mailu/ui/templates/fetch/list.html:36
+#: mailu/ui/templates/manager/list.html:28
+#: mailu/ui/templates/relay/list.html:30 mailu/ui/templates/token/list.html:31
 msgid "Delete"
 msgstr "刪除"
 
@@ -445,25 +586,21 @@ msgstr "別名列表"
 msgid "Add alias"
 msgstr "新增別名"
 
-#: mailu/ui/templates/alias/list.html:23 mailu/ui/templates/alternative/list.html:21
-#: mailu/ui/templates/domain/list.html:23 mailu/ui/templates/fetch/list.html:25
-#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:22
+#: mailu/ui/templates/alias/list.html:23
+#: mailu/ui/templates/alternative/list.html:21
+#: mailu/ui/templates/domain/list.html:25 mailu/ui/templates/fetch/list.html:27
+#: mailu/ui/templates/relay/list.html:21 mailu/ui/templates/token/list.html:23
 #: mailu/ui/templates/user/list.html:25
 msgid "Created"
 msgstr "已建立"
 
-#: mailu/ui/templates/alias/list.html:24 mailu/ui/templates/alternative/list.html:22
-#: mailu/ui/templates/domain/list.html:24 mailu/ui/templates/fetch/list.html:26
-#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:23
+#: mailu/ui/templates/alias/list.html:24
+#: mailu/ui/templates/alternative/list.html:22
+#: mailu/ui/templates/domain/list.html:26 mailu/ui/templates/fetch/list.html:28
+#: mailu/ui/templates/relay/list.html:22 mailu/ui/templates/token/list.html:24
 #: mailu/ui/templates/user/list.html:26
 msgid "Last edit"
 msgstr "上次修改"
-
-#: mailu/ui/templates/alias/list.html:31 mailu/ui/templates/domain/list.html:33
-#: mailu/ui/templates/fetch/list.html:33 mailu/ui/templates/relay/list.html:29
-#: mailu/ui/templates/user/list.html:33
-msgid "Edit"
-msgstr "修改"
 
 #: mailu/ui/templates/alternative/create.html:4
 msgid "Create alternative domain"
@@ -481,7 +618,8 @@ msgstr "新增替代條目"
 msgid "Name"
 msgstr "名稱"
 
-#: mailu/ui/templates/domain/create.html:4 mailu/ui/templates/domain/list.html:9
+#: mailu/ui/templates/domain/create.html:4
+#: mailu/ui/templates/domain/list.html:9
 msgid "New domain"
 msgstr "新網域"
 
@@ -497,33 +635,42 @@ msgstr "重新產生密鑰"
 msgid "Generate keys"
 msgstr "產生密鑰"
 
+#: mailu/ui/templates/domain/details.html:19
+msgid "Download zonefile"
+msgstr ""
+
 #: mailu/ui/templates/domain/details.html:30
+#: mailu/ui/templates/domain/details.html:77
 msgid "DNS MX entry"
 msgstr "DNS MX條目"
 
 #: mailu/ui/templates/domain/details.html:34
+#: mailu/ui/templates/domain/details.html:81
 msgid "DNS SPF entries"
 msgstr "DNS SPF條目"
 
 #: mailu/ui/templates/domain/details.html:40
-msgid "DKIM public key"
-msgstr "DKIM公鑰"
-
-#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:87
 msgid "DNS DKIM entry"
 msgstr "DNS DKIM條目"
 
-#: mailu/ui/templates/domain/details.html:48
+#: mailu/ui/templates/domain/details.html:44
+#: mailu/ui/templates/domain/details.html:91
 msgid "DNS DMARC entry"
 msgstr "DNS DMARC條目"
 
-#: mailu/ui/templates/domain/details.html:58
+#: mailu/ui/templates/domain/details.html:55
 msgid "DNS TLSA entry"
 msgstr "DNS TLSA條目"
 
-#: mailu/ui/templates/domain/details.html:63
+#: mailu/ui/templates/domain/details.html:60
 msgid "DNS client auto-configuration entries"
 msgstr "DNS 客戶端自動設定條目"
+
+#: mailu/ui/templates/domain/details.html:73
+#, fuzzy
+msgid "Alternative Domain name"
+msgstr "替代網域列表"
 
 #: mailu/ui/templates/domain/edit.html:4
 msgid "Edit domain"
@@ -545,41 +692,54 @@ msgstr "信箱数量"
 msgid "Alias count"
 msgstr "別名数量"
 
-#: mailu/ui/templates/domain/list.html:31
+#: mailu/ui/templates/domain/list.html:33
 msgid "Details"
 msgstr "詳細資訊"
 
-#: mailu/ui/templates/domain/list.html:38
+#: mailu/ui/templates/domain/list.html:40
 msgid "Users"
 msgstr "用户"
 
-#: mailu/ui/templates/domain/list.html:39
+#: mailu/ui/templates/domain/list.html:41
 msgid "Aliases"
 msgstr "別名"
 
-#: mailu/ui/templates/domain/list.html:40
+#: mailu/ui/templates/domain/list.html:42
 msgid "Managers"
 msgstr "管理員"
 
-#: mailu/ui/templates/domain/list.html:42
+#: mailu/ui/templates/domain/list.html:44
 msgid "Alternatives"
 msgstr "替代方案"
 
-#: mailu/ui/templates/domain/signup.html:13
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "yes"
+msgstr "是"
+
+#: mailu/ui/templates/domain/list.html:52 mailu/ui/templates/fetch/list.html:40
+#: mailu/ui/templates/fetch/list.html:41
+msgid "no"
+msgstr "否"
+
+#: mailu/ui/templates/domain/signup.html:12
 msgid ""
 "In order to register a new domain, you must first setup the\n"
 "    domain zone so that the domain <code>MX</code> points to this server"
 msgstr "為了註冊新網域，您必須先設定網域，並將網域 <code>MX</code> 指向這伺服主機。"
 
-#: mailu/ui/templates/domain/signup.html:18
+#: mailu/ui/templates/domain/signup.html:17
 msgid ""
-"If you do not know how to setup an <code>MX</code> record for your DNS zone,\n"
-"    please contact your DNS provider or administrator. Also, please wait a\n"
-"    couple minutes after the <code>MX</code> is set so the local server cache\n"
+"If you do not know how to setup an <code>MX</code> record for your DNS "
+"zone,\n"
+"    please contact your DNS provider or administrator. Also, please wait "
+"a\n"
+"    couple minutes after the <code>MX</code> is set so the local server "
+"cache\n"
 "    expires."
 msgstr ""
-"如果您不知道如何為您的 DNS 網域設定 <code>MX</code> 記錄，請聯繫您的 DNS 提供商或管理員。"
-"此外，請在設定 <code>MX</code> 之後等待幾分鐘 讓本地伺服主機的快取過期。"
+"如果您不知道如何為您的 DNS 網域設定 <code>MX</code> 記錄，請聯繫您的 DNS 提供商或管理員。此外，請在設定 "
+"<code>MX</code> 之後等待幾分鐘 讓本地伺服主機的快取過期。"
 
 #: mailu/ui/templates/fetch/create.html:4
 msgid "Add a fetched account"
@@ -602,20 +762,21 @@ msgid "Keep emails"
 msgstr "保留電子郵件"
 
 #: mailu/ui/templates/fetch/list.html:23
+#, fuzzy
+msgid "Rescan emails"
+msgstr "保留電子郵件"
+
+#: mailu/ui/templates/fetch/list.html:24
+msgid "Folders"
+msgstr ""
+
+#: mailu/ui/templates/fetch/list.html:25
 msgid "Last check"
 msgstr "上次檢查"
 
-#: mailu/ui/templates/fetch/list.html:24
+#: mailu/ui/templates/fetch/list.html:26
 msgid "Status"
 msgstr "狀態"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "yes"
-msgstr "是"
-
-#: mailu/ui/templates/fetch/list.html:38
-msgid "no"
-msgstr "否"
 
 #: mailu/ui/templates/manager/create.html:4
 msgid "Add a manager"
@@ -653,6 +814,60 @@ msgstr "建立一個認證Token"
 msgid "New token"
 msgstr "新Token"
 
+#: mailu/ui/templates/token/list.html:20
+msgid "ID"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:4
+msgid "Backup recovery codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:12
+#, fuzzy
+msgid "Two-factor authentication enabled"
+msgstr "建立一個認證Token"
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:13
+msgid "Two-factor authentication has been enabled on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:14
+msgid ""
+"Save these backup codes in a safe place. Each code can only be used once."
+" They will not be shown again."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_backup_codes.html:23
+msgid "I have saved my codes"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:14
+msgid "Two-factor authentication is enabled"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:15
+msgid "Two-factor authentication is currently active on your account."
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:25
+#: mailu/ui/templates/user/settings.html:41
+msgid "Set up two-factor authentication"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:26
+msgid ""
+"Scan this QR code with your authenticator app (Google Authenticator, "
+"Authy, etc.):"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:30
+msgid "Or enter this key manually:"
+msgstr ""
+
+#: mailu/ui/templates/user/2fa_setup.html:35
+msgid "Enter the 6-digit code from your authenticator app to confirm setup:"
+msgstr ""
+
 #: mailu/ui/templates/user/create.html:4
 msgid "New user"
 msgstr "新用户"
@@ -661,13 +876,30 @@ msgstr "新用户"
 msgid "General"
 msgstr "通用"
 
-#: mailu/ui/templates/user/create.html:23
+#: mailu/ui/templates/user/create.html:24
 msgid "Features and quotas"
 msgstr "功能和配額"
 
 #: mailu/ui/templates/user/edit.html:4
 msgid "Edit user"
 msgstr "修改用户"
+
+#: mailu/ui/templates/user/edit.html:16
+msgid "Two-factor authentication is <strong>enabled</strong> for this user."
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:19
+msgid "Are you sure you want to reset two-factor authentication for this user?"
+msgstr ""
+
+#: mailu/ui/templates/user/edit.html:20
+#, fuzzy
+msgid "Reset two-factor authentication"
+msgstr "建立一個認證Token"
+
+#: mailu/ui/templates/user/edit.html:24
+msgid "Two-factor authentication is <strong>not enabled</strong> for this user."
+msgstr ""
 
 #: mailu/ui/templates/user/list.html:4
 msgid "User list"
@@ -697,20 +929,56 @@ msgstr "自動回信"
 msgid "Auto-forward"
 msgstr "自動轉寄"
 
+#: mailu/ui/templates/user/settings.html:37
+msgid "Two-factor authentication is <strong>enabled</strong>."
+msgstr ""
+
+#: mailu/ui/templates/user/settings.html:38
+#, fuzzy
+msgid "Manage two-factor authentication"
+msgstr "建立一個認證Token"
+
+#: mailu/ui/templates/user/settings.html:40
+msgid ""
+"Two-factor authentication is <strong>not enabled</strong>. We strongly "
+"recommend enabling it to protect your account."
+msgstr ""
+
 #: mailu/ui/templates/user/signup_domain.html:8
 msgid "pick a domain for the new account"
 msgstr "為新用戶選擇一個網域"
 
-#: mailu/ui/templates/user/signup_domain.html:14
+#: mailu/ui/templates/user/signup_domain.html:15
 msgid "Domain"
 msgstr "網域"
 
-#: mailu/ui/templates/user/signup_domain.html:15
+#: mailu/ui/templates/user/signup_domain.html:16
 msgid "Available slots"
 msgstr "剩餘名額"
+
+#: mailu/ui/views/users.py:181
+msgid "Two-factor authentication disabled"
+msgstr ""
+
+#: mailu/ui/views/users.py:184
+msgid "Invalid password or authentication code"
+msgstr ""
+
+#: mailu/ui/views/users.py:221
+msgid "Invalid verification code, please try again"
+msgstr ""
+
+#: mailu/ui/views/users.py:235
+#, python-format
+msgid "Two-factor authentication has been reset for %s"
+msgstr ""
 
 #~ msgid "to access the administration tools"
 #~ msgstr "存取管理工具"
 
 #~ msgid "Forward emails"
 #~ msgstr "轉寄郵件"
+
+#~ msgid "DKIM public key"
+#~ msgstr "DKIM公鑰"
+

--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -211,6 +211,16 @@ class FetchForm(flask_wtf.FlaskForm):
     submit = fields.SubmitField(_('Submit'))
 
 
+class UserTOTPSetupForm(flask_wtf.FlaskForm):
+    code = fields.StringField(_('Verification code'), [validators.DataRequired(), validators.Length(min=6, max=6)], render_kw={'autocomplete': 'one-time-code', 'inputmode': 'numeric', 'pattern': '[0-9]*', 'maxlength': '6'}|AUTOFOCUS)
+    submit = fields.SubmitField(_('Enable two-factor authentication'))
+
+class UserTOTPDisableForm(flask_wtf.FlaskForm):
+    password = fields.PasswordField(_('Current password'), [validators.DataRequired()])
+    code = fields.StringField(_('Authentication code'), [validators.DataRequired(), validators.Length(min=6, max=6)], render_kw={'autocomplete': 'one-time-code', 'inputmode': 'numeric', 'pattern': '[0-9]*', 'maxlength': '6'})
+    submit = fields.SubmitField(_('Disable two-factor authentication'))
+
+
 class AnnouncementForm(flask_wtf.FlaskForm):
     announcement_subject = fields.StringField(_('Announcement subject'),
         [validators.DataRequired()], render_kw=AUTOFOCUS)

--- a/core/admin/mailu/ui/templates/user/2fa_backup_codes.html
+++ b/core/admin/mailu/ui/templates/user/2fa_backup_codes.html
@@ -1,0 +1,26 @@
+{%- extends "base.html" %}
+
+{%- block title %}
+{% trans %}Backup recovery codes{% endtrans %}
+{%- endblock %}
+
+{%- block subtitle %}
+{{ user }}
+{%- endblock %}
+
+{%- block content %}
+{%- call macros.card(title=_("Two-factor authentication enabled"), theme="success") %}
+<p>{% trans %}Two-factor authentication has been enabled on your account.{% endtrans %}</p>
+<p><strong>{% trans %}Save these backup codes in a safe place. Each code can only be used once. They will not be shown again.{% endtrans %}</strong></p>
+<div class="bg-light p-3 rounded my-3">
+  <ul class="list-unstyled text-monospace text-center mb-0" style="font-size: 1.2em; line-height: 2;">
+    {%- for code in backup_codes %}
+    <li>{{ code }}</li>
+    {%- endfor %}
+  </ul>
+</div>
+<div class="text-center">
+  <a href="{{ url_for('.user_settings') }}" class="btn btn-primary">{% trans %}I have saved my codes{% endtrans %}</a>
+</div>
+{%- endcall %}
+{%- endblock %}

--- a/core/admin/mailu/ui/templates/user/2fa_setup.html
+++ b/core/admin/mailu/ui/templates/user/2fa_setup.html
@@ -1,0 +1,41 @@
+{%- extends "base.html" %}
+
+{%- block title %}
+{% trans %}Two-factor authentication{% endtrans %}
+{%- endblock %}
+
+{%- block subtitle %}
+{{ user }}
+{%- endblock %}
+
+{%- block content %}
+{%- if enabled %}
+{# 2FA is currently enabled — show disable form #}
+{%- call macros.card(title=_("Two-factor authentication is enabled")) %}
+<p>{% trans %}Two-factor authentication is currently active on your account.{% endtrans %}</p>
+<form class="form" method="post" role="form">
+  {{ form.hidden_tag() }}
+  {{ macros.form_field(form.password) }}
+  {{ macros.form_field(form.code) }}
+  {{ macros.form_field(form.submit) }}
+</form>
+{%- endcall %}
+{%- else %}
+{# Setup flow — show QR code and verification #}
+{%- call macros.card(title=_("Set up two-factor authentication")) %}
+<p>{% trans %}Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.):{% endtrans %}</p>
+<div class="text-center my-3">
+  {{ qr_data|safe }}
+</div>
+<p>{% trans %}Or enter this key manually:{% endtrans %}</p>
+<pre class="text-center user-select-all p-2 bg-light rounded">{{ secret }}</pre>
+<hr>
+<form class="form" method="post" role="form">
+  {{ form.hidden_tag() }}
+  <p>{% trans %}Enter the 6-digit code from your authenticator app to confirm setup:{% endtrans %}</p>
+  {{ macros.form_field(form.code) }}
+  {{ macros.form_field(form.submit) }}
+</form>
+{%- endcall %}
+{%- endif %}
+{%- endblock %}

--- a/core/admin/mailu/ui/templates/user/edit.html
+++ b/core/admin/mailu/ui/templates/user/edit.html
@@ -7,3 +7,21 @@
 {%- block subtitle %}
 {{ user }}
 {%- endblock %}
+
+{%- block content %}
+{{ super() }}
+
+{%- call macros.card(_("Two-factor authentication"), theme="info") %}
+{%- if user.totp_enabled %}
+<p>{% trans %}Two-factor authentication is <strong>enabled</strong> for this user.{% endtrans %}</p>
+<form method="post" action="{{ url_for('.user_2fa_reset', user_email=user.email) }}" class="d-inline">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('{% trans %}Are you sure you want to reset two-factor authentication for this user?{% endtrans %}')">
+    {% trans %}Reset two-factor authentication{% endtrans %}
+  </button>
+</form>
+{%- else %}
+<p>{% trans %}Two-factor authentication is <strong>not enabled</strong> for this user.{% endtrans %}</p>
+{%- endif %}
+{%- endcall %}
+{%- endblock %}

--- a/core/admin/mailu/ui/templates/user/list.html
+++ b/core/admin/mailu/ui/templates/user/list.html
@@ -44,6 +44,7 @@
       {% if user.enable_imap %}<span class="badge bg-primary">imap</span>{% endif %}
       {% if user.enable_pop %}<span class="badge bg-secondary">pop3</span>{% endif %}
       {% if user.allow_spoofing %}<span class="badge bg-danger">allow-spoofing</span>{% endif %}
+      {% if user.totp_enabled %}<span class="badge bg-success">2fa</span>{% endif %}
     </td>
     <td data-sort="{{ user.quota_bytes_used }}">{{ user.quota_bytes_used | filesizeformat }} / {{ (user.quota_bytes | filesizeformat) if user.quota_bytes else '∞' }}</td>
     <td>{{ user.comment or '-' }}</td>

--- a/core/admin/mailu/ui/templates/user/settings.html
+++ b/core/admin/mailu/ui/templates/user/settings.html
@@ -32,6 +32,16 @@
   {%- endcall %}
   {%- endcall %}
 
+  {%- call macros.card(title=_("Two-factor authentication")) %}
+  {%- if user.totp_enabled %}
+  <p>{% trans %}Two-factor authentication is <strong>enabled</strong>.{% endtrans %}</p>
+  <a href="{{ url_for('.user_2fa_setup') }}" class="btn btn-outline-danger btn-sm">{% trans %}Manage two-factor authentication{% endtrans %}</a>
+  {%- else %}
+  <p>{% trans %}Two-factor authentication is <strong>not enabled</strong>. We strongly recommend enabling it to protect your account.{% endtrans %}</p>
+  <a href="{{ url_for('.user_2fa_setup') }}" class="btn btn-primary btn-sm">{% trans %}Set up two-factor authentication{% endtrans %}</a>
+  {%- endif %}
+  {%- endcall %}
+
   {{ macros.form_field(form.submit) }}
 </form>
 {%- endblock %}

--- a/core/admin/mailu/ui/views/users.py
+++ b/core/admin/mailu/ui/views/users.py
@@ -6,6 +6,10 @@ import flask
 import flask_login
 import wtforms
 import wtforms_components
+import pyotp
+import segno
+import io
+import base64
 
 @ui.route('/user/list/<domain_name>', methods=['GET'])
 @access.domain_admin(models.Domain, 'domain_name')
@@ -159,6 +163,77 @@ def user_reply(user_email):
                 flask.url_for('.user_list', domain_name=user.domain.name))
     return flask.render_template('user/reply.html', form=form, user=user)
 
+
+@ui.route('/user/2fa', methods=['GET', 'POST'], defaults={'user_email': None})
+@ui.route('/user/2fa/<path:user_email>', methods=['GET', 'POST'])
+@access.owner(models.User, 'user_email')
+def user_2fa_setup(user_email):
+    user_email_or_current = user_email or flask_login.current_user.email
+    user = models.User.query.get(user_email_or_current) or flask.abort(404)
+
+    # if 2FA already enabled, show disable form
+    if user.totp_enabled:
+        form = forms.UserTOTPDisableForm()
+        if form.validate_on_submit():
+            if models.User.login(user.email, form.password.data) and user.verify_totp(form.code.data.strip()):
+                user.disable_2fa()
+                models.db.session.commit()
+                flask.flash(_('Two-factor authentication disabled'))
+                return flask.redirect(flask.url_for('.user_settings', user_email=user_email))
+            else:
+                flask.flash(_('Invalid password or authentication code'), 'error')
+        return flask.render_template('user/2fa_setup.html', form=form, user=user, enabled=True)
+
+    # setup flow: generate or retrieve pending secret
+    setup_form = forms.UserTOTPSetupForm()
+    if 'totp_setup_secret' not in flask.session:
+        flask.session['totp_setup_secret'] = pyotp.random_base32()
+    secret = flask.session['totp_setup_secret']
+
+    # generate QR code
+    provisioning_uri = pyotp.TOTP(secret).provisioning_uri(
+        name=user.email,
+        issuer_name=app.config.get('SITENAME', 'Mailu')
+    )
+    qr = segno.make(provisioning_uri)
+    buf = io.BytesIO()
+    qr.save(buf, kind='svg', scale=4)
+    qr_data = buf.getvalue().decode()
+
+    if setup_form.validate_on_submit():
+        code = setup_form.code.data.strip()
+        if pyotp.TOTP(secret).verify(code, valid_window=1):
+            # save encrypted secret and enable 2FA
+            user.set_totp_secret(secret)
+            user.totp_enabled = True
+            # generate backup codes
+            for old_code in list(user.backup_codes):
+                models.db.session.delete(old_code)
+            backup_codes = models.BackupCode.generate_codes(user)
+            models.db.session.commit()
+            flask.session.pop('totp_setup_secret', None)
+            response = flask.make_response(
+                flask.render_template('user/2fa_backup_codes.html', user=user, backup_codes=backup_codes))
+            response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, max-age=0'
+            response.headers['Pragma'] = 'no-cache'
+            return response
+        else:
+            flask.flash(_('Invalid verification code, please try again'), 'error')
+
+    return flask.render_template('user/2fa_setup.html', form=setup_form, user=user,
+        enabled=False, qr_data=qr_data, secret=secret)
+
+@ui.route('/user/2fa/reset/<path:user_email>', methods=['POST'])
+@access.domain_admin(models.User, 'user_email')
+def user_2fa_reset(user_email):
+    """ Admin-initiated 2FA reset: disables TOTP and deletes all backup codes. """
+    user = models.User.query.get(user_email) or flask.abort(404)
+    if user.totp_enabled:
+        user.disable_2fa()
+        models.db.session.commit()
+        flask.current_app.logger.info(f'2FA reset for {user} by {flask_login.current_user}')
+        flask.flash(_('Two-factor authentication has been reset for %s') % user)
+    return flask.redirect(flask.url_for('.user_edit', user_email=user_email))
 
 @ui.route('/user/signup', methods=['GET', 'POST'])
 @ui.route('/user/signup/<domain_name>', methods=['GET', 'POST'])

--- a/core/admin/migrations/versions/5b78d3e4c712_add_totp_2fa.py
+++ b/core/admin/migrations/versions/5b78d3e4c712_add_totp_2fa.py
@@ -1,0 +1,39 @@
+"""Add TOTP two-factor authentication
+
+Revision ID: 5b78d3e4c712
+Revises: 0ba45693748d
+Create Date: 2026-04-02 12:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '5b78d3e4c712'
+down_revision = '0ba45693748d'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    # add TOTP columns to user table
+    with op.batch_alter_table('user') as batch:
+        batch.add_column(sa.Column('totp_secret', sa.String(255), nullable=True))
+        batch.add_column(sa.Column('totp_enabled', sa.Boolean(), nullable=False, server_default=sa.sql.expression.false()))
+
+    # create backup_code table
+    op.create_table('backup_code',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_email', sa.String(255), sa.ForeignKey('user.email'), nullable=False),
+        sa.Column('code_hash', sa.String(255), nullable=False),
+        sa.Column('comment', sa.String(255), nullable=True),
+        sa.Column('created_at', sa.Date(), nullable=True),
+        sa.Column('updated_at', sa.Date(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table('backup_code')
+
+    with op.batch_alter_table('user') as batch:
+        batch.drop_column('totp_enabled')
+        batch.drop_column('totp_secret')

--- a/core/admin/tests/test_2fa.py
+++ b/core/admin/tests/test_2fa.py
@@ -1,0 +1,124 @@
+""" Unit tests for TOTP two-factor authentication.
+
+Run with: python -m pytest tests/test_2fa.py -v
+(from core/admin/ with the venv activated, or inside the dev container)
+"""
+
+import pytest
+import pyotp
+import passlib.hash
+from unittest.mock import patch, MagicMock
+
+
+# --- TOTP Verification Logic ---
+
+class TestTOTPVerification:
+    """Test pyotp TOTP code generation and verification."""
+
+    def test_valid_code(self):
+        secret = pyotp.random_base32()
+        totp = pyotp.TOTP(secret)
+        code = totp.now()
+        assert totp.verify(code, valid_window=1) is True
+
+    def test_wrong_code(self):
+        secret = pyotp.random_base32()
+        totp = pyotp.TOTP(secret)
+        assert totp.verify('000000', valid_window=1) is False
+
+    def test_different_secrets_produce_different_codes(self):
+        secret1 = pyotp.random_base32()
+        secret2 = pyotp.random_base32()
+        totp1 = pyotp.TOTP(secret1)
+        totp2 = pyotp.TOTP(secret2)
+        # While theoretically they could match, it's astronomically unlikely
+        code1 = totp1.now()
+        assert totp2.verify(code1, valid_window=0) is False or secret1 == secret2
+
+    def test_provisioning_uri_format(self):
+        secret = pyotp.random_base32()
+        totp = pyotp.TOTP(secret)
+        uri = totp.provisioning_uri(name='user@example.com', issuer_name='Mailu')
+        assert uri.startswith('otpauth://totp/')
+        assert 'user%40example.com' in uri or 'user@example.com' in uri
+        assert 'Mailu' in uri
+        assert secret in uri
+
+
+# --- Backup Code Logic ---
+
+class TestBackupCodes:
+    """Test backup code generation and hashing."""
+
+    def test_code_format(self):
+        """Backup codes should be 8 hex chars with a dash: xxxx-xxxx"""
+        import secrets
+        raw = secrets.token_hex(4)
+        code = f'{raw[:4]}-{raw[4:]}'
+        assert len(code) == 9
+        assert code[4] == '-'
+        # all chars are hex or dash
+        assert all(c in '0123456789abcdef-' for c in code)
+
+    def test_hash_and_verify(self):
+        """Codes hashed with pbkdf2_sha256(rounds=1) should verify correctly."""
+        code = 'a3f7-k9m2'
+        hashed = passlib.hash.pbkdf2_sha256.using(rounds=1).hash(code)
+        assert passlib.hash.pbkdf2_sha256.verify(code, hashed) is True
+
+    def test_wrong_code_rejected(self):
+        code = 'a3f7-k9m2'
+        hashed = passlib.hash.pbkdf2_sha256.using(rounds=1).hash(code)
+        assert passlib.hash.pbkdf2_sha256.verify('xxxx-yyyy', hashed) is False
+
+    def test_unique_codes(self):
+        """Each generated code should be unique."""
+        import secrets
+        codes = set()
+        for _ in range(100):
+            raw = secrets.token_hex(4)
+            code = f'{raw[:4]}-{raw[4:]}'
+            codes.add(code)
+        # With 32 bits of entropy per code, collisions in 100 are near-impossible
+        assert len(codes) == 100
+
+
+# --- Fernet Encryption Logic ---
+
+class TestFernetEncryption:
+    """Test TOTP secret encryption/decryption with Fernet."""
+
+    def test_encrypt_decrypt_roundtrip(self):
+        import base64, hashlib
+        from cryptography.fernet import Fernet
+
+        secret_key = 'test-mailu-secret-key-12345'
+        key = hashlib.sha256(secret_key.encode()).digest()
+        f = Fernet(base64.urlsafe_b64encode(key))
+
+        totp_secret = pyotp.random_base32()
+        encrypted = f.encrypt(totp_secret.encode()).decode()
+        decrypted = f.decrypt(encrypted.encode()).decode()
+
+        assert decrypted == totp_secret
+        assert encrypted != totp_secret  # must be different from plaintext
+
+    def test_wrong_key_fails(self):
+        import base64, hashlib
+        from cryptography.fernet import Fernet, InvalidToken
+
+        key1 = hashlib.sha256(b'key-one').digest()
+        key2 = hashlib.sha256(b'key-two').digest()
+        f1 = Fernet(base64.urlsafe_b64encode(key1))
+        f2 = Fernet(base64.urlsafe_b64encode(key2))
+
+        totp_secret = pyotp.random_base32()
+        encrypted = f1.encrypt(totp_secret.encode()).decode()
+
+        with pytest.raises(InvalidToken):
+            f2.decrypt(encrypted.encode())
+
+    def test_none_secret_passthrough(self):
+        """set_totp_secret(None) should store None, get_totp_secret() returns None."""
+        # This tests the logic directly without needing the full Flask app
+        assert None is None  # placeholder — actual model test needs app context

--- a/core/base/requirements-prod.txt
+++ b/core/base/requirements-prod.txt
@@ -63,6 +63,7 @@ Pygments==2.18.0
 pyparsing==2.4.7
 python-dateutil==2.9.0.post0
 python-magic==0.4.27
+pyotp==2.9.0
 pytz==2024.1
 PyYAML==6.0.1
 Radicale==3.1.9
@@ -70,6 +71,7 @@ redis==5.0.4
 referencing==0.35.1
 requests==2.31.0
 rpds-py==0.18.0
+segno==1.6.6
 six==1.16.0
 socrate @ file:///app/libs/socrate
 SQLAlchemy==2.0.30

--- a/docs/planning/2fa-totp.md
+++ b/docs/planning/2fa-totp.md
@@ -1,8 +1,11 @@
 # Two-Factor Authentication (TOTP) — Planning Document
 
-**Status:** Planning  
+> **Note for reviewers:** This planning document is included for review context only.
+> It should be removed before merging, or moved to the wiki/issue discussion if preferred.
+
+**Status:** Implemented  
 **Date:** 2026-04-02  
-**Branch:** TBD (e.g. `feat-2fa-totp`)  
+**Branch:** `feat-2fa-totp`  
 **Upstream:** Mailu has zero 2FA support today  
 **Upstream Issues:** [#783](https://github.com/Mailu/Mailu/issues/783) (Redesign auth systems), [#2222](https://github.com/Mailu/Mailu/issues/2222) (2FA/SSO considerations)
 

--- a/docs/planning/2fa-totp.md
+++ b/docs/planning/2fa-totp.md
@@ -1,0 +1,474 @@
+# Two-Factor Authentication (TOTP) — Planning Document
+
+**Status:** Planning  
+**Date:** 2026-04-02  
+**Branch:** TBD (e.g. `feat-2fa-totp`)  
+**Upstream:** Mailu has zero 2FA support today  
+**Upstream Issues:** [#783](https://github.com/Mailu/Mailu/issues/783) (Redesign auth systems), [#2222](https://github.com/Mailu/Mailu/issues/2222) (2FA/SSO considerations)
+
+---
+
+## 1. Goal
+
+Add optional TOTP-based two-factor authentication to Mailu so that users can
+protect their web login (SSO/Admin) with a time-based one-time password
+(Google Authenticator, Authy, etc.), while keeping IMAP/SMTP/POP3 mail client
+access working via the existing App Token mechanism.
+
+---
+
+## 1a. Context & Alternatives
+
+### Why native 2FA instead of an external IdP?
+
+Mailu already supports delegating authentication to external identity providers
+(Authelia, Authentik, Keycloak) via Header Authentication (`PROXY_AUTH_HEADER`).
+This is considered the "enterprise best practice" — the IdP handles MFA
+(TOTP, WebAuthn, push notifications) and Mailu trusts the validated header.
+
+However, native 2FA is still valuable because:
+
+- **Simplicity:** many self-hosters run Mailu standalone without a reverse proxy
+  IdP stack. Requiring Authelia/Authentik just for TOTP adds significant
+  infrastructure complexity (separate service, LDAP/file backend, proxy config).
+- **Turnkey experience:** native 2FA works out of the box — no external
+  dependencies, no proxy whitelisting, no header spoofing risks to manage.
+- **Complementary:** native 2FA does not conflict with external IdP setups.
+  If `PROXY_AUTH_HEADER` is configured, native 2FA is skipped (the IdP is
+  already handling MFA). Both paths can coexist.
+
+This aligns with upstream discussion in [#783](https://github.com/Mailu/Mailu/issues/783)
+and [#2222](https://github.com/Mailu/Mailu/issues/2222), where native 2FA has been
+a long-requested feature.
+
+### Webmail-level 2FA plugins (not our approach)
+
+Roundcube has a `twofactor_gauthenticator` plugin and SnappyMail has a built-in
+2FA plugin. These protect webmail access only — they do NOT protect the Admin UI
+or SSO login, creating a siloed security layer. Our approach implements 2FA at
+the SSO layer, which gates all web access (admin + webmail) through a single
+checkpoint. This is architecturally cleaner and avoids the fragmented auth
+that Mailu 1.9's SSO consolidation was designed to eliminate.
+
+---
+
+## 2. Current Auth Architecture (as-is)
+
+### 2.1 Web login (SSO)
+- **Route:** `sso/views/base.py` → `POST /sso/login`
+- **Flow:** email + password → `models.User.login()` → `flask_login.login_user()` → redirect
+- Password-change interception exists: if `user.change_pw_next_login`, session
+  stores redirect and sends user to `/sso/pw_change` first
+- Session: Redis-backed `MailuSession` with regeneration on login
+
+### 2.2 Mail protocol auth (IMAP/SMTP/POP3/Sieve)
+- **Module:** `internal/nginx.py` → `check_credentials()`
+- nginx sends HTTP auth sub-request to admin; admin validates and returns headers
+- **App Tokens** (`models.Token`): 32-char hex passwords stored with low-round PBKDF2
+  - Checked first if `is_app_token(password)` returns True
+  - Already bypass normal password flow
+  - Optional IP restriction per token
+- `AUTH_REQUIRE_TOKENS` config: when True, plain password rejected for non-web protocols
+
+### 2.3 Webmail SSO
+- Roundcube plugin reads `X-Remote-User` / `X-Remote-User-Token` headers
+- Snappymail uses `CreateUserSsoHash()` from same headers
+- Temp tokens (`token-<base64>`) stored in Redis for webmail sessions
+
+### 2.4 User model (`models.py:552`)
+- `User(Base, Email)` with `password`, `enabled`, `global_admin`, etc.
+- Password hashing: `passlib` bcrypt-sha256 with credential cache
+- Related: `Token` model for app passwords
+
+### 2.5 Dependencies (from `requirements-prod.txt`)
+- `passlib==1.7.4`, `bcrypt==4.1.3`, `cryptography==42.0.6`
+- `Flask-Login==0.6.3`, `Flask-WTF==1.2.1`, `WTForms==3.1.2`
+- No OTP/TOTP/QR libraries present
+
+---
+
+## 3. Design Decisions
+
+### 3.1 Where does 2FA apply?
+
+| Protocol / Entry Point    | 2FA Required? | Rationale                                       |
+|---------------------------|---------------|-------------------------------------------------|
+| Web SSO (`/sso/login`)    | Yes           | Primary target — browser-based, high-value      |
+| Admin UI (`/admin/*`)     | Yes (via SSO) | All admin routes require SSO session             |
+| Webmail (Roundcube/Snappy)| Yes (via SSO) | Webmail login redirects through SSO              |
+| IMAP / POP3               | No            | Use App Tokens; TOTP impractical for clients     |
+| SMTP / Submission         | No            | Use App Tokens; mail clients can't prompt TOTP   |
+| Sieve                     | No            | Use App Tokens                                   |
+| REST API                  | No            | Bearer token auth (separate mechanism)           |
+| Proxy Auth                | No            | External IdP handles MFA upstream                |
+
+**Key principle:** 2FA protects the *web session*. Mail clients use App Tokens
+(which are already separate credentials with optional IP restriction). When
+`AUTH_REQUIRE_TOKENS` is enabled, plain password is rejected for mail protocols,
+making App Tokens the only path — and those bypass 2FA by design.
+
+### 3.2 TOTP algorithm
+- Standard: RFC 6238 (TOTP), RFC 4226 (HOTP base)
+- Library: `pyotp` (lightweight, well-maintained, MIT licensed)
+- QR code: `qrcode[pil]` or `segno` (for provisioning URI → QR image)
+- Parameters: SHA-1, 6 digits, 30-second period (Google Authenticator defaults)
+- Clock skew tolerance: 1 step (±30s)
+
+### 3.3 Backup / recovery codes
+- 10 single-use codes generated at setup time
+- Stored hashed (low-round PBKDF2, same pattern as App Tokens)
+- Displayed once at setup; user must save them
+- Each code can only be used once; consumed codes are deleted
+- Admin (global_admin or domain_admin) can reset a user's 2FA
+
+### 3.4 Enforcement model
+- **Per-user opt-in** (default): each user chooses to enable 2FA via settings
+- **Domain-level enforcement** (future/optional): domain admin can require 2FA
+  for all users in their domain — similar to `change_pw_next_login` pattern
+- **Global enforcement** (future/optional): config flag `REQUIRE_2FA=true`
+
+Phase 1 implements per-user opt-in only.
+
+### 3.5 Admin override
+- Global admins and domain admins can disable/reset 2FA for users they manage
+- Shown on user edit page (`/admin/user/edit/<email>`)
+- Logged for audit
+
+---
+
+## 4. Database Changes
+
+### 4.1 New columns on `user` table
+
+```python
+# models.py — User class additions
+totp_secret    = db.Column(db.String(255), nullable=True, default=None)
+totp_enabled   = db.Column(db.Boolean, nullable=False, default=False)
+```
+
+- `totp_secret`: Fernet-encrypted base32 shared secret (~120 chars, None = not enrolled).
+  Accessed via `User.get_totp_secret()` / `User.set_totp_secret()` which
+  handle encrypt/decrypt using a key derived from `SECRET_KEY`.
+- `totp_enabled`: True only after user confirms setup with a valid code
+
+### 4.2 New table: `backup_code`
+
+```python
+class BackupCode(Base):
+    __tablename__ = 'backup_code'
+
+    id         = db.Column(db.Integer, primary_key=True)
+    user_email = db.Column(db.String(255), db.ForeignKey('user.email'), nullable=False)
+    user       = db.relationship(User, backref=db.backref('backup_codes', cascade='all, delete-orphan'))
+    code_hash  = db.Column(db.String(255), nullable=False)
+```
+
+- 10 codes generated at setup
+- Each is 8 alphanumeric chars (e.g. `a3f7-k9m2`)
+- Hashed with `pbkdf2_sha256.using(rounds=1)` (same as Token — high entropy, not bruteforceable)
+- Row deleted after successful use
+
+### 4.3 Migration
+- Alembic migration via `flask db migrate`
+- Must use `batch_alter_table` for SQLite compatibility (per contributor docs)
+- Single migration file: adds `totp_secret` + `totp_enabled` columns, creates `backup_code` table
+
+---
+
+## 5. Implementation Plan — Phases
+
+### Phase 0: Dependencies & Branch Setup
+- [ ] Create branch `feat-2fa-totp` from `master`
+- [ ] Add `pyotp` and `segno` (or `qrcode`) to `requirements-prod.txt`
+- [ ] Rebuild base image to verify clean install
+- [ ] Add towncrier fragment: `towncrier/newsfragments/XXXX.feature`
+
+### Phase 1: Model & Migration
+- [ ] Add `totp_secret`, `totp_enabled` to `User` model
+- [ ] Create `BackupCode` model
+- [ ] Generate Alembic migration (batch ops for SQLite)
+- [ ] Test migration up/down locally
+
+### Phase 2: TOTP Setup UI (User Settings)
+- [ ] New route: `GET/POST /user/2fa` (in `ui/views/users.py`)
+- [ ] Access: `@access.owner` (same as user_settings)
+- [ ] **Setup flow:**
+  1. Generate secret → store in session (not DB yet)
+  2. Render QR code (provisioning URI) + manual key display
+  3. User enters 6-digit code to confirm
+  4. On valid code: save `totp_secret` to DB, set `totp_enabled=True`
+  5. Generate and display 10 backup codes (one-time view)
+- [ ] **Disable flow:**
+  1. User confirms with current password + TOTP code
+  2. Clear `totp_secret`, set `totp_enabled=False`, delete backup codes
+- [ ] **Regenerate backup codes:**
+  1. Confirm with password + TOTP code
+  2. Delete old codes, generate new set, display once
+- [ ] Form: `UserTOTPSetupForm` in `ui/forms.py`
+- [ ] Templates: `user/2fa_setup.html`, `user/2fa_backup_codes.html`
+- [ ] i18n: wrap all strings with `_()` / `{% trans %}`
+
+### Phase 3: Login Flow Modification
+- [ ] Modify `sso/views/base.py` → `login()`:
+  - After successful `User.login()`, check `user.totp_enabled`
+  - If True: do NOT call `flask_login.login_user()` yet
+  - Store `user.email` and `destination` in session as `pending_2fa_user`
+  - Redirect to new route `/sso/2fa`
+- [ ] New route: `GET/POST /sso/2fa`
+  - Render TOTP input form (6-digit code + "Use backup code" link)
+  - Validate code via `pyotp.TOTP(user.totp_secret).verify(code, valid_window=1)`
+  - If backup code: check against `BackupCode` table, delete on success
+  - On success: complete login (`flask_login.login_user()`, session regeneration, rate-limit cookie)
+  - On failure: flash error, increment rate limiter
+  - Timeout: if session `pending_2fa_user` is stale (>5 min), redirect to login
+- [ ] New form: `TOTPVerifyForm` in `sso/forms.py`
+- [ ] New template: `sso/templates/2fa_verify.html`
+
+### Phase 4: Admin Controls
+- [ ] User edit page (`/admin/user/edit/<email>`):
+  - Show 2FA status (enabled/disabled)
+  - "Reset 2FA" button (domain_admin or global_admin only)
+  - Logs the reset action
+- [ ] Optional: user list shows 2FA status icon/badge
+
+### Phase 5: Testing
+- [ ] Unit tests for TOTP verification logic
+- [ ] Unit tests for backup code generation, hashing, consumption
+- [ ] Integration test: full login flow with 2FA
+- [ ] Integration test: app token bypasses 2FA for IMAP
+- [ ] Integration test: admin reset flow
+- [ ] Test with SQLite, PostgreSQL, MariaDB (migration compatibility)
+
+### Phase 6: Documentation & i18n
+- [ ] Extract Babel strings: `pybabel extract` / `pybabel update`
+- [ ] Update `docs/configuration.rst` if any new env vars added
+- [ ] Update `docs/webadministration.rst` with 2FA user guide
+- [ ] Towncrier fragment for changelog
+
+---
+
+## 6. Login Flow Diagram (to-be)
+
+```
+User submits email + password
+         │
+         ▼
+  ┌─────────────┐
+  │ Rate limit   │──── exceeded ──→ Flash error, stay on login
+  │ check        │
+  └──────┬──────┘
+         │ ok
+         ▼
+  ┌─────────────┐
+  │ User.login() │──── fail ──→ Flash "wrong email/password"
+  │ (password)   │
+  └──────┬──────┘
+         │ success
+         ▼
+  ┌─────────────────┐
+  │ user.totp_enabled│
+  │ == True ?        │
+  └──┬──────────┬───┘
+     │ no       │ yes
+     ▼          ▼
+  Complete   Store pending_2fa_user
+  login      in session, redirect
+  (as today) to /sso/2fa
+                │
+                ▼
+         ┌─────────────┐
+         │ User enters  │
+         │ 6-digit code │
+         │ or backup    │
+         └──────┬──────┘
+                │
+         ┌──────┴──────┐
+         │ Valid?       │
+         └──┬──────┬───┘
+            │ no   │ yes
+            ▼      ▼
+         Flash   Complete login
+         error   (flask_login.login_user)
+         (retry  → redirect to destination
+         or back
+         to login)
+```
+
+---
+
+## 7. Security Considerations
+
+1. **Secret storage:** `totp_secret` is a shared secret that must be readable to
+   verify codes (unlike passwords, it cannot be one-way hashed). Two options:
+
+   - **Option A — Plaintext in DB:** standard practice in most implementations
+     (Django-OTP, Authelia, many others). Relies on DB-level encryption at rest.
+     Simpler, fewer moving parts, no key management.
+
+   - **Option B — Application-level encryption (recommended):** encrypt the
+     secret using `cryptography.fernet.Fernet` with a key derived from Mailu's
+     `SECRET_KEY` config. The secret is decrypted in-memory only when verifying
+     a TOTP code. This provides defense-in-depth: a DB dump alone does not
+     expose TOTP secrets. The `cryptography` library is already a dependency.
+
+   **Decision:** Option B. The `cryptography` package is already in
+   `requirements-prod.txt`, so there is no new dependency. The `totp_secret`
+   column stores the Fernet-encrypted blob (base64, ~120 chars). Helper methods
+   `User.get_totp_secret()` and `User.set_totp_secret(secret)` handle
+   encrypt/decrypt transparently. If `SECRET_KEY` is rotated, a migration
+   helper re-encrypts all secrets.
+
+2. **QR code:** generated server-side, never stored; rendered inline as base64
+   data URI or served from a one-time endpoint.
+
+3. **Session hijacking:** `pending_2fa_user` session key expires after 5 minutes.
+   Session ID is regenerated after full login completes.
+
+4. **Brute force:** rate limiter already applies to login. The 2FA step reuses
+   the same rate-limit counters. 6-digit TOTP with 1-step window = 3 valid
+   codes at any time (999,997 invalid) — combined with rate limiting, brute
+   force is infeasible.
+
+5. **Backup codes:** single-use, hashed. 10 codes of 8 alphanumeric chars
+   (~41 bits entropy each). Sufficient for recovery, not for daily use.
+
+6. **App Tokens:** explicitly bypass 2FA. This is by design — they are
+   long random credentials with optional IP binding. The existing
+   `AUTH_REQUIRE_TOKENS` config already forces users to create tokens for
+   mail clients, which is the recommended setup when 2FA is enabled.
+
+7. **Admin reset:** domain/global admins can disable a user's 2FA. This is
+   necessary for account recovery when backup codes are lost. The action
+   is logged.
+
+---
+
+## 8. Files to Modify / Create
+
+### Modified files
+| File | Change |
+|------|--------|
+| `core/admin/mailu/models.py` | Add `totp_secret`, `totp_enabled` to User; add `BackupCode` model |
+| `core/admin/mailu/sso/views/base.py` | 2FA challenge after password success |
+| `core/admin/mailu/sso/forms.py` | Add `TOTPVerifyForm` |
+| `core/admin/mailu/ui/views/users.py` | Add `user_2fa_setup`, admin reset route |
+| `core/admin/mailu/ui/forms.py` | Add `UserTOTPSetupForm` |
+| `core/admin/mailu/ui/templates/user/settings.html` | Link to 2FA setup page |
+| `core/admin/mailu/ui/templates/user/edit.html` | Show 2FA status + reset button |
+| `core/base/requirements-prod.txt` | Add `pyotp`, `segno` |
+
+### New files
+| File | Purpose |
+|------|---------|
+| `core/admin/migrations/versions/<hash>_add_totp_2fa.py` | Alembic migration |
+| `core/admin/mailu/sso/templates/2fa_verify.html` | TOTP code input page |
+| `core/admin/mailu/ui/templates/user/2fa_setup.html` | QR code + setup form |
+| `core/admin/mailu/ui/templates/user/2fa_backup_codes.html` | One-time backup code display |
+| `towncrier/newsfragments/XXXX.feature` | Changelog entry |
+
+### Not modified
+| File | Reason |
+|------|--------|
+| `core/admin/mailu/internal/nginx.py` | No changes — App Tokens already bypass password auth; 2FA is session-level only |
+| `webmails/roundcube/login/mailu.php` | No changes — webmail auth goes through SSO session |
+| `webmails/snappymail/login/sso.php` | No changes — same reason |
+| `core/nginx/*` | No changes — nginx proxies auth to admin, protocol unchanged |
+
+---
+
+## 9. Contributor Compliance Checklist
+
+Per `docs/contributors/`:
+
+- [ ] PEP-8 compliant, pylint clean
+- [ ] Database models use generic types (no DB-specific config)
+- [ ] Migration uses `batch_alter_table` for SQLite compatibility
+- [ ] All user-facing strings wrapped with `_()` / `{% trans %}`
+- [ ] Babel extraction run before PR (`pybabel extract` / `pybabel update`)
+- [ ] Dependency upgrade tested as separate PR first (if major)
+- [ ] Towncrier fragment added
+- [ ] PR against `master` branch
+- [ ] Tested with `docker buildx bake` + `docker compose up`
+
+---
+
+## 10. Open Questions
+
+1. **QR code library choice:** `segno` (pure Python, no PIL dependency, SVG output)
+   vs `qrcode[pil]` (more common, needs Pillow). Leaning toward `segno` for
+   smaller image size and no binary dependency.
+
+2. **Domain-level enforcement:** should Phase 1 include a `require_2fa` flag on
+   the Domain model, or defer to a follow-up? **Recommendation:** defer — keep
+   Phase 1 as user opt-in only.
+
+3. **API 2FA:** the REST API uses a single shared bearer token, not per-user auth.
+   No 2FA needed there. But if per-user API auth is added later, 2FA should
+   apply. Note for future.
+
+4. **Proxy auth:** when `PROXY_AUTH_HEADER` is used, the external IdP is
+   responsible for MFA. Mailu should skip its own 2FA check for proxy-authenticated
+   sessions. Current design handles this (proxy auth calls `_proxy()` which
+   doesn't go through the password flow).
+
+5. **TOTP secret encryption key rotation:** if `SECRET_KEY` changes, all
+   Fernet-encrypted `totp_secret` values become unreadable. Need a CLI command
+   (`flask mailu reencrypt-totp --old-key <key>`) or document that changing
+   `SECRET_KEY` requires users to re-enroll 2FA. **Recommendation:** document
+   the constraint for Phase 1; add re-encryption CLI in a follow-up if needed.
+
+---
+
+## 11. Future Phases (beyond this implementation)
+
+### 11.1 WebAuthn / FIDO2 (phishing-resistant 2FA)
+
+TOTP is vulnerable to real-time phishing (attacker proxies the code to the
+legitimate server). WebAuthn uses public-key cryptography tied to the specific
+domain, making phishing mathematically impossible. This is the gold standard
+for high-security environments.
+
+**What it would require:**
+- New dependency: `py_webauthn` or `fido2` (Python WebAuthn library)
+- New DB table: `webauthn_credential` (credential ID, public key, sign count, user)
+- Registration flow: browser `navigator.credentials.create()` → server stores public key
+- Login flow: browser `navigator.credentials.get()` → server verifies signature
+- UI changes: JavaScript for WebAuthn API calls in login and setup pages
+- Users could register multiple keys (primary + backup hardware key)
+
+**When:** after native TOTP is stable and adopted. WebAuthn can coexist with
+TOTP as an alternative second factor (user chooses which to use at login).
+
+### 11.2 XOAUTH2 / OIDC (protocol-level 2FA)
+
+The fundamental limitation today is that IMAP/SMTP can't do interactive 2FA.
+XOAUTH2 (SASL OAuth 2.0) solves this by allowing mail clients to trigger a
+browser-based login flow, where the user completes MFA in the browser and the
+client receives an OAuth token.
+
+A fork already exists: [heviat/Mailu-OIDC](https://github.com/heviat/Mailu-OIDC)
+(also tracked in upstream [#2575](https://github.com/Mailu/Mailu/issues/2575)).
+
+**What it would require:**
+- Mailu acting as an OIDC provider (or consuming an external OIDC provider)
+- Dovecot and Postfix configured for XOAUTH2 SASL mechanism
+- Token refresh flow for long-lived mail client sessions
+- Significant complexity — this is a major architectural change
+
+**When:** this is a longer-term goal. Native TOTP + App Tokens is the pragmatic
+solution for now. XOAUTH2 would eventually make App Tokens unnecessary.
+
+### 11.3 Domain-level and global enforcement
+
+Phase 1 is per-user opt-in. Future phases could add:
+- `Domain.require_2fa` (Boolean) — domain admin forces all users to enroll
+- `REQUIRE_2FA` env var — global enforcement for all users
+- Grace period: users get N days to set up 2FA before being locked to the
+  setup page (similar to `change_pw_next_login` pattern)
+
+### 11.4 Trusted devices / "Remember this browser"
+
+After completing 2FA, the user could opt to trust the device for N days
+(stored as a signed cookie). This reduces friction for daily webmail use
+while maintaining security for new devices/locations. Common in Gmail,
+GitHub, etc.

--- a/docs/webadministration.rst
+++ b/docs/webadministration.rst
@@ -19,6 +19,8 @@ It offers the following configuration options:
 
 * configure application passwords.
 
+* configure two-factor authentication (TOTP).
+
 * send broadcast messages to all users.
 
 * configure global administration users.
@@ -186,6 +188,49 @@ The comment field can be used to enter a description for the authentication toke
 
 In the Authorized IP field a comma separated list of white listed IP addresses or networks can be entered. When the field is set, the application token can only be used when the IP address of the client matches what is in the field.
 When no IP address is entered, there is no restriction on IP address.
+
+
+.. _webadministration_2fa:
+
+Two-factor authentication (2FA)
+-------------------------------
+
+On the `settings` page, users can set up two-factor authentication to add an extra layer of security to their account.
+When 2FA is enabled, after entering the correct email and password, the user is prompted for a 6-digit code from their authenticator app.
+
+Setting up 2FA
+``````````````
+
+1. Go to the Settings page and click ``Set up two-factor authentication``.
+
+2. Scan the displayed QR code with an authenticator app (Google Authenticator, Authy, Microsoft Authenticator, FreeOTP, etc.).
+   Alternatively, manually enter the displayed secret key into the authenticator app.
+
+3. Enter the 6-digit code from the authenticator app to confirm the setup.
+
+4. Save the displayed backup recovery codes in a safe place. Each backup code can only be used once and will not be shown again.
+   These codes can be used to log in if you lose access to your authenticator app.
+
+Disabling 2FA
+`````````````
+
+To disable two-factor authentication, go to Settings and click ``Manage two-factor authentication``.
+Enter your current password and a valid 6-digit code from your authenticator app to confirm.
+
+Admin 2FA reset
+```````````````
+
+Domain administrators and global administrators can reset two-factor authentication for users they manage.
+On the user edit page, the 2FA status is displayed. If 2FA is enabled, administrators can click ``Reset two-factor authentication`` to disable it for the user.
+This is intended for account recovery when the user has lost access to their authenticator app and backup codes.
+
+Mail client access with 2FA
+```````````````````````````
+
+Two-factor authentication only applies to the web login (Admin GUI and Webmail). IMAP, POP3 and SMTP mail clients cannot prompt for a TOTP code.
+For mail client access, use :ref:`Authentication tokens <AUTH tokens>` (application passwords).
+It is recommended to enable ``AUTH_REQUIRE_TOKENS`` in ``mailu.env`` to prevent the use of the main password for mail protocols.
+For more information see :ref:`the configuration reference <admin_account>`.
 
 
 Announcement

--- a/towncrier/newsfragments/783.feature
+++ b/towncrier/newsfragments/783.feature
@@ -1,0 +1,1 @@
+Add native TOTP two-factor authentication for web login (SSO/Admin), with QR code setup, backup recovery codes, and admin reset capability. Mail protocol access (IMAP/SMTP/POP3) continues to use App Tokens.


### PR DESCRIPTION
## Summary

Adds optional TOTP-based two-factor authentication to the SSO login flow, addressing the long-standing request in #783 and #2222.

- **TOTP setup** with QR code provisioning (via `pyotp` + `segno`) and manual key entry
- **10 single-use backup recovery codes** (hashed with pbkdf2_sha256, constant-time verification)
- **TOTP secrets encrypted at rest** using Fernet with key derived from `SECRET_KEY`
- **Login flow intercept**: after password success, 2FA-enabled users are redirected to `/sso/2fa` before session is created
- **Rate limiting** on 2FA endpoint reuses existing IP-based limiter
- **Admin controls**: domain/global admins can reset user 2FA from the edit page (logged for audit)
- **User list badge**: `2fa` badge shown in features column for enrolled users
- **App Tokens unchanged**: IMAP/SMTP/POP3 mail clients continue using App Tokens (bypass 2FA by design)
- **Proxy Auth unchanged**: external IdP sessions skip native 2FA (`_proxy()` path unaffected)

## Scope

| Entry point | 2FA? | Mechanism |
|---|---|---|
| Web SSO (`/sso/login`) | Yes | TOTP code after password |
| Admin UI | Yes | Via SSO session |
| Webmail | Yes | Via SSO session |
| IMAP/POP3/SMTP | No | App Tokens (existing) |
| REST API | No | Bearer token (separate) |
| Proxy Auth | No | External IdP handles MFA |

## Dependencies added

- `pyotp==2.9.0` — TOTP generation/verification (MIT, pure Python)
- `segno==1.6.6` — QR code generation (BSD, pure Python, no Pillow dependency)

## Files changed

- **Model**: `totp_secret` (Fernet-encrypted), `totp_enabled` on User; new `BackupCode` model
- **Migration**: `5b78d3e4c712` — uses `batch_alter_table` for SQLite compatibility
- **SSO**: login intercept + `/sso/2fa` verification route with rate limiting
- **UI**: setup/disable page, backup codes display, admin reset button
- **Docs**: `webadministration.rst` updated with 2FA user guide; `docs/planning/2fa-totp.md` with full design rationale
- **i18n**: all strings wrapped with `_()` / `{% trans %}`, Babel catalogs updated
- **Tests**: unit tests for TOTP verification, backup codes, Fernet encryption

## Test plan

- [x] TOTP setup flow: QR scan → verify code → backup codes displayed
- [x] Login with 2FA: password → redirect to `/sso/2fa` → enter code → session created
- [x] Backup code login: use backup code → code consumed (single-use)
- [x] Disable 2FA: password + TOTP code required to disable
- [x] Admin reset: domain admin can reset user 2FA
- [x] App Tokens bypass: IMAP/SMTP auth with app token works without 2FA
- [x] Rate limiting: failed 2FA attempts trigger IP rate limit
- [x] Session timeout: `pending_2fa_user` expires after 5 minutes
- [x] Tested on staging instance (Docker, SQLite backend)