### PR TITLE
fix: preserve recipient-delimiter detail when resolving explicit aliases (#2988)

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -506,6 +506,14 @@ class Email(object):
             domain_name = alternative.domain_name
         return (localpart, domain_name)
 
+    @staticmethod
+    def _append_detail(address, detail):
+        """ insert a recipient-delimiter detail into an address localpart """
+        if not detail or '@' not in address:
+            return address
+        localpart, domain_name = address.rsplit('@', 1)
+        return f'{localpart}{detail}@{domain_name}'
+
     @classmethod
     def resolve_destination(cls, localpart, domain_name, ignore_forward_keep=False):
         """ return destination for email address localpart@domain_name """
@@ -543,7 +551,13 @@ class Email(object):
                 return pure_alias.destination
 
         if stripped_alias := Alias.resolve(localpart_stripped, domain_name):
-            return stripped_alias.destination
+            if stripped_alias.wildcard:
+                return stripped_alias.destination
+            # Re-attach the recipient delimiter detail (e.g. '+tag') that was
+            # stripped for the lookup, so it is not lost for the recipient. This
+            # mirrors postfix' propagate_unmatched_extensions for explicit aliases.
+            detail = localpart[len(localpart_stripped):]
+            return [cls._append_detail(dst, detail) for dst in stripped_alias.destination]
 
         if pure_alias:
             return pure_alias.destination

--- a/tests/anonmail/test_alias_detail.py
+++ b/tests/anonmail/test_alias_detail.py
@@ -1,0 +1,69 @@
+"""Regression tests for #2988: recipient-delimiter detail must be preserved
+when an address resolves through an explicit (non-wildcard) alias."""
+import os
+
+from mailu import models
+
+
+def _base(app):
+    os.environ['RECIPIENT_DELIMITER'] = '+'
+    models.db.session.add(models.Domain(name='example.com'))
+    user = models.User(localpart='joe', domain_name='example.com')
+    user.set_password('password')
+    models.db.session.add(user)
+    models.db.session.add(models.Alias(
+        localpart='team', domain_name='example.com',
+        destination=['joe@example.com'], wildcard=False))
+    models.db.session.commit()
+
+
+class TestAliasRecipientDelimiter:
+
+    def test_explicit_alias_preserves_detail(self, app):
+        """alias+detail must keep the +detail on the destination (the #2988 bug)."""
+        with app.app_context():
+            _base(app)
+            # sanity: plain alias and plain user unchanged
+            assert models.Email.resolve_destination('team', 'example.com') == ['joe@example.com']
+            assert models.Email.resolve_destination('joe', 'example.com') == ['joe@example.com']
+            # the fix: +detail is re-attached to the alias destination
+            assert models.Email.resolve_destination('team+test', 'example.com') == ['joe+test@example.com']
+
+    def test_user_detail_unchanged(self, app):
+        """user+detail already worked and must stay unchanged."""
+        with app.app_context():
+            _base(app)
+            assert models.Email.resolve_destination('joe+test', 'example.com') == ['joe+test@example.com']
+
+    def test_catchall_does_not_swallow_explicit_alias_detail(self, app):
+        """With a catch-all present, alias+detail must still reach the explicit
+        alias (not the catch-all), and the catch-all itself stays unchanged."""
+        with app.app_context():
+            _base(app)
+            models.db.session.add(models.Alias(
+                localpart='%', domain_name='example.com',
+                destination=['catchall@example.com'], wildcard=True))
+            models.db.session.commit()
+            # explicit alias wins over catch-all, detail preserved
+            assert models.Email.resolve_destination('team+test', 'example.com') == ['joe+test@example.com']
+            # catch-all behaviour is untouched
+            assert models.Email.resolve_destination('random', 'example.com') == ['catchall@example.com']
+            assert models.Email.resolve_destination('random+x', 'example.com') == ['catchall@example.com']
+
+    def test_multiple_destinations_each_get_detail(self, app):
+        with app.app_context():
+            os.environ['RECIPIENT_DELIMITER'] = '+'
+            models.db.session.add(models.Domain(name='example.com'))
+            models.db.session.add(models.Alias(
+                localpart='all', domain_name='example.com',
+                destination=['a@example.com', 'b@other.org'], wildcard=False))
+            models.db.session.commit()
+            assert models.Email.resolve_destination('all+sales', 'example.com') == \
+                ['a+sales@example.com', 'b+sales@other.org']
+
+    def test_postfix_endpoint_returns_detail(self, app, client):
+        with app.app_context():
+            _base(app)
+            rv = client.get('/internal/postfix/alias/team+test@example.com')
+            assert rv.status_code == 200
+            assert 'joe+test@example.com' in rv.get_json()

--- a/towncrier/newsfragments/2988.bugfix
+++ b/towncrier/newsfragments/2988.bugfix
@@ -1,0 +1,1 @@
+Preserve the recipient-delimiter detail (e.g. +tag) when delivering to an explicit alias, instead of dropping it (fixes lmtp_save_to_detail_mailbox for aliases)


### PR DESCRIPTION
Fixes #2988.

## Problem

With `lmtp_save_to_detail_mailbox`, mail to `alias+detail@domain` loses the `+detail` part when `alias` is an explicit alias. `Email.resolve_destination` strips the delimiter to find the alias, then returns the alias destination **without re-attaching the detail**. The user path (`user+detail@domain`) already preserved it; only aliases were affected.

## Why not just "remove the split"

The thread suggested dropping the delimiter split and letting Postfix `propagate_unmatched_extensions` do the rest. That regresses the catch-all case: Mailu models a catch-all as a wildcard alias, so `Alias.resolve('team+test')` already matches the wildcard — Postfix gets a hit on its first lookup and never retries the specific `team` alias. With a catch-all plus an explicit `team` alias, `team+test` then goes to the catch-all instead of `team`. The `test_catchall_does_not_swallow_explicit_alias_detail` test captures exactly this.

## Fix

Re-attach the stripped detail to the destination of an **explicit (non-wildcard)** alias — mirroring `propagate_unmatched_extensions` — and leave wildcard/catch-all resolution untouched:

- `team+test@dom` → `joe+test@dom` (was `joe@dom`)
- `random+x@dom` via catch-all → unchanged
- `user+detail@dom` → unchanged

`+15/-1` in `core/admin/mailu/models.py`, plus a `2988.bugfix` news fragment.

## Tests

`tests/anonmail/test_alias_detail.py` (5 cases): explicit-alias detail preserved, multiple destinations, catch-all not swallowing an explicit alias, user-detail unchanged, and the `/internal/postfix/alias/` endpoint. Red without the fix, green with it; the full `tests/anonmail` suite (26 tests) passes.
