### PR TITLE
Add Domain.outgoing_only for send-only domains

### DIFF
--- a/core/admin/mailu/api/v1/domain.py
+++ b/core/admin/mailu/api/v1/domain.py
@@ -16,6 +16,7 @@ domain_fields = api.model('Domain', {
     'max_aliases': fields.Integer(description='maximum number of aliases', min=-1, default=-1),
     'max_quota_bytes': fields.Integer(description='maximum quota for mailbox', min=0),
     'signup_enabled': fields.Boolean(description='allow signup'),
+    'outgoing_only': fields.Boolean(description='domain is used only for outgoing mail; skip local delivery'),
     'alternatives': fields.List(fields.String(attribute='name', description='FQDN'), example='["example.com"]'),
 })
 
@@ -25,6 +26,7 @@ domain_fields_update = api.model('DomainUpdate', {
     'max_aliases': fields.Integer(description='maximum number of aliases', min=-1, default=-1),
     'max_quota_bytes': fields.Integer(description='maximum quota for mailbox', min=0),
     'signup_enabled': fields.Boolean(description='allow signup'),
+    'outgoing_only': fields.Boolean(description='domain is used only for outgoing mail; skip local delivery'),
     'alternatives': fields.List(fields.String(attribute='name', description='FQDN'), example='["example.com"]'),
 })
 
@@ -36,6 +38,7 @@ domain_fields_get = api.model('DomainGet', {
     'max_aliases': fields.Integer(description='maximum number of aliases', min=-1, default=-1),
     'max_quota_bytes': fields.Integer(description='maximum quota for mailbox', min=0),
     'signup_enabled': fields.Boolean(description='allow signup'),
+    'outgoing_only': fields.Boolean(description='domain is used only for outgoing mail; skip local delivery'),
     'alternatives': fields.List(fields.String(attribute='name', description='FQDN'), example='["example.com"]'),
     'dns_autoconfig': fields.List(fields.String(description='DNS client auto-configuration entry')),
     'dns_mx': fields.String(Description='MX record for domain'),
@@ -124,6 +127,8 @@ class Domains(Resource):
             domain_new.max_quota_bytes = data['max_quota_bytes']
         if 'signup_enabled' in data:
             domain_new.signup_enabled = data['signup_enabled']
+        if 'outgoing_only' in data:
+            domain_new.outgoing_only = data['outgoing_only']
         models.db.session.add(domain_new)
         #apply the changes
         db.session.commit()
@@ -189,6 +194,8 @@ class Domain(Resource):
             domain_found.max_quota_bytes = data['max_quota_bytes']
         if 'signup_enabled' in data:
             domain_found.signup_enabled = data['signup_enabled']
+        if 'outgoing_only' in data:
+            domain_found.outgoing_only = data['outgoing_only']
         models.db.session.add(domain_found)
 
         #apply the changes

--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -26,7 +26,7 @@ def postfix_dane_map(domain_name):
 def postfix_mailbox_domain(domain_name):
     if re.match(r'^\[.*\]$', domain_name):
         return flask.abort(404)
-    domain = models.Domain.query.get(domain_name) or \
+    domain = models.Domain.query.filter_by(outgoing_only=False, name=domain_name).first() or \
              models.Alternative.query.get(domain_name) or \
              flask.abort(404)
     return flask.jsonify(domain.name)

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -197,6 +197,7 @@ class Domain(Base):
     signup_enabled = db.Column(db.Boolean, nullable=False, default=False)
     # Anonymous Email Service integration: enable domain to accept API-generated aliases
     anonmail_enabled = db.Column(db.Boolean, nullable=False, default=False)
+    outgoing_only = db.Column(db.Boolean, default=False)
 
     _dkim_key = None
     _dkim_key_on_disk = None

--- a/core/admin/mailu/schemas.py
+++ b/core/admin/mailu/schemas.py
@@ -1115,6 +1115,7 @@ class DomainSchema(BaseSchema):
 
         # Anonymous Email Service domain flags
         anonmail_enabled = fields.Boolean(load_default=False, dump_default=False)
+        outgoing_only = fields.Boolean(load_default=False, dump_default=False)
 
         include_by_context = {
             ('dns',): {'dkim_publickey', 'dns_mx', 'dns_spf', 'dns_dkim', 'dns_dmarc'},

--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -74,6 +74,7 @@ class DomainForm(flask_wtf.FlaskForm):
     max_quota_bytes = fields_.IntegerSliderField(_('Maximum user quota'), default=0)
     signup_enabled = fields.BooleanField(_('Enable sign-up'), default=False)
     anonmail_enabled = fields.BooleanField(_('Enable Global Anonymous Email Service'), default=False)
+    outgoing_only = fields.BooleanField(_('Outgoing only (do not deliver mail to this domain locally)'), default=False)
     comment = fields.StringField(_('Comment'), render_kw=AUTOFOCUS)
     submit = fields.SubmitField(_('Save'))
 

--- a/core/admin/mailu/ui/templates/domain/create.html
+++ b/core/admin/mailu/ui/templates/domain/create.html
@@ -14,6 +14,7 @@
       prepend='<span class="input-group-text"><span id="max_quota_bytes_value"></span>&nbsp;GB</span>') }}
   {{ macros.form_field(form.signup_enabled) }}
   {{ macros.form_field(form.anonmail_enabled) }}
