### PR TITLE
fetchmail: remove duplicate logging of fetch errors

### DIFF
--- a/optional/fetchmail/fetchmail.py
+++ b/optional/fetchmail/fetchmail.py
@@ -93,12 +93,6 @@ def run(debug):
                 # No mail is not an error
                 if not error_message.startswith("fetchmail: No mail"):
                     print(error_message)
-                user_info = "for %s at %s" % (fetch["user_email"], fetch["host"])
-                # Number of messages seen is not a error as well
-                if ("messages" in error_message and
-                        "(seen " in error_message and
-                        user_info in error_message):
-                    print(error_message)
             finally:
                 requests.post("http://{}:8080/internal/fetch/{}".format(os.environ['ADMIN_ADDRESS'],fetch['id']),
                     json=error_message.split('\n')[0]

--- a/towncrier/newsfragments/3970.misc
+++ b/towncrier/newsfragments/3970.misc
@@ -1,0 +1,1 @@
+fetchmail: remove duplicate logging of fetch errors (the "messages seen" branch re-printed output the preceding check already logged)


### PR DESCRIPTION
Closes #3970.

The error handler in `fetchmail.py` printed the fetch output twice. The "messages seen" branch reprints `error_message`, but it can only fire on output the preceding check already printed: a `fetchmail: No mail …` line (the only case the first check skips) never contains `(seen `, so the second branch was always a duplicate. Removed it along with the now-unused `user_info`.

I kept the `No mail` check (the other half of #3970): current fetchmail still emits `No mail for %s` (verified in the `fetchmail` binary shipped by `apk add fetchmail`), so dropping that suppression would log a "no mail" line on every poll of an empty mailbox.

No behavior change beyond removing the duplicate log line — the status posted back to admin (`error_message.split('\n')[0]`) is unchanged.
