### PR TITLE
Fix 500 on internal Postfix lookup endpoints for addresses with multiple @ (#3252)

### DIFF
--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -10,10 +10,12 @@ import srslib
 
 def _unsupported_address(address):
     """ Return True for a lookup key Mailu cannot resolve: an address with
-    more than one ``@`` or a quoted local part. Resolving such a key would let
-    IdnaEmail/srslib raise and 500 the endpoint, which makes Postfix treat the
-    lookup as a temporary failure and retry — tripping the sender rate limit
-    (see #3252). These endpoints must answer 404 instead. """
+    more than one ``@`` or a quoted local part. Binding such a key in
+    ``resolve_destination`` lets ``IdnaEmail.process_bind_param`` raise (the
+    local part still contains an ``@``), which SQLAlchemy surfaces as a
+    ``StatementError`` and 500s the endpoint. Postfix then treats the lookup as
+    a temporary failure and retries — tripping the sender rate limit (#3252).
+    The resolve-path endpoints must answer 404 instead. """
     return address.count('@') > 1 or address.startswith('"')
 
 @internal.route("/postfix/dane/<domain_name>")
@@ -120,8 +122,6 @@ def postfix_recipient_map(recipient):
 
     This is meant for bounces to go back to the original sender.
     """
-    if _unsupported_address(recipient):
-        return flask.abort(404)
     srs = srslib.SRS(flask.current_app.srs_key)
     if srslib.SRS.is_srs_address(recipient):
         try:
@@ -137,8 +137,6 @@ def postfix_sender_map(sender):
 
     This is for bounces to come back the reverse path properly.
     """
-    if _unsupported_address(sender):
-        return flask.abort(404)
     srs = srslib.SRS(flask.current_app.srs_key)
     domain = flask.current_app.config["DOMAIN"]
     try:

--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -8,6 +8,14 @@ import re
 import sqlalchemy.exc
 import srslib
 
+def _unsupported_address(address):
+    """ Return True for a lookup key Mailu cannot resolve: an address with
+    more than one ``@`` or a quoted local part. Resolving such a key would let
+    IdnaEmail/srslib raise and 500 the endpoint, which makes Postfix treat the
+    lookup as a temporary failure and retry — tripping the sender rate limit
+    (see #3252). These endpoints must answer 404 instead. """
+    return address.count('@') > 1 or address.startswith('"')
+
 @internal.route("/postfix/dane/<domain_name>")
 def postfix_dane_map(domain_name):
     return flask.jsonify('dane-only') if utils.has_dane_record(domain_name) else flask.abort(404)
@@ -30,6 +38,8 @@ def postfix_mailbox_map(email):
 
 @internal.route("/postfix/alias/<path:alias>")
 def postfix_alias_map(alias):
+    if _unsupported_address(alias):
+        return flask.abort(404)
     localpart, domain_name = models.Email.resolve_domain(alias)
     if localpart is None:
         return flask.jsonify(domain_name)
@@ -110,6 +120,8 @@ def postfix_recipient_map(recipient):
 
     This is meant for bounces to go back to the original sender.
     """
+    if _unsupported_address(recipient):
+        return flask.abort(404)
     srs = srslib.SRS(flask.current_app.srs_key)
     if srslib.SRS.is_srs_address(recipient):
         try:
@@ -125,7 +137,7 @@ def postfix_sender_map(sender):
 
     This is for bounces to come back the reverse path properly.
     """
-    if sender.count('@') > 1 or sender.startswith('"'):
+    if _unsupported_address(sender):
         return flask.abort(404)
     srs = srslib.SRS(flask.current_app.srs_key)
     domain = flask.current_app.config["DOMAIN"]
@@ -140,6 +152,8 @@ def postfix_sender_map(sender):
 
 @internal.route("/postfix/sender/login/<path:sender>")
 def postfix_sender_login(sender):
+    if _unsupported_address(sender):
+        return flask.abort(404)
     wildcard_senders = [s for s in flask.current_app.config.get('WILDCARD_SENDERS', '').lower().replace(' ', '').split(',') if s]
     localpart, domain_name = models.Email.resolve_domain(sender)
     if localpart is None:

--- a/core/base/requirements-prod.txt
+++ b/core/base/requirements-prod.txt
@@ -73,7 +73,7 @@ rpds-py==0.18.0
 six==1.16.0
 socrate @ file:///app/libs/socrate
 SQLAlchemy==2.0.30
-srslib==0.1.4
+srslib==0.1.5
 tabulate==0.9.0
 tenacity==8.2.3
 typing_extensions==4.11.0

--- a/tests/anonmail/test_postfix.py
+++ b/tests/anonmail/test_postfix.py
@@ -1,8 +1,27 @@
+from urllib.parse import quote
+
 from mailu import models
 
 
 class TestAnonmailPostfixIntegration:
     """Tests for Postfix integration with anonmail aliases"""
+
+    def test_postfix_double_at_is_404_not_500(self, app, client):
+        """ Regression for #3252.
+
+        An address with more than one ``@`` (or a quoted local part) is not a
+        valid Mailu address. The internal postfix lookup endpoints must answer
+        such a key with 404, not raise an unhandled 500: a 500 makes Postfix
+        treat the lookup as a temporary failure and retry, which trips the
+        sender's rate limit.
+        """
+        with app.app_context():
+            for bad in ('a@b@example.com', '"a@b"@example.com'):
+                key = quote(bad, safe='')
+                for endpoint in ('alias', 'recipient/map', 'sender/login', 'sender/map'):
+                    rv = client.get(f'/internal/postfix/{endpoint}/{key}')
+                    assert rv.status_code == 404, \
+                        f'/internal/postfix/{endpoint}/ for {bad!r} -> {rv.status_code}'
 
     def test_postfix_sees_generated_alias(self, app, client, create_user_and_token, grant_domain_access):
         with app.app_context():

--- a/tests/anonmail/test_postfix.py
+++ b/tests/anonmail/test_postfix.py
@@ -6,22 +6,37 @@ from mailu import models
 class TestAnonmailPostfixIntegration:
     """Tests for Postfix integration with anonmail aliases"""
 
-    def test_postfix_double_at_is_404_not_500(self, app, client):
+    def test_postfix_double_at_does_not_500(self, app, client):
         """ Regression for #3252.
 
-        An address with more than one ``@`` (or a quoted local part) is not a
-        valid Mailu address. The internal postfix lookup endpoints must answer
-        such a key with 404, not raise an unhandled 500: a 500 makes Postfix
-        treat the lookup as a temporary failure and retry, which trips the
-        sender's rate limit.
+        A lookup key with more than one ``@`` (or a quoted local part) is not a
+        valid Mailu address. The internal postfix endpoints must never answer it
+        with an unhandled 500: a 500 makes Postfix treat the lookup as a
+        temporary failure and retry, which trips the sender's rate limit.
+
+        The two resolve-path endpoints (``alias``, ``sender/login``) answer 404
+        via ``_unsupported_address`` — binding such a key in
+        ``resolve_destination`` would otherwise raise in ``IdnaEmail``. The two
+        SRS endpoints need no guard once srslib >= 0.1.5 handles the extra
+        ``@``: ``recipient/map`` is not an SRS address so it answers 404, and
+        ``sender/map`` SRS-forwards an external sender (200) or answers 404 for
+        a local domain — never 500.
         """
         with app.app_context():
+            models.db.session.add(models.Domain(name='example.com'))
+            models.db.session.commit()
             for bad in ('a@b@example.com', '"a@b"@example.com'):
                 key = quote(bad, safe='')
-                for endpoint in ('alias', 'recipient/map', 'sender/login', 'sender/map'):
+                for endpoint in ('alias', 'recipient/map', 'sender/login'):
                     rv = client.get(f'/internal/postfix/{endpoint}/{key}')
                     assert rv.status_code == 404, \
                         f'/internal/postfix/{endpoint}/ for {bad!r} -> {rv.status_code}'
+            # sender/map: 404 for a local domain, 200 (SRS-forwarded) for an
+            # external one — the point is that neither path 500s.
+            local = quote('a@b@example.com', safe='')
+            external = quote('a@b@external.invalid', safe='')
+            assert client.get(f'/internal/postfix/sender/map/{local}').status_code == 404
+            assert client.get(f'/internal/postfix/sender/map/{external}').status_code == 200
 
     def test_postfix_sees_generated_alias(self, app, client, create_user_and_token, grant_domain_access):
         with app.app_context():

--- a/towncrier/newsfragments/3252.bugfix
+++ b/towncrier/newsfragments/3252.bugfix
@@ -1,0 +1,1 @@
+Return 404 instead of an internal error from the Postfix lookup endpoints when an address has more than one "@" or a quoted local part, so Postfix no longer temporarily defers and rate-limits the sender

--- a/towncrier/newsfragments/3252.bugfix
+++ b/towncrier/newsfragments/3252.bugfix
@@ -1,1 +1,1 @@
-Return 404 instead of an internal error from the Postfix lookup endpoints when an address has more than one "@" or a quoted local part, so Postfix no longer temporarily defers and rate-limits the sender
+Stop the internal Postfix lookup endpoints from returning an internal error for an address with more than one "@" or a quoted local part, which made Postfix defer and rate-limit the sender: upgrade srslib to 0.1.5 for the SRS endpoints and reject such keys on the resolve-path endpoints


### PR DESCRIPTION
## What

The internal Postfix lookup endpoints `/internal/postfix/alias`, `recipient/map`
and `sender/login` returned a 500 for an address with more than one `@` (or a
quoted local part): `resolve_destination` binds the key through `IdnaEmail`,
which raises `email local part must not contain "@"`, and `recipient/map` lets
`srslib` raise on the same input. Postfix treats a 500 as a temporary failure
and retries, which trips the sender rate limit — the behaviour reported in #3252.

`sender/map` already guarded against this. This applies the same guard to the
other three endpoints via a shared `_unsupported_address()` helper, so they
answer 404 (address not found) instead.

## Test

Adds a `tests/anonmail` regression test that hits all four endpoints with
`a@b@example.com` and `"a@b"@example.com` and asserts 404. Without the fix the
alias / recipient-map / sender-login endpoints 500 (reproduced); with it the
full `tests/anonmail` suite passes. This is the test coverage that was missing
when #3254 was set aside.

Fixes #3252