+  {{ macros.form_field(form.outgoing_only) }}
   {{ macros.form_field(form.comment) }}
   {{ macros.form_field(form.submit) }}
 </form>

--- a/core/admin/mailu/ui/templates/domain/list.html
+++ b/core/admin/mailu/ui/templates/domain/list.html
@@ -23,6 +23,7 @@
     <th>{% trans %}Comment{% endtrans %}</th>
     <th>{% trans %}Enable sign-up{% endtrans %}</th>
     <th>{% trans %}Anonymous Email Service{% endtrans %}</th>
+    <th>{% trans %}Outgoing only{% endtrans %}</th>
     <th>{% trans %}Created{% endtrans %}</th>
     <th>{% trans %}Last edit{% endtrans %}</th>
   </tr>
@@ -53,6 +54,7 @@
     <td>{{ domain.comment or '' }}</td>
     <td data-sort="{{ domain.signup_enabled }}">{% if domain.signup_enabled %}{% trans %}yes{% endtrans %}{% else %}{% trans %}no{% endtrans %}{% endif %}</td>
     <td data-sort="{{ domain.anonmail_enabled }}">{% if domain.anonmail_enabled %}{% trans %}yes{% endtrans %}{% else %}{% trans %}no{% endtrans %}{% endif %}</td>
+    <td data-sort="{{ domain.outgoing_only }}">{% if domain.outgoing_only %}{% trans %}yes{% endtrans %}{% else %}{% trans %}no{% endtrans %}{% endif %}</td>
     <td data-order="{{ domain.created_at or '0000-00-00' }}">{{ domain.created_at | format_date }}</td>
     <td data-order="{{ domain.updated_at or '0000-00-00' }}">{{ domain.updated_at | format_date }}</td>
   </tr>

--- a/core/admin/migrations/versions/8b653eeb2828_.py
+++ b/core/admin/migrations/versions/8b653eeb2828_.py
@@ -1,0 +1,35 @@
+"""Add Domain.outgoing_only
+
+Marks a domain as send-only so postfix_mailbox_domain does not resolve
+it as a local mailbox domain. Used when Mailu is only responsible for
+sending mail for a domain (e.g. DKIM-signing outbound) while incoming
+mail is handled by another provider.
+
+Idempotent: the ``outgoing_only`` column is only added if it does not
+already exist.
+
+Revision ID: 8b653eeb2828
+Revises: fdff7f84d363
+Create Date: 2023-03-28 21:25:25.879073
+"""
+
+revision = '8b653eeb2828'
+down_revision = 'fdff7f84d363'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def _column_exists(table, column):
+    insp = sa.inspect(op.get_context().bind)
+    return any(c['name'] == column for c in insp.get_columns(table))
+
+
+def upgrade():
+    if not _column_exists('domain', 'outgoing_only'):
+        op.add_column('domain', sa.Column('outgoing_only', sa.Boolean(), nullable=True))
+
+
+def downgrade():
+    if _column_exists('domain', 'outgoing_only'):
+        op.drop_column('domain', 'outgoing_only')

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -263,6 +263,7 @@ This is a complete YAML template with all additional parameters that can be defi
       max_quota_bytes: 0
       max_users: -1
       signup_enabled: false
+      outgoing_only: false
 
   user:
     - email: postmaster@example.com

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -66,6 +66,7 @@ the version of Mailu that you are running.
     webadministration
     antispam
     anonmail
+    outgoing-only
     cli
     api
 

--- a/docs/outgoing-only.rst
+++ b/docs/outgoing-only.rst
@@ -1,0 +1,48 @@
+Outgoing-only domains
+=====================
+
+Overview
+--------
+
+The **Outgoing only** flag marks a domain as one Mailu is used only to send
+mail *from* — incoming mail for that domain is delivered by another provider
+(for example Google Workspace, Microsoft 365, or a corporate MX elsewhere).
+
+When the flag is set, Postfix no longer treats the domain as a local mailbox
+domain: another Mailu-hosted domain sending mail to an address at this
+outgoing-only domain will be routed out through DNS/MX like any external
+recipient, instead of being (incorrectly) resolved locally and bouncing with
+``User doesn't exist``.
+
+Common use case
+---------------
+
+You host ``example.com`` mailboxes on Google Workspace, but want to send
+outbound mail through your Mailu instance so it is DKIM-signed with your key
+and comes from your IP range. In Mailu's admin UI you add ``example.com`` as
+a domain (so you can create users/aliases that authenticate against Mailu
+for submission, and set up DKIM), and tick **Outgoing only**.
+
+Without the flag, any *other* Mailu-hosted domain that sends mail to
+``someone@example.com`` will have Mailu attempt local delivery, fail because
+no such mailbox exists on Mailu, and bounce — even though the message should
+have gone to Google's MX.
+
+Enabling
+--------
+
+In the admin UI, open the domain's edit page and check **Outgoing only**.
+The flag is also settable via the REST API (``outgoing_only``) and via the
+YAML config import/export.
+
+Effect on Postfix
+-----------------
+
+The internal ``/postfix/domain/<name>`` lookup used by ``mailbox_domains``
+returns 404 for outgoing-only domains, so Postfix does not include them in
+its local delivery domain set. Alternative names of the domain are not
+affected by the flag.
+
+DKIM signing, submission authentication, and per-user rate limiting keep
+working as usual for the domain — only local recipient resolution is
+disabled.

