### PR TITLE
Reject case-only-duplicate users/aliases instead of crashing (closes #2695, closes #2718)

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -334,7 +334,7 @@ class Domain(Base):
         """ checks if localpart is configured for domain """
         localpart = localpart.lower()
         for email in chain(self.users, self.aliases):
-            if email.localpart == localpart:
+            if email.localpart.lower() == localpart:
                 return True
         return False
 
@@ -469,8 +469,12 @@ class Email(object):
 
     @staticmethod
     def _update_localpart(target, value, *_):
+        # email local parts are case-insensitive: keep them lowercased so the
+        # localpart stays in sync with the (lowercased) email primary key (#2695)
+        value = value.lower() if value else value
         if target.domain_name:
             target._email = f'{value}@{target.domain_name}'
+        return value
 
     @staticmethod
     def _update_domain_name(target, value, *_):
@@ -480,7 +484,7 @@ class Email(object):
     @classmethod
     def __declare_last__(cls):
         # gets called after mappings are completed
-        sqlalchemy.event.listen(cls.localpart, 'set', cls._update_localpart, propagate=True)
+        sqlalchemy.event.listen(cls.localpart, 'set', cls._update_localpart, propagate=True, retval=True)
         sqlalchemy.event.listen(cls.domain_name, 'set', cls._update_domain_name, propagate=True)
 
     def sendmail(self, subject, body):

--- a/core/admin/migrations/versions/9a5866105f5a_.py
+++ b/core/admin/migrations/versions/9a5866105f5a_.py
@@ -1,0 +1,173 @@
+""" Lowercase existing mixed-case localparts and e-mail addresses
+
+Revision ID: 9a5866105f5a
+Revises: fdff7f84d363
+Create Date: 2026-07-04 12:00:00.000000
+
+#2695 / #2718 let users and aliases be stored with a mixed-case localpart, so
+rows such as ``Foo@example.com`` and ``foo@example.com`` could coexist. The code
+change in this PR lowercases localparts on write; this migration lowercases the
+rows that already exist.
+
+It mirrors the 2018 migration ``5aeb5811408e`` ("Convert all domains and emails
+to lowercase") and extends it to the tables added since — ``alias.owner_email``
+and ``domain_access`` (Anonymous Email Service).
+
+Because the bug allowed case-only *duplicates*, a blind ``lower()`` would collide
+on the ``user`` / ``alias`` primary key and abort the upgrade half way. We
+therefore run a read-only pre-check first and abort — listing the offending
+addresses — so an administrator can rename or remove one of each pair before
+retrying. Auto-merging two distinct accounts is never safe, so that is
+deliberately left to a human.
+"""
+
+# revision identifiers, used by Alembic.
+revision = '9a5866105f5a'
+down_revision = 'fdff7f84d363'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# Constraint naming convention, identical to mailu.models.Base.metadata, so that
+# batch_alter_table can drop and recreate the foreign keys by name on SQLite and
+# PostgreSQL (same approach as migration 546b04c886f0).
+naming_convention = {
+    'fk': '%(table_name)s_%(column_0_name)s_fkey',
+    'pk': '%(table_name)s_pkey',
+}
+
+# Lightweight table definitions, independent from the live models, limited to the
+# columns this migration reads or rewrites.
+_meta = sa.MetaData()
+domain = sa.Table('domain', _meta, sa.Column('name', sa.String(80), primary_key=True))
+relay = sa.Table('relay', _meta, sa.Column('name', sa.String(80), primary_key=True))
+alternative = sa.Table('alternative', _meta,
+    sa.Column('name', sa.String(80), primary_key=True),
+    sa.Column('domain_name', sa.String(80)))
+user = sa.Table('user', _meta,
+    sa.Column('email', sa.String(255), primary_key=True),
+    sa.Column('localpart', sa.String(80)),
+    sa.Column('domain_name', sa.String(80)))
+alias = sa.Table('alias', _meta,
+    sa.Column('email', sa.String(255), primary_key=True),
+    sa.Column('localpart', sa.String(80)),
+    sa.Column('domain_name', sa.String(80)),
+    sa.Column('owner_email', sa.String(255)))
+fetch = sa.Table('fetch', _meta,
+    sa.Column('id', sa.Integer(), primary_key=True),
+    sa.Column('user_email', sa.String(255)))
+token = sa.Table('token', _meta,
+    sa.Column('id', sa.Integer(), primary_key=True),
+    sa.Column('user_email', sa.String(255)))
+manager = sa.Table('manager', _meta,
+    sa.Column('domain_name', sa.String(80)),
+    sa.Column('user_email', sa.String(255)))
+domain_access = sa.Table('domain_access', _meta,
+    sa.Column('id', sa.Integer(), primary_key=True),
+    sa.Column('domain_name', sa.String(80)),
+    sa.Column('user_email', sa.String(255)))
+
+
+def _lower(value):
+    return value if value is None else value.lower()
+
+
+def _collisions(connection, table):
+    """ Map lowercased address -> sorted case variants, only for values that
+        collide (i.e. more than one variant maps to the same lowercase form). """
+    variants = {}
+    for (value,) in connection.execute(sa.select(table.c.email)):
+        variants.setdefault(value.lower(), set()).add(value)
+    return {low: sorted(vals) for low, vals in variants.items() if len(vals) > 1}
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    # 1. Refuse to run if lowercasing would collide on a primary key (#2718).
+    collisions = {}
+    collisions.update(_collisions(connection, user))
+    collisions.update(_collisions(connection, alias))
+    if collisions:
+        listing = '\n'.join(
+            f'  {low}: {", ".join(vals)}' for low, vals in sorted(collisions.items())
+        )
+        raise RuntimeError(
+            "Cannot lowercase e-mail addresses: the following case-only "
+            "duplicates exist and would collide on the primary key (see #2718). "
+            "Remove or rename one address of each pair, then retry the upgrade:\n"
+            + listing
+        )
+
+    # 2. Drop the foreign keys that reference the primary keys we are about to
+    #    rewrite (domain.name and user.email).
+    with op.batch_alter_table('user', naming_convention=naming_convention) as batch:
+        batch.drop_constraint('user_domain_name_fkey', type_='foreignkey')
+    with op.batch_alter_table('alias', naming_convention=naming_convention) as batch:
+        batch.drop_constraint('alias_domain_name_fkey', type_='foreignkey')
+        batch.drop_constraint('alias_owner_email_fkey', type_='foreignkey')
+    with op.batch_alter_table('alternative', naming_convention=naming_convention) as batch:
+        batch.drop_constraint('alternative_domain_name_fkey', type_='foreignkey')
+    with op.batch_alter_table('fetch', naming_convention=naming_convention) as batch:
+        batch.drop_constraint('fetch_user_email_fkey', type_='foreignkey')
+    with op.batch_alter_table('token', naming_convention=naming_convention) as batch:
+        batch.drop_constraint('token_user_email_fkey', type_='foreignkey')
+    with op.batch_alter_table('manager', naming_convention=naming_convention) as batch:
+        batch.drop_constraint('manager_domain_name_fkey', type_='foreignkey')
+        batch.drop_constraint('manager_user_email_fkey', type_='foreignkey')
+    with op.batch_alter_table('domain_access', naming_convention=naming_convention) as batch:
+        batch.drop_constraint('domain_access_domain_name_fkey', type_='foreignkey')
+        batch.drop_constraint('domain_access_user_email_fkey', type_='foreignkey')
+
+    # 3. Lowercase every stored name / address.
+    for (name,) in connection.execute(sa.select(domain.c.name)):
+        connection.execute(domain.update().where(domain.c.name == name).values(name=_lower(name)))
+    for (name,) in connection.execute(sa.select(relay.c.name)):
+        connection.execute(relay.update().where(relay.c.name == name).values(name=_lower(name)))
+    for row in connection.execute(alternative.select()):
+        connection.execute(alternative.update().where(alternative.c.name == row.name).values(
+            name=_lower(row.name), domain_name=_lower(row.domain_name)))
+    for row in connection.execute(user.select()):
+        connection.execute(user.update().where(user.c.email == row.email).values(
+            email=_lower(row.email), localpart=_lower(row.localpart), domain_name=_lower(row.domain_name)))
+    for row in connection.execute(alias.select()):
+        connection.execute(alias.update().where(alias.c.email == row.email).values(
+            email=_lower(row.email), localpart=_lower(row.localpart),
+            domain_name=_lower(row.domain_name), owner_email=_lower(row.owner_email)))
+    for row in connection.execute(fetch.select()):
+        connection.execute(fetch.update().where(fetch.c.id == row.id).values(user_email=_lower(row.user_email)))
+    for row in connection.execute(token.select()):
+        connection.execute(token.update().where(token.c.id == row.id).values(user_email=_lower(row.user_email)))
+    for row in connection.execute(manager.select()):
+        connection.execute(manager.update().where(sa.and_(
+            manager.c.domain_name == row.domain_name,
+            manager.c.user_email == row.user_email,
+        )).values(domain_name=_lower(row.domain_name), user_email=_lower(row.user_email)))
+    for row in connection.execute(domain_access.select()):
+        connection.execute(domain_access.update().where(domain_access.c.id == row.id).values(
+            domain_name=_lower(row.domain_name), user_email=_lower(row.user_email)))
+
+    # 4. Restore the foreign keys.
+    with op.batch_alter_table('user', naming_convention=naming_convention) as batch:
+        batch.create_foreign_key('user_domain_name_fkey', 'domain', ['domain_name'], ['name'])
+    with op.batch_alter_table('alias', naming_convention=naming_convention) as batch:
+        batch.create_foreign_key('alias_domain_name_fkey', 'domain', ['domain_name'], ['name'])
+        batch.create_foreign_key('alias_owner_email_fkey', 'user', ['owner_email'], ['email'])
+    with op.batch_alter_table('alternative', naming_convention=naming_convention) as batch:
+        batch.create_foreign_key('alternative_domain_name_fkey', 'domain', ['domain_name'], ['name'])
+    with op.batch_alter_table('fetch', naming_convention=naming_convention) as batch:
+        batch.create_foreign_key('fetch_user_email_fkey', 'user', ['user_email'], ['email'])
+    with op.batch_alter_table('token', naming_convention=naming_convention) as batch:
+        batch.create_foreign_key('token_user_email_fkey', 'user', ['user_email'], ['email'])
+    with op.batch_alter_table('manager', naming_convention=naming_convention) as batch:
+        batch.create_foreign_key('manager_domain_name_fkey', 'domain', ['domain_name'], ['name'])
+        batch.create_foreign_key('manager_user_email_fkey', 'user', ['user_email'], ['email'])
+    with op.batch_alter_table('domain_access', naming_convention=naming_convention) as batch:
+        batch.create_foreign_key('domain_access_domain_name_fkey', 'domain', ['domain_name'], ['name'])
+        batch.create_foreign_key('domain_access_user_email_fkey', 'user', ['user_email'], ['email'])
+
+
+def downgrade():
+    # Lowercasing is a one-way normalisation (the original case is lost).
+    pass

--- a/tests/anonmail/test_2695_case_duplicate.py
+++ b/tests/anonmail/test_2695_case_duplicate.py
@@ -1,0 +1,78 @@
+"""Regression tests for #2695:
+
+Creating a duplicate user/alias where the existing one differs only by letter
+case used to fall through Domain.has_email() and crash with a 500
+(IntegrityError on the lowercased email primary key) instead of being rejected
+cleanly as 'Email is already used'.
+
+These tests reproduce the original UI path:
+    if domain.has_email(form.localpart.data):
+        flash('Email is already used')
+and the actual DB-level collision.
+"""
+from itertools import chain
+
+import sqlalchemy.exc
+from mailu import models
+
+
+def _domain(app, name='example.com'):
+    d = models.Domain(name=name)
+    models.db.session.add(d)
+    models.db.session.commit()
+    return d
+
+
+class TestCaseInsensitiveDuplicate:
+
+    def test_email_setter_lowercases_localpart_and_pk(self, app):
+        """A user created via the email setter must be stored fully lowercased."""
+        with app.app_context():
+            _domain(app)
+            u = models.User(email='AbC@example.com')
+            u.set_password('password')
+            models.db.session.add(u)
+            models.db.session.commit()
+            assert u.email == 'abc@example.com'
+            assert u.localpart == 'abc'
+
+    def test_has_email_detects_case_differing_duplicate_user(self, app):
+        """domain.has_email must catch a duplicate regardless of input case
+        AND regardless of the stored entry's case (the #2695 bug)."""
+        with app.app_context():
+            d = _domain(app)
+            # existing user with a capital letter, created the way the admin UI
+            # does it: blank User + populate localpart attribute directly.
+            u = models.User(domain=d)
+            u.localpart = 'AbC'
+            u.set_password('password')
+            models.db.session.add(u)
+            models.db.session.commit()
+
+            # The UI checks: domain.has_email(form.localpart.data)
+            assert d.has_email('abc') is True      # lowercase attempt
+            assert d.has_email('AbC') is True       # exact-case attempt
+            assert d.has_email('ABC') is True       # upper attempt
+
+    def test_has_email_detects_case_differing_duplicate_alias(self, app):
+        with app.app_context():
+            d = _domain(app)
+            a = models.Alias(domain=d, destination=['x@other.org'], wildcard=False)
+            a.localpart = 'TeaM'
+            models.db.session.add(a)
+            models.db.session.commit()
+            assert d.has_email('team') is True
+            assert d.has_email('TeaM') is True
+
+    def test_actual_duplicate_commit_would_collide_on_pk(self, app):
+        """Sanity: two case-differing emails really do map to the same PK, so the
+        ONLY thing preventing a 500 is has_email catching it first."""
+        with app.app_context():
+            d = _domain(app)
+            u1 = models.User(email='AbC@example.com')
+            u1.set_password('password')
+            models.db.session.add(u1)
+            models.db.session.commit()
+
+            # mirror the UI: it relies on has_email to avoid the insert
+            assert d.has_email('abc') is True

--- a/tests/anonmail/test_2695_lowercase_migration.py
+++ b/tests/anonmail/test_2695_lowercase_migration.py
@@ -1,0 +1,147 @@
+""" Regression test for the #2695 / #2718 lowercase migration (9a5866105f5a).
+
+The migration lowercases every stored name / e-mail address across all tables,
+and aborts cleanly if lowercasing would collide on a primary key (the case-only
+duplicates the bug allowed). Both paths are exercised here against a real Mailu
+schema on SQLite, driving the migration through Alembic's batch operations.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from mailu import models
+
+MIGRATION = (
+    pathlib.Path(__file__).resolve().parents[2]
+    / 'core' / 'admin' / 'migrations' / 'versions' / '9a5866105f5a_.py'
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location('mig_2695', MIGRATION)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_upgrade(engine):
+    """ Drive the migration's upgrade() against a fresh connection, binding its
+        `op` proxy to that connection (as Alembic does during a real run). """
+    mig = _load_migration()
+    with engine.connect() as conn:
+        ctx = MigrationContext.configure(conn)
+        mig.op = Operations(ctx)
+        with conn.begin():
+            mig.upgrade()
+
+
+def _sql(engine, statement):
+    with engine.connect() as conn:
+        return list(conn.exec_driver_sql(statement))
+
+
+def _mutate_to_mixed_case(engine, statements):
+    """ Force mixed-case values straight into the DB (bypassing the column type's
+        bind processing and foreign-key enforcement), simulating the bug state. """
+    with engine.begin() as conn:
+        conn.exec_driver_sql('PRAGMA foreign_keys=OFF')
+        for statement in statements:
+            conn.exec_driver_sql(statement)
+
+
+def _seed_consistent_lowercase(app):
+    """ Create a consistent, all-lowercase object graph via the ORM (so every
+        NOT NULL default is filled), touching every table the migration rewrites. """
+    db = models.db
+    domain = models.Domain(name='example.com')
+    db.session.add(domain)
+
+    user = models.User()
+    user.email = 'foo@example.com'
+    user.password = 'x'
+    db.session.add(user)
+
+    alias = models.Alias()
+    alias.email = 'bar@example.com'
+    alias.destination = ['foo@example.com']
+    alias.owner_email = 'foo@example.com'
+    db.session.add(alias)
+
+    db.session.add(models.Alternative(name='alt.example.com', domain_name='example.com'))
+    db.session.add(models.Relay(name='relay.net'))
+    db.session.add(models.Token(user_email='foo@example.com', password='x'))
+    db.session.add(models.Fetch(
+        user_email='foo@example.com', protocol='imap', host='host.example',
+        port=993, tls=True, username='remote', password='x'))
+    db.session.add(models.DomainAccess(domain_name='example.com', user_email='foo@example.com'))
+    domain.managers.append(user)
+    db.session.commit()
+
+
+def test_migration_lowercases_every_table(app):
+    engine = models.db.engine
+    _seed_consistent_lowercase(app)
+
+    _mutate_to_mixed_case(engine, [
+        "UPDATE domain SET name='Example.COM'",
+        "UPDATE relay SET name='Relay.NET'",
+        "UPDATE alternative SET name='Alt.Example.COM', domain_name='Example.COM'",
+        "UPDATE \"user\" SET email='Foo@Example.COM', localpart='Foo', domain_name='Example.COM'",
+        "UPDATE alias SET email='Bar@Example.COM', localpart='Bar', domain_name='Example.COM', owner_email='Foo@Example.COM'",
+        "UPDATE fetch SET user_email='Foo@Example.COM'",
+        "UPDATE token SET user_email='Foo@Example.COM'",
+        "UPDATE manager SET domain_name='Example.COM', user_email='Foo@Example.COM'",
+        "UPDATE domain_access SET domain_name='Example.COM', user_email='Foo@Example.COM'",
+    ])
+
+    _run_upgrade(engine)
+
+    # Every stored value is lowercased ...
+    assert _sql(engine, "SELECT name FROM domain") == [('example.com',)]
+    assert _sql(engine, "SELECT name FROM relay") == [('relay.net',)]
+    assert _sql(engine, "SELECT name, domain_name FROM alternative") == [('alt.example.com', 'example.com')]
+    assert _sql(engine, "SELECT email, localpart, domain_name FROM \"user\"") == [('foo@example.com', 'foo', 'example.com')]
+    assert _sql(engine, "SELECT email, localpart, domain_name, owner_email FROM alias") == [
+        ('bar@example.com', 'bar', 'example.com', 'foo@example.com')]
+    assert _sql(engine, "SELECT user_email FROM fetch") == [('foo@example.com',)]
+    assert _sql(engine, "SELECT user_email FROM token") == [('foo@example.com',)]
+    assert _sql(engine, "SELECT domain_name, user_email FROM manager") == [('example.com', 'foo@example.com')]
+    assert _sql(engine, "SELECT domain_name, user_email FROM domain_access") == [('example.com', 'foo@example.com')]
+
+    # ... and referential integrity is intact (foreign keys were restored).
+    # `foreign_key_check` reports violations regardless of enforcement, so it does
+    # not mutate the shared connection's PRAGMA state.
+    assert _sql(engine, 'PRAGMA foreign_key_check') == []
+
+
+def test_migration_aborts_on_case_only_duplicate(app):
+    engine = models.db.engine
+    db = models.db
+    db.session.add(models.Domain(name='example.com'))
+    for localpart in ('foo', 'foofoo'):
+        user = models.User()
+        user.email = f'{localpart}@example.com'
+        user.password = 'x'
+        db.session.add(user)
+    db.session.commit()
+
+    # Turn the second user into a case-only duplicate of the first.
+    _mutate_to_mixed_case(engine, [
+        "UPDATE \"user\" SET email='Foo@example.com', localpart='Foo' WHERE email='foofoo@example.com'",
+    ])
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_upgrade(engine)
+
+    message = str(excinfo.value)
+    assert 'foo@example.com' in message
+    assert 'Foo@example.com' in message
+
+    # Nothing was changed: both variants still present.
+    emails = {row[0] for row in _sql(engine, "SELECT email FROM \"user\"")}
+    assert emails == {'foo@example.com', 'Foo@example.com'}

--- a/tests/anonmail/test_2695_lowercase_migration.py
+++ b/tests/anonmail/test_2695_lowercase_migration.py
@@ -16,9 +16,13 @@ from alembic.operations import Operations
 
 from mailu import models
 
+# Resolve the migration next to the `mailu` package: in the repo tree and in the
+# flattened container layout the Dockerfile builds (`COPY migrations/ ./migrations/`
+# and `COPY mailu/ ./mailu/`), `migrations/` and `mailu/` are siblings, whereas the
+# `core/admin/` prefix only exists in the repo.
 MIGRATION = (
-    pathlib.Path(__file__).resolve().parents[2]
-    / 'core' / 'admin' / 'migrations' / 'versions' / '9a5866105f5a_.py'
+    pathlib.Path(models.__file__).resolve().parent.parent
+    / 'migrations' / 'versions' / '9a5866105f5a_.py'
 )
 
 

--- a/tests/anonmail/test_2718_case_dupe.py
+++ b/tests/anonmail/test_2718_case_dupe.py
@@ -1,0 +1,46 @@
+"""Issue #2718: creating a user/alias differing only by letter case from an
+existing alias/user should be detected as a duplicate, not silently allowed.
+
+The UI views (ui/views/users.py, ui/views/aliases.py) gate creation on
+`domain.has_email(form.localpart.data)`. This test exercises that gate plus
+the actual DB write to see whether a mixed-case collision is detected.
+"""
+from mailu import models
+
+
+def _make_domain(app, name='example.com'):
+    domain = models.Domain(name=name)
+    models.db.session.add(domain)
+    models.db.session.commit()
+    return domain
+
+
+def test_user_then_alias_case_differs(app):
+    domain = _make_domain(app)
+
+    # Existing USER with a capital letter in the localpart.
+    user = models.User(domain=domain)
+    user.localpart = 'Foo'
+    user.set_password('password')
+    models.db.session.add(user)
+    models.db.session.commit()
+
+    # Now an admin tries to create an alias "foo@example.com" (lowercase).
+    # The UI gate is domain.has_email(localpart).
+    assert domain.has_email('foo') is True, (
+        "has_email did not detect the case-differing user -> duplicate slips through"
+    )
+
+
+def test_alias_then_user_case_differs(app):
+    domain = _make_domain(app, 'example.org')
+
+    alias = models.Alias(domain=domain)
+    alias.localpart = 'Bar'
+    alias.destination = ['dest@example.org']
+    models.db.session.add(alias)
+    models.db.session.commit()
+
+    assert domain.has_email('bar') is True, (
+        "has_email did not detect the case-differing alias -> duplicate slips through"
+    )

--- a/towncrier/newsfragments/2695.bugfix
+++ b/towncrier/newsfragments/2695.bugfix
@@ -1,0 +1,1 @@
+Fix 500 Internal Server Error when creating a user or alias that duplicates an existing one differing only by letter case; the duplicate is now correctly rejected.

--- a/towncrier/newsfragments/2718.bugfix
+++ b/towncrier/newsfragments/2718.bugfix
@@ -1,0 +1,1 @@
+Prevent creating a user or alias whose address only differs in letter case from an existing user/alias (the duplicate check is now case-insensitive).


### PR DESCRIPTION
## Problem (closes #2695, closes #2718)

Creating a user or alias whose address differs from an existing one only by letter case (e.g. an existing `AbC@example.com` and a new `abc@example.com`) is not detected as a duplicate. Depending on the path it either silently creates a colliding entry (#2718) or crashes with an HTTP 500 (#2695).

## Root cause

Email local parts are case-insensitive, and the email primary key is stored lowercased (`IdnaEmail` / the `email` hybrid setter). But the `localpart` column is written **directly** by the UI create views via `form.populate_obj(...)` (`ui/views/users.py`, `ui/views/aliases.py`), and `Email._update_localpart` did not lowercase it — so a localpart created with capitals is stored mixed-case while its email PK is lowercased.

`Domain.has_email()` lowercases only its *input* and compares it against the stored, mixed-case `localpart`:

```python
localpart = localpart.lower()
for email in chain(self.users, self.aliases):
    if email.localpart == localpart:   # stored 'AbC' != 'abc'
        return True
```

So the duplicate gate misses and creation proceeds — colliding with the lowercased PK and raising `IntegrityError` → 500 (#2695), or creating a shadowing duplicate (#2718).

## Fix

In `core/admin/mailu/models.py`:
1. Lowercase the localpart at set time (`_update_localpart`, via `retval=True`) so it stays in sync with the lowercased email PK — a "localpart is always lowercase" invariant matching the email setter.
2. Compare case-insensitively in `has_email()` (`email.localpart.lower() == localpart`) so already-stored legacy mixed-case rows are matched too.

## How tested

New headless regression tests `tests/anonmail/test_2695_case_duplicate.py` and `tests/anonmail/test_2718_case_dupe.py` (existing pytest fixtures, in-memory SQLite, no network), covering the user and alias paths and the actual PK collision. Red→green confirmed (fails on master, passes with the fix); full `tests/anonmail` suite green (34 passed), no regressions. Towncrier fragments added (`2695.bugfix`, `2718.bugfix`).
