### PR TITLE
config-import: clear configuration through the ORM to avoid FK violations (closes #2715)

### DIFF
--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -1128,9 +1128,19 @@ class MailuConfig:
 
     def clear(self, models=None):
         """ remove complete configuration """
+        # Delete via the ORM (load + session.delete) instead of a bulk
+        # query(model).delete(). Bulk deletes neither honour FK ordering nor
+        # trigger ORM cascades / many-to-many (manager) secondary cleanup, so on
+        # a FK-enforcing backend (e.g. PostgreSQL) "DELETE FROM domain" fails
+        # while users/aliases/managers still reference it (#2715). Loading the
+        # rows lets the unit-of-work emit deletes in dependency order and
+        # cascade to dependent rows. The explicit flush keeps the tables
+        # physically empty before the new configuration is loaded.
         for model in self._models:
             if models is None or model in models:
-                db.session.query(model).delete()
+                for item in model.query.all():
+                    db.session.delete(item)
+        db.session.flush()
 
     def check(self):
         """ check for duplicate domain names """

--- a/tests/anonmail/test_2715_config_import_fk.py
+++ b/tests/anonmail/test_2715_config_import_fk.py
@@ -1,0 +1,92 @@
+"""Regression test for #2715:
+
+`flask mailu config-import` (full replace, clear=True) issues bulk
+``DELETE FROM`` statements via ``MailuConfig.clear()``. Bulk deletes neither
+respect FK ordering nor trigger ORM cascades / m2m secondary cleanup, so under a
+FK-enforcing backend (PostgreSQL; SQLite with ``PRAGMA foreign_keys=ON``) the
+delete violates ``user_domain_name_fkey`` and friends.
+
+We enable SQLite FK enforcement to mimic PostgreSQL and assert that clearing the
+config does not raise an IntegrityError.
+"""
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from mailu import models
+
+
+def _set_sqlite_fk(on):
+    """Toggle FK enforcement on the current (in-memory, single) connection so
+    SQLite behaves like PostgreSQL. Turned off again before teardown's
+    drop_all() so dropping the tables is not blocked by FKs."""
+    models.db.session.execute(text(f"PRAGMA foreign_keys={'ON' if on else 'OFF'}"))
+
+
+def _seed(app):
+    """Create a domain referenced by a user, a manager (m2m) row, an alias,
+    an alternative, a token and a domain-access row -- i.e. every relationship
+    that points at domain/user."""
+    domain = models.Domain(name='example.com')
+    models.db.session.add(domain)
+    models.db.session.commit()
+
+    user = models.User(localpart='alice', domain_name='example.com')
+    user.set_password('password')
+    models.db.session.add(user)
+    models.db.session.commit()
+
+    # m2m manager association row (the 'manager' table, no ON DELETE)
+    domain.managers.append(user)
+
+    token = models.Token(user_email=user.email)
+    token.set_password('b' * 32)
+    models.db.session.add(token)
+
+    alias = models.Alias(
+        localpart='info',
+        domain_name='example.com',
+        destination=['alice@example.com'],
+    )
+    models.db.session.add(alias)
+
+    alt = models.Alternative(name='alt.example.com', domain_name='example.com')
+    models.db.session.add(alt)
+
+    da = models.DomainAccess(domain_name='example.com', user_email=user.email)
+    models.db.session.add(da)
+
+    models.db.session.commit()
+
+
+def test_config_clear_does_not_violate_fk(app):
+    with app.app_context():
+        _seed(app)
+        _set_sqlite_fk(True)
+        try:
+            config = models.MailuConfig()
+            # same model-set the import schema passes (config-import full replace)
+            model_set = {models.Domain, models.User, models.Alias, models.Relay}
+
+            try:
+                config.clear(models=model_set)
+                models.db.session.flush()
+            except IntegrityError as exc:
+                models.db.session.rollback()
+                pytest.fail(f'config clear raised FK violation (#2715): {exc.orig}')
+
+            # everything that was cleared (and its dependents) must be gone
+            assert models.Domain.query.count() == 0
+            assert models.User.query.count() == 0
+            assert models.Alias.query.count() == 0
+            assert models.Alternative.query.count() == 0
+            assert models.DomainAccess.query.count() == 0
+            assert models.Token.query.count() == 0
+            assert models.db.session.execute(
+                text('SELECT COUNT(*) FROM manager')
+            ).scalar() == 0
+        finally:
+            # let teardown's drop_all() run without FK enforcement
+            models.db.session.rollback()
+            _set_sqlite_fk(False)

--- a/towncrier/newsfragments/2715.bugfix
+++ b/towncrier/newsfragments/2715.bugfix
@@ -1,0 +1,1 @@
+Fix "flask mailu config-import" raising a foreign-key constraint violation on FK-enforcing databases (e.g. PostgreSQL) by clearing the existing configuration through the ORM so deletes are ordered and cascade to dependent rows.


### PR DESCRIPTION
## Problem (#2715)

`flask mailu config-import` fails with a foreign-key constraint violation on FK-enforcing databases (e.g. PostgreSQL) while clearing the existing configuration before loading the new one.

## Root cause

`MailuConfig.clear()` (`core/admin/mailu/models.py`) deletes each table with a bulk `query(model).delete()`. Bulk deletes bypass ORM cascades and the many-to-many `manager` secondary-row cleanup, and are not ordered by FK dependency. So `DELETE FROM domain` runs while `manager` / alias / user rows still reference it → `FOREIGN KEY constraint failed`. SQLite doesn't enforce FKs by default, which is why this surfaces on PostgreSQL.

## Fix

Clear via the ORM: load each model's rows and `session.delete()` them, then `flush()`. The unit of work emits deletes in dependency order and cascades to dependent rows. config-import is not a hot path, so the extra load is negligible.

## How tested

New `tests/anonmail/test_2715_config_import_fk.py`. **Note on the repro:** the isolated headless harness can't spin up a real PostgreSQL, so the test enables SQLite FK enforcement (`PRAGMA foreign_keys=ON`) to mimic it — this reproduces the exact `FOREIGN KEY constraint failed` reported, failing on master and passing with the fix. A quick sanity check against a real PostgreSQL instance would be welcome. Full `tests/anonmail` suite green, no regressions. Towncrier fragment `2715.bugfix` added.
