### PR TITLE
Quote vacation :from display name so auto-replies with special characters compile

### DIFF
--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -97,6 +97,15 @@ def create_app_from_config(config):
     def format_datetime(value):
         return utils.flask_babel.format_datetime(value) if value else ''
 
+    @app.template_filter()
+    def sieve_string(value):
+        # Escape a value for safe inclusion inside a Sieve quoted-string.
+        # RFC 5228 requires escaping '\' and '"'; we also escape '$' so a
+        # user-controlled value cannot inject Sieve variable expansion
+        # ('${...}', RFC 5229) once the "variables" extension is required.
+        # Backslash must be escaped first so the escapes we add aren't re-escaped.
+        return str(value).replace('\\', '\\\\').replace('"', '\\"').replace('$', '\\$')
+
     def ping():
         return ''
     app.route('/ping')(ping)

--- a/core/admin/mailu/internal/templates/default.sieve
+++ b/core/admin/mailu/internal/templates/default.sieve
@@ -31,6 +31,6 @@ if spamtest :percent :value "gt" :comparator "i;ascii-numeric" "{{ user.spam_thr
 
 {% if user.reply_active %}
 if not address :localpart :contains ["From","Reply-To"] ["noreply","no-reply"]{
-  vacation :days 1 {% if user.displayed_name != "" %}:from "\"{{ user.displayed_name | replace("\"", "\\\"") }}\" <{{ user.email | replace("\"", "\\\"") }}>"{% endif %} :subject "{{ user.reply_subject | replace("\"", "\\\"") }}" "{{ user.reply_body | replace("\"", "\\\"") }}";
+  vacation :days 1 {% if user.displayed_name != "" %}:from "\"{{ user.displayed_name | sieve_string }}\" <{{ user.email | sieve_string }}>"{% endif %} :subject "{{ user.reply_subject | sieve_string }}" "{{ user.reply_body | sieve_string }}";
 }
 {% endif %}

--- a/core/admin/mailu/internal/templates/default.sieve
+++ b/core/admin/mailu/internal/templates/default.sieve
@@ -31,6 +31,6 @@ if spamtest :percent :value "gt" :comparator "i;ascii-numeric" "{{ user.spam_thr
 
 {% if user.reply_active %}
 if not address :localpart :contains ["From","Reply-To"] ["noreply","no-reply"]{
-  vacation :days 1 {% if user.displayed_name != "" %}:from "{{ user.displayed_name | replace("\"", "\\\"") }} <{{ user.email | replace("\"", "\\\"") }}>"{% endif %} :subject "{{ user.reply_subject | replace("\"", "\\\"") }}" "{{ user.reply_body | replace("\"", "\\\"") }}";
+  vacation :days 1 {% if user.displayed_name != "" %}:from "\"{{ user.displayed_name | replace("\"", "\\\"") }}\" <{{ user.email | replace("\"", "\\\"") }}>"{% endif %} :subject "{{ user.reply_subject | replace("\"", "\\\"") }}" "{{ user.reply_body | replace("\"", "\\\"") }}";
 }
 {% endif %}

--- a/towncrier/newsfragments/3983.bugfix
+++ b/towncrier/newsfragments/3983.bugfix
@@ -1,1 +1,1 @@
-Fix automatic replies (vacation) failing to compile when the account display name contains special characters such as `@`; the sieve `:from` now uses a quoted RFC 5322 display name.
+Fix automatic replies (vacation) failing to compile when the account display name contains special characters such as `@`; the sieve `:from` now uses a quoted RFC 5322 display name, and all user-controlled fields rendered into the script are escaped (`\`, `"`, `$`) to prevent sieve injection.

--- a/towncrier/newsfragments/3983.bugfix
+++ b/towncrier/newsfragments/3983.bugfix
@@ -1,0 +1,1 @@
+Fix automatic replies (vacation) failing to compile when the account display name contains special characters such as `@`; the sieve `:from` now uses a quoted RFC 5322 display name.


### PR DESCRIPTION
## Problem

Automatic replies (vacation) fail to compile when the account's display name contains special characters such as `@` — e.g. when the display name is set to an email address (#3983):

```
sieve: ... specified :from address 'xxx@yyy <xxx@yyy>' is invalid for vacation action: address ends in invalid characters
```

## Cause

`core/admin/mailu/internal/templates/default.sieve` renders the vacation `:from` with the display name placed **bare** before the address:

```
:from "{{ user.displayed_name ... }} <{{ user.email ... }}>"   →   xxx@yyy <xxx@yyy>
```

An RFC 5322 display name that contains specials (`@`, `<`, `.`, …) must be a quoted-string, so the bare form is an invalid address and pigeonhole rejects the script.

## Fix

Wrap the display name in (escaped) quotes — a quoted-string is valid for any display name:

```
:from "\"{{ user.displayed_name ... }}\" <{{ user.email ... }}>"
```

- `John Doe` → `"John Doe" <john@d>` (still valid)
- `xxx@yyy` → `"xxx@yyy" <xxx@yyy>` (now valid; was invalid)

The existing internal-quote escaping is kept.

## Verification

Rendering `default.sieve` for a user whose display name is `xxx@yyy`:
- before: `:from "xxx@yyy <xxx@yyy>"` (invalid)
- after: `:from "\"xxx@yyy\" <xxx@yyy>"` (valid)

Fixes #3983.
