### PR TITLE
CVE-2026-49217: Missing authentication on PATCH /api/v1/token/<id>

### DIFF
--- a/core/admin/mailu/api/v1/token.py
+++ b/core/admin/mailu/api/v1/token.py
@@ -1,5 +1,6 @@
 from flask_restx import Resource, fields, marshal
 import validators, datetime
+import ipaddress
 import flask
 from passlib import pwd
 
@@ -78,8 +79,9 @@ class Tokens(Resource):
         if 'AuthorizedIP' in data:
             token_new.ip = data['AuthorizedIP']
             for ip in token_new.ip:
-                if (not validators.ip_address.ipv4(ip,cidr=True, strict=False, host_bit=False) and
-                    not validators.ip_address.ipv6(ip,cidr=True, strict=False, host_bit=False)):
+                try:
+                    ipaddress.ip_network(ip, False)
+                except ValueError:
                     return { 'code': 400, 'message': f'Provided AuthorizedIP {ip} in {token_new.ip} is invalid'}, 400
         raw_password = pwd.genword(entropy=128, length=32, charset="hex")
         token_new.set_password(raw_password)
@@ -198,6 +200,7 @@ class Token(Resource):
     @token.doc(responses={401: 'Authorization header missing', 403: 'Invalid authorization header'})
     @token.response(404, 'User not found', response_fields)
     @token.doc(security='Bearer')
+    @common.api_token_authorization
     def patch(self, token_id):
         """ Update the specified token """
         data = api.payload
@@ -211,8 +214,9 @@ class Token(Resource):
         if 'AuthorizedIP' in data:
             token.ip = token.ip = data['AuthorizedIP']
             for ip in token.ip:
-                if (not validators.ip_address.ipv4(ip,cidr=True, strict=False, host_bit=False) and
-                    not validators.ip_address.ipv6(ip,cidr=True, strict=False, host_bit=False)):
+                try:
+                    ipaddress.ip_network(ip, False)
+                except ValueError:
                     return { 'code': 400, 'message': f'Provided AuthorizedIP {ip} in {token.ip} is invalid'}, 400
         models.db.session.add(token)
         #apply the changes

--- a/towncrier/newsfragments/4030.misc
+++ b/towncrier/newsfragments/4030.misc
@@ -1,0 +1,1 @@
+Upgrade roundcube to 1.6.16 and carddav to 5.1.3

--- a/towncrier/newsfragments/4032.bugfix
+++ b/towncrier/newsfragments/4032.bugfix
@@ -1,0 +1,1 @@
+CVE-2026-49217: Missing authentication on PATCH /api/v1/token/<id>. Thanks to Geo (https://github.com/geo-chen) for reporting it!

--- a/webmails/Dockerfile
+++ b/webmails/Dockerfile
@@ -28,8 +28,8 @@ RUN set -euxo pipefail \
   ; mkdir -p /run/nginx /conf
 
 # roundcube
-ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.15/roundcubemail-1.6.15-complete.tar.gz
-ENV CARDDAV_URL https://github.com/mstilkerich/rcmcarddav/releases/download/v5.1.2/carddav-v5.1.2.tar.gz
+ENV ROUNDCUBE_URL https://github.com/roundcube/roundcubemail/releases/download/1.6.16/roundcubemail-1.6.16-complete.tar.gz
+ENV CARDDAV_URL https://github.com/mstilkerich/rcmcarddav/releases/download/v5.1.3/carddav-v5.1.3.tar.gz
 
 RUN set -euxo pipefail \
   ; cd /var/www \


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

- fix CVE-2026-49217 (Missing authentication on PATCH /api/v1/token/<id>). Thanks to Geo (https://github.com/geo-chen) for reporting it!
- upgrade roundcube to 1.6.16 and carddav to 5.1.3

### Related issue(s)
- closes #4030 
- closes #4031 

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
