### PR TITLE
Fix 500 when saving a fetch with empty folders

### DIFF
--- a/core/admin/mailu/ui/views/fetches.py
+++ b/core/admin/mailu/ui/views/fetches.py
@@ -32,8 +32,7 @@ def fetch_create(user_email):
     if form.validate_on_submit():
         fetch = models.Fetch(user=user)
         form.populate_obj(fetch)
-        if form.folders.data:
-            fetch.folders = form.folders.data.replace(' ','').split(',')
+        fetch.folders = form.folders.data.replace(' ','').split(',') if form.folders.data else []
         models.db.session.add(fetch)
         models.db.session.commit()
         flask.flash('Fetch configuration created')
@@ -54,8 +53,7 @@ def fetch_edit(fetch_id):
         if not form.password.data:
             form.password.data = fetch.password
         form.populate_obj(fetch)
-        if form.folders.data:
-            fetch.folders = form.folders.data.replace(' ','').split(',')
+        fetch.folders = form.folders.data.replace(' ','').split(',') if form.folders.data else []
         models.db.session.commit()
         flask.flash('Fetch configuration updated')
         return flask.redirect(

--- a/tests/anonmail/test_fetch_folders.py
+++ b/tests/anonmail/test_fetch_folders.py
@@ -1,0 +1,69 @@
+"""Regression tests for #4025 — saving a fetch with an empty "Folders" field.
+
+The fetch create/edit views call ``form.populate_obj(fetch)`` (which sets
+``fetch.folders`` to the raw *string* from the StringField) and only convert it
+to a list when the field is non-empty. With an empty Folders field the value
+stays as ``''``, so ``CommaSeparatedList.process_bind_param`` raises
+``TypeError('Must be a list of strings')`` on commit -> HTTP 500.
+An empty folder list is valid (POP3 ignores it; fetchmail defaults to INBOX).
+"""
+
+from mailu import models
+
+
+class TestFetchEmptyFolders:
+
+    @staticmethod
+    def _login(client, user):
+        with client.session_transaction() as sess:
+            sess['_user_id'] = user.get_id()
+            sess['_fresh'] = True
+
+    @staticmethod
+    def _make_user():
+        models.db.session.add(models.Domain(name='example.com'))
+        user = models.User(localpart='u', domain_name='example.com')
+        user.set_password('password')
+        models.db.session.add(user)
+        models.db.session.commit()
+        return user
+
+    def test_fetch_edit_with_empty_folders_does_not_500(self, app, client):
+        app.config['FETCHMAIL_ENABLED'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        with app.app_context():
+            user = self._make_user()
+            fetch = models.Fetch(user=user, protocol='pop3', host='mail.example.com',
+                                 port=110, username='remote', password='secret',
+                                 folders=['INBOX'])
+            models.db.session.add(fetch)
+            models.db.session.commit()
+            fetch_id = fetch.id
+
+            self._login(client, user)
+            prefix = app.config['WEB_ADMIN']
+            rv = client.post(
+                f'{prefix}/fetch/edit/{fetch_id}',
+                data={'protocol': 'pop3', 'host': 'mail.example.com', 'port': '110',
+                      'username': 'remote', 'password': '', 'folders': '',
+                      'submit': 'Submit'},
+            )
+            assert rv.status_code == 302, f'expected redirect, got {rv.status_code}'
+            assert models.Fetch.query.get(fetch_id).folders == []
+
+    def test_fetch_create_with_empty_folders_does_not_500(self, app, client):
+        app.config['FETCHMAIL_ENABLED'] = True
+        app.config['WTF_CSRF_ENABLED'] = False
+        with app.app_context():
+            user = self._make_user()
+            self._login(client, user)
+            prefix = app.config['WEB_ADMIN']
+            rv = client.post(
+                f'{prefix}/fetch/create/{user.email}',
+                data={'protocol': 'pop3', 'host': 'mail.example.com', 'port': '110',
+                      'username': 'remote', 'password': 'secret', 'folders': '',
+                      'submit': 'Submit'},
+            )
+            assert rv.status_code == 302, f'expected redirect, got {rv.status_code}'
+            fetch = models.Fetch.query.filter_by(username='remote').first()
+            assert fetch is not None and fetch.folders == []

--- a/towncrier/newsfragments/4025.bugfix
+++ b/towncrier/newsfragments/4025.bugfix
@@ -1,0 +1,1 @@
+Fix a 500 error when saving a fetched account with an empty list of folders


### PR DESCRIPTION
Fixes #4025.

## Problem

Saving a fetched account with an empty "Folders" field returns HTTP 500. `fetch_create` / `fetch_edit` call `form.populate_obj(fetch)`, which sets `fetch.folders` to the raw string from the StringField, and only convert it to a list inside `if form.folders.data:`. With an empty field the value stays `''`, so `CommaSeparatedList.process_bind_param` raises `TypeError: Must be a list of strings` on commit (`core/admin/mailu/models.py:90`). An empty folder list is valid — POP3 ignores it and fetchmail defaults to `INBOX`.

## Fix

Always coerce the Folders field to a list, using `[]` when empty, in both views (`core/admin/mailu/ui/views/fetches.py`):

```python
fetch.folders = form.folders.data.replace(' ','').split(',') if form.folders.data else []
```

## Tests

`tests/anonmail/test_fetch_folders.py` drives the real edit and create views over HTTP with an empty Folders field: red without the fix (`TypeError: Must be a list of strings`, matching the report), green with it (`folders == []`). The full `tests/anonmail` suite (23 tests) passes.
