### PR TITLE
api: return proper HTTP status instead of 500 on malformed input

### DIFF
--- a/core/admin/mailu/api/v1/domain.py
+++ b/core/admin/mailu/api/v1/domain.py
@@ -163,7 +163,7 @@ class Domain(Resource):
             return { 'code': 400, 'message': f'Domain {domain} is not a valid domain'}, 400
         domain_found = models.Domain.query.get(domain)
         if not domain_found:
-            return { 'code': 404, 'message': f'Domain {data["name"]} does not exist'}, 404
+            return { 'code': 404, 'message': f'Domain {domain} does not exist'}, 404
         data = api.payload
 
         if 'alternatives' in data:

--- a/core/admin/mailu/api/v1/user.py
+++ b/core/admin/mailu/api/v1/user.py
@@ -9,6 +9,15 @@ db = models.db
 
 user = api.namespace('user', description='User operations')
 
+def parse_reply_date(value):
+    """ Parse a reply date given as 'YYYY-MM-DD'. Returns a datetime, or None when
+        the value is not a well-formed, in-range date. """
+    try:
+        year, month, day = value.split('-')
+        return datetime.datetime(int(year), int(month), int(day))
+    except (ValueError, TypeError, AttributeError):
+        return None
+
 user_fields_get = api.model('UserGet', {
     'email': fields.String(description='The email address of the user', example='John.Doe@example.com', attribute='_email'),
     'password': fields.String(description="Hash of the user's password; Example='$bcrypt-sha256$v=2,t=2b,r=12$fmsAdJbYAD1gGQIE5nfJq.$zLkQUEs2XZfTpAEpcix/1k5UTNPm0jO'"),
@@ -158,12 +167,14 @@ class Users(Resource):
         if 'reply_body' in data:
             user_new.reply_body = data['reply_body']
         if 'reply_startdate' in data:
-            year, month, day = data['reply_startdate'].split('-')
-            date = datetime.datetime(int(year), int(month), int(day))
+            date = parse_reply_date(data['reply_startdate'])
+            if date is None:
+                return { 'code': 400, 'message': f'Provided reply_startdate {data["reply_startdate"]!r} is not a valid date (expected YYYY-MM-DD)'}, 400
             user_new.reply_startdate = date
         if 'reply_enddate' in data:
-            year, month, day = data['reply_enddate'].split('-')
-            date = datetime.datetime(int(year), int(month), int(day))
+            date = parse_reply_date(data['reply_enddate'])
+            if date is None:
+                return { 'code': 400, 'message': f'Provided reply_enddate {data["reply_enddate"]!r} is not a valid date (expected YYYY-MM-DD)'}, 400
             user_new.reply_enddate = date
         if 'displayed_name' in data:
             user_new.displayed_name = data['displayed_name']
@@ -252,12 +263,14 @@ class User(Resource):
         if 'reply_body' in data:
             user_found.reply_body = data['reply_body']
         if 'reply_startdate' in data:
-            year, month, day = data['reply_startdate'].split('-')
-            date = datetime.datetime(int(year), int(month), int(day))
+            date = parse_reply_date(data['reply_startdate'])
+            if date is None:
+                return { 'code': 400, 'message': f'Provided reply_startdate {data["reply_startdate"]!r} is not a valid date (expected YYYY-MM-DD)'}, 400
             user_found.reply_startdate = date
         if 'reply_enddate' in data:
-            year, month, day = data['reply_enddate'].split('-')
-            date = datetime.datetime(int(year), int(month), int(day))
+            date = parse_reply_date(data['reply_enddate'])
+            if date is None:
+                return { 'code': 400, 'message': f'Provided reply_enddate {data["reply_enddate"]!r} is not a valid date (expected YYYY-MM-DD)'}, 400
             user_found.reply_enddate = date
         if 'displayed_name' in data:
             user_found.displayed_name = data['displayed_name']

--- a/tests/anonmail/test_api_v1_malformed_input.py
+++ b/tests/anonmail/test_api_v1_malformed_input.py
@@ -1,0 +1,57 @@
+""" Regression tests: the admin API v1 must answer malformed input with a proper
+    4xx status, not crash with an HTTP 500.
+
+    - PATCH /domain/<name> on a non-existent domain built its 404 message from a
+      variable that is only assigned on the next line -> UnboundLocalError -> 500.
+    - POST/PATCH /user parse reply_startdate/reply_enddate by hand; a value that
+      is not a valid YYYY-MM-DD raised ValueError -> 500.
+"""
+
+from mailu import models
+
+
+def _bearer(app):
+    return {'Authorization': f'Bearer {app.config["API_TOKEN"]}'}
+
+
+def test_patch_nonexistent_domain_returns_404(app, client):
+    with app.app_context():
+        rv = client.patch('/api/v1/domain/nonexistent.example',
+                           json={'comment': 'x'}, headers=_bearer(app))
+        assert rv.status_code == 404
+
+
+def _make_user(email='replytest@example.com'):
+    domain = models.Domain(name=email.split('@', 1)[1])
+    models.db.session.add(domain)
+    user = models.User(localpart=email.split('@', 1)[0], domain_name=email.split('@', 1)[1])
+    user.set_password('password')
+    models.db.session.add(user)
+    models.db.session.commit()
+    return user
+
+
+def test_patch_user_malformed_reply_startdate_returns_400(app, client):
+    with app.app_context():
+        user = _make_user()
+        rv = client.patch(f'/api/v1/user/{user.email}',
+                          json={'reply_startdate': '2022-02-30'}, headers=_bearer(app))
+        assert rv.status_code == 400
+
+
+def test_patch_user_nondate_reply_enddate_returns_400(app, client):
+    with app.app_context():
+        user = _make_user(email='replytest2@example.com')
+        rv = client.patch(f'/api/v1/user/{user.email}',
+                          json={'reply_enddate': 'notadate'}, headers=_bearer(app))
+        assert rv.status_code == 400
+
+
+def test_post_user_malformed_reply_startdate_returns_400(app, client):
+    with app.app_context():
+        models.db.session.add(models.Domain(name='example.com'))
+        models.db.session.commit()
+        rv = client.post('/api/v1/user',
+                         json={'email': 'new@example.com', 'raw_password': 'Secret12!',
+                               'reply_startdate': '2022-13-40'}, headers=_bearer(app))
+        assert rv.status_code == 400

--- a/towncrier/newsfragments/4056.bugfix
+++ b/towncrier/newsfragments/4056.bugfix
@@ -1,0 +1,1 @@
+Return a proper 4xx status instead of HTTP 500 when the admin API is given malformed input (a non-existent domain in PATCH /domain, or an invalid reply_startdate/reply_enddate in POST/PATCH /user).


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Two admin API v1 endpoints returned HTTP 500 (an uncaught exception) on input that should produce a clean 4xx:

- `PATCH /api/v1/domain/<name>` for a non-existent domain built its 404 message from `data`, which is only assigned on the following line, so it raised `UnboundLocalError` → 500. It now uses the `domain` argument in the message and returns 404 as intended.
- `POST` / `PATCH /api/v1/user` parse `reply_startdate` / `reply_enddate` by hand; a value that is not a valid `YYYY-MM-DD` (e.g. `2022-02-30` or `notadate`) raised `ValueError` → 500. The dates are now parsed through a small helper that returns 400 on a malformed value.

Verified with a new headless regression test (`tests/anonmail/test_api_v1_malformed_input.py`): each malformed-input case returned 500 before and now returns 404/400; the full `tests/anonmail` suite passes (51 tests).

### Related issue(s)

- None — found while reading the code.

## Prerequisites

- [x] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