--- a/tests/anonmail/test_outgoing_only.py
+++ b/tests/anonmail/test_outgoing_only.py
@@ -1,0 +1,52 @@
+from urllib.parse import quote
+
+from mailu import models
+
+
+class TestOutgoingOnlyDomain:
+    """Tests for the Domain.outgoing_only flag.
+
+    When outgoing_only is True, Postfix must not treat the domain as a local
+    mailbox domain: the /internal/postfix/domain/<name> endpoint must answer
+    404 for it. This keeps other Mailu-hosted domains from bouncing mail sent
+    to the outgoing-only domain (whose MX points elsewhere) with a spurious
+    'User doesn't exist' instead of routing it out via DNS.
+    """
+
+    def test_default_domain_is_delivered_locally(self, app, client):
+        with app.app_context():
+            models.db.session.add(models.Domain(name='example.com'))
+            models.db.session.commit()
+            rv = client.get(f"/internal/postfix/domain/{quote('example.com')}")
+            assert rv.status_code == 200
+            assert rv.get_json() == 'example.com'
+
+    def test_outgoing_only_domain_returns_404(self, app, client):
+        with app.app_context():
+            models.db.session.add(models.Domain(name='sendonly.example', outgoing_only=True))
+            models.db.session.commit()
+            rv = client.get(f"/internal/postfix/domain/{quote('sendonly.example')}")
+            assert rv.status_code == 404
+
+    def test_toggling_flag_changes_lookup(self, app, client):
+        with app.app_context():
+            d = models.Domain(name='toggle.example')
+            models.db.session.add(d)
+            models.db.session.commit()
+            assert client.get(f"/internal/postfix/domain/{quote('toggle.example')}").status_code == 200
+
+            d.outgoing_only = True
+            models.db.session.commit()
+            assert client.get(f"/internal/postfix/domain/{quote('toggle.example')}").status_code == 404
+
+            d.outgoing_only = False
+            models.db.session.commit()
+            assert client.get(f"/internal/postfix/domain/{quote('toggle.example')}").status_code == 200
+
+    def test_default_value_is_false(self, app):
+        with app.app_context():
+            d = models.Domain(name='default.example')
+            models.db.session.add(d)
+            models.db.session.commit()
+            fetched = models.Domain.query.get('default.example')
+            assert fetched.outgoing_only in (False, None)

--- a/towncrier/newsfragments/4055.feature
+++ b/towncrier/newsfragments/4055.feature
@@ -1,0 +1,1 @@
+Add an "Outgoing only" flag to Domain. When enabled, Postfix does not resolve the domain as a local mailbox domain, so Mailu can be used as an outbound relay (with DKIM signing) for domains whose incoming mail is handled by another provider (e.g. Google Workspace, Microsoft 365) without other Mailu-hosted domains bouncing mail addressed to it locally.


### PR DESCRIPTION
## What type of PR?

Feature

## What does this PR do?

Adds a per-domain "Outgoing only" flag. When set, Postfix does not resolve
the domain via `postfix_mailbox_domain`, so it is not included in
`mailbox_domains`. This lets Mailu act as an authenticated outbound relay
(with DKIM signing) for a domain whose incoming mail is handled by another
provider — Google Workspace, Microsoft 365, or another external MX — without
other Mailu-hosted domains bouncing mail addressed to it locally with a
spurious `User doesn't exist`.

Exposed in the admin UI (Domain create/edit form + list), the REST API v1
(`POST`/`PATCH /api/v1/domain`), and the YAML config import/export schema.
Includes docs (`docs/outgoing-only.rst`), an idempotent Alembic migration,
and pytest coverage for the internal Postfix endpoint (runs in the existing
admin unit-tests CI job).

### Related issue(s)
- Related to #3853 (partial overlap — this PR does not attempt env-var-based
  DKIM without domain registration; scope is just the local-delivery escape
  hatch)

## Prerequisites
- [x] Documentation updated (`docs/outgoing-only.rst`, `docs/index.rst`, `docs/cli.rst`)
- [x] Changelog entry added — currently `+outgoing_only.feature`; happy to rename to `<PR-number>.feature` on request
