### PR TITLE
Prevent a domain manager from taking over a higher-privileged account (#2685)

### DIFF
--- a/core/admin/mailu/ui/access.py
+++ b/core/admin/mailu/ui/access.py
@@ -46,6 +46,24 @@ def global_admin(args, kwargs):
     return flask_login.current_user.global_admin
 
 
+def _can_manage_user(actor, target):
+    """ Whether ``actor`` may manage the account of ``target`` (a User).
+
+    Global admins may manage anyone, and any user may manage themselves.
+    Otherwise a (domain) manager may only manage a target that does not
+    outrank them: the target must not be a global admin, and every domain the
+    target manages must also be managed by the actor. Without this, a manager
+    of a domain could reset the password of -- or mint an API token for -- a
+    global admin (or a manager of another domain) who merely owns a mailbox in
+    the managed domain, taking over that privileged account (#2685).
+    """
+    if actor.global_admin or target.email == actor.email:
+        return True
+    if target.global_admin:
+        return False
+    return set(target.get_managed_domains()) <= set(actor.get_managed_domains())
+
+
 @permissions_wrapper
 def domain_admin(args, kwargs, model, key):
     """ The view is only available to specific domain admins.
@@ -55,11 +73,19 @@ def domain_admin(args, kwargs, model, key):
     based on the query parameter named after the key. The model may
     either be Domain or an Email subclass (or any class with a
     ``domain`` attribute which stores a related Domain instance).
+
+    When the resource is a User, the manager must additionally outrank the
+    target (see ``_can_manage_user``) so a domain manager cannot take over a
+    higher-privileged account that owns a mailbox in the managed domain (#2685).
     """
     obj = model.query.get(kwargs[key])
     if obj:
         domain = obj if type(obj) is models.Domain else obj.domain
-        return domain in flask_login.current_user.get_managed_domains()
+        if domain not in flask_login.current_user.get_managed_domains():
+            return False
+        if isinstance(obj, models.User):
+            return _can_manage_user(flask_login.current_user, obj)
+        return True
 
 
 @permissions_wrapper
@@ -74,15 +100,21 @@ def owner(args, kwargs, model, key):
     If the query parameter is empty and the model is User, then
     the resource being accessed is supposed to be the current
     logged in user and access is obviously authorized.
+
+    A manager accessing someone else's resource must outrank the target user
+    (see ``_can_manage_user``), so a domain manager cannot e.g. mint an API
+    token for a global admin who owns a mailbox in the managed domain (#2685).
     """
     if kwargs[key] is None and model == models.User:
         return True
     obj = model.query.get(kwargs[key])
     if obj:
         user = obj if type(obj) is models.User else obj.user
+        if user.email == flask_login.current_user.email:
+            return True
         return (
-            user.email == flask_login.current_user.email
-            or user.domain in flask_login.current_user.get_managed_domains()
+            user.domain in flask_login.current_user.get_managed_domains()
+            and _can_manage_user(flask_login.current_user, user)
         )
 
 

--- a/tests/anonmail/test_domain_admin_privesc.py
+++ b/tests/anonmail/test_domain_admin_privesc.py
@@ -1,0 +1,111 @@
+"""Regression tests for #2685 -- a domain manager must not be able to take over
+an account that outranks them.
+
+``access.domain_admin`` (user_edit, user_password) and ``access.owner``
+(token_create) authorize purely on the *target's* domain: ``domain in
+current_user.get_managed_domains()``. With no rank check, a manager of a domain
+can reset the password of -- or mint an API token for -- a global admin (or a
+manager of another domain) who merely owns a mailbox in the managed domain,
+taking over that privileged account.
+
+These tests exercise the authorization decorators via GET (the decorator runs
+before the view body): 200 == access granted, 403 == denied. Without the fix the
+403 cases return 200.
+"""
+
+from mailu import models
+
+
+class TestDomainAdminPrivesc:
+
+    @staticmethod
+    def _login(client, user):
+        with client.session_transaction() as sess:
+            sess['_user_id'] = user.get_id()
+            sess['_fresh'] = True
+
+    @staticmethod
+    def _user(localpart, domain_name, *, global_admin=False, manages=()):
+        user = models.User(localpart=localpart, domain_name=domain_name)
+        user.set_password('password')
+        user.global_admin = global_admin
+        models.db.session.add(user)
+        models.db.session.commit()
+        for dom in manages:
+            dom.managers.append(user)
+        models.db.session.commit()
+        return user
+
+    def _setup(self):
+        example = models.Domain(name='example.com')
+        other = models.Domain(name='other.com')
+        models.db.session.add_all([example, other])
+        models.db.session.commit()
+        return {
+            'example': example,
+            'other': other,
+            # manager of example.com
+            'mgr': self._user('mgr', 'example.com', manages=[example]),
+            # global admin who happens to own a mailbox in example.com
+            'admin': self._user('admin', 'example.com', global_admin=True),
+            # plain mailbox in example.com (subordinate)
+            'plain': self._user('plain', 'example.com'),
+            # manager of another domain, but owns a mailbox in example.com
+            'othermgr': self._user('othermgr', 'example.com', manages=[other]),
+        }
+
+    def _get(self, app, client, path):
+        prefix = app.config['WEB_ADMIN']
+        return client.get(f'{prefix}{path}').status_code
+
+    # --- privesc must be denied (403) -----------------------------------
+
+    def test_manager_cannot_reset_global_admin_password(self, app, client):
+        with app.app_context():
+            u = self._setup()
+            self._login(client, u['mgr'])
+            assert self._get(app, client, '/user/password/admin@example.com') == 403
+
+    def test_manager_cannot_edit_global_admin(self, app, client):
+        with app.app_context():
+            u = self._setup()
+            self._login(client, u['mgr'])
+            assert self._get(app, client, '/user/edit/admin@example.com') == 403
+
+    def test_manager_cannot_create_token_for_global_admin(self, app, client):
+        with app.app_context():
+            u = self._setup()
+            self._login(client, u['mgr'])
+            assert self._get(app, client, '/token/create/admin@example.com') == 403
+
+    def test_manager_cannot_reset_other_domain_manager_password(self, app, client):
+        with app.app_context():
+            u = self._setup()
+            self._login(client, u['mgr'])
+            assert self._get(app, client, '/user/password/othermgr@example.com') == 403
+
+    # --- legitimate management must keep working (no regression) ---------
+
+    def test_manager_can_reset_subordinate_password(self, app, client):
+        with app.app_context():
+            u = self._setup()
+            self._login(client, u['mgr'])
+            assert self._get(app, client, '/user/password/plain@example.com') == 200
+
+    def test_manager_can_edit_subordinate(self, app, client):
+        with app.app_context():
+            u = self._setup()
+            self._login(client, u['mgr'])
+            assert self._get(app, client, '/user/edit/plain@example.com') == 200
+
+    def test_global_admin_can_reset_manager_password(self, app, client):
+        with app.app_context():
+            u = self._setup()
+            self._login(client, u['admin'])
+            assert self._get(app, client, '/user/password/mgr@example.com') == 200
+
+    def test_user_can_create_own_token(self, app, client):
+        with app.app_context():
+            u = self._setup()
+            self._login(client, u['mgr'])
+            assert self._get(app, client, '/token/create/mgr@example.com') == 200

--- a/towncrier/newsfragments/2685.bugfix
+++ b/towncrier/newsfragments/2685.bugfix
@@ -1,0 +1,1 @@
+Prevent a domain manager from resetting the password of, editing, or creating API tokens for a user that outranks them (a global admin or a manager of another domain) who merely owns a mailbox in the managed domain


### PR DESCRIPTION
## What

`access.domain_admin` (used by `user_edit`, `user_password`) and `access.owner`
(used by `token_create`) authorize purely on the **target's** domain —
`domain in current_user.get_managed_domains()` — with no rank check. So a
manager of a domain can edit, reset the password of, or mint an API token for a
**global admin** (or a **manager of another domain**) who merely owns a mailbox
in the managed domain, taking that privileged account over. Exactly as
@fastlorenzo described.

This adds a single `_can_manage_user(actor, target)` helper and calls it from
both decorators when the resource is a `User`: a non-global manager may only act
on a target that does not outrank them — the target must not be a global admin,
and every domain the target manages must also be managed by the actor. Global
admins and self-service are unaffected.

Scope note (re your comment): this gates **all** management of a higher-or-equal-rank
target (edit / password / token), not only password+token. The flip side is the
case you raised — a domain manager can then no longer flip the `disabled` bit on
a compromised global-admin (or other-domain-manager) account that lives in their
domain; that stays a global-admin action. `_can_manage_user` is the single place
to scope it, so narrowing this to only password+token (leaving edit/disable
open) is a one-line change if you prefer that trade-off.

## Test

Adds `tests/anonmail/test_domain_admin_privesc.py` (8 cases), exercising the
decorators via GET — the decorator runs before the view body, so 200 = allowed,
403 = denied:

- manager → reset / edit / create-token-for a global admin in the managed domain → **403** (was 200)
- manager → reset a manager of another domain → **403** (was 200)
- manager → reset / edit a plain subordinate → **200** (unchanged)
- global admin → reset a manager → **200**; user → create own token → **200**

Verified rot→green; the full `tests/anonmail` suite passes (31).

Fixes #2685
