### PR TITLE
internal: return a clean status instead of 500 on a malformed username

### DIFF
--- a/core/admin/mailu/internal/views/auth.py
+++ b/core/admin/mailu/internal/views/auth.py
@@ -5,6 +5,7 @@ from flask import current_app as app
 import flask
 import flask_login
 import base64
+import binascii
 import sqlalchemy.exc
 import urllib
 
@@ -92,26 +93,31 @@ def basic_authentication():
     authorization = flask.request.headers.get("Authorization")
     if authorization and authorization.startswith("Basic "):
         encoded = authorization.replace("Basic ", "")
-        user_email, password = base64.b64decode(encoded).split(b":", 1)
-        user_email = user_email.decode("utf8")
-        if utils.limiter.should_rate_limit_user(user_email, client_ip):
-            response = flask.Response(status=401)
-            response.headers["WWW-Authenticate"] = 'Basic realm="Authentication rate limit for this username exceeded"'
-            response.headers['Retry-After'] = '60'
-            return response
         try:
-            user = models.User.query.get(user_email) if '@' in user_email else None
-        except sqlalchemy.exc.StatementError as exc:
-            exc = str(exc).split('\n', 1)[0]
-            app.logger.warn(f'Invalid user {user_email!r}: {exc}')
-        else:
-            if user is not None and nginx.check_credentials(user, password.decode('utf-8'), client_ip, "web", flask.request.headers.get('X-Real-Port', None), user_email):
-                response = flask.Response()
-                response.headers["X-User"] = models.IdnaEmail.process_bind_param(flask_login, user.email, "")
-                utils.limiter.exempt_ip_from_ratelimits(client_ip)
+            user_email, password = base64.b64decode(encoded).split(b":", 1)
+            user_email = user_email.decode("utf8")
+        except (binascii.Error, ValueError, UnicodeDecodeError):
+            # malformed header: fall through to the generic 401 below
+            user_email = None
+        if user_email is not None:
+            if utils.limiter.should_rate_limit_user(user_email, client_ip):
+                response = flask.Response(status=401)
+                response.headers["WWW-Authenticate"] = 'Basic realm="Authentication rate limit for this username exceeded"'
+                response.headers['Retry-After'] = '60'
                 return response
-            # We failed check_credentials
-            utils.limiter.rate_limit_user(user_email, client_ip) if user else utils.limiter.rate_limit_ip(client_ip, user_email)
+            try:
+                user = models.User.query.get(user_email) if '@' in user_email else None
+            except sqlalchemy.exc.StatementError as exc:
+                exc = str(exc).split('\n', 1)[0]
+                app.logger.warn(f'Invalid user {user_email!r}: {exc}')
+            else:
+                if user is not None and nginx.check_credentials(user, password.decode('utf-8'), client_ip, "web", flask.request.headers.get('X-Real-Port', None), user_email):
+                    response = flask.Response()
+                    response.headers["X-User"] = models.IdnaEmail.process_bind_param(flask_login, user.email, "")
+                    utils.limiter.exempt_ip_from_ratelimits(client_ip)
+                    return response
+                # We failed check_credentials
+                utils.limiter.rate_limit_user(user_email, client_ip) if user else utils.limiter.rate_limit_ip(client_ip, user_email)
     response = flask.Response(status=401)
     response.headers["WWW-Authenticate"] = 'Basic realm="Login Required"'
     return response

--- a/core/admin/mailu/internal/views/dovecot.py
+++ b/core/admin/mailu/internal/views/dovecot.py
@@ -7,9 +7,18 @@ import socket
 import os
 import sqlalchemy.exc
 
+def _get_user_or_404(user_email):
+    """ Look up a user by their (possibly malformed) address, returning a clean
+        404 rather than a 500 when the address is not a valid stored e-mail. """
+    try:
+        user = models.User.query.get(user_email)
+    except sqlalchemy.exc.StatementError:
+        user = None
+    return user or flask.abort(404)
+
 @internal.route("/dovecot/passdb/<path:user_email>")
 def dovecot_passdb_dict(user_email):
-    user = models.User.query.get(user_email) or flask.abort(404)
+    user = _get_user_or_404(user_email)
     allow_nets = []
     allow_nets.append(app.config["SUBNET"])
     if app.config["SUBNET6"]:
@@ -39,7 +48,7 @@ def dovecot_userdb_dict(user_email):
 
 @internal.route("/dovecot/quota/<ns>/<path:user_email>", methods=["POST"])
 def dovecot_quota(ns, user_email):
-    user = models.User.query.get(user_email) or flask.abort(404)
+    user = _get_user_or_404(user_email)
     if ns == "storage":
         user.quota_bytes_used = flask.request.get_json()
         user.dont_change_updated_at()
@@ -54,5 +63,5 @@ def dovecot_sieve_name(script, user_email):
 
 @internal.route("/dovecot/sieve/data/default/<path:user_email>")
 def dovecot_sieve_data(user_email):
-    user = models.User.query.get(user_email) or flask.abort(404)
+    user = _get_user_or_404(user_email)
     return flask.jsonify(flask.render_template("default.sieve", user=user))

--- a/tests/anonmail/test_internal_malformed_input.py
+++ b/tests/anonmail/test_internal_malformed_input.py
@@ -1,0 +1,45 @@
+""" Regression tests: internal endpoints that look a user up by a client-supplied
+    address must answer malformed input with a clean status, not crash with 500.
+
+    - /internal/auth/basic decoded the Basic credentials without guarding against a
+      malformed header (bad base64, or no ':' separator) -> binascii.Error/ValueError
+      -> 500. It should fall through to 401.
+    - /internal/dovecot/passdb|quota|sieve looked the user up with an unguarded
+      User.query.get(); a username that is not a storable e-mail (no '@', or a
+      non-IDNA domain) raised a StatementError -> 500. The sibling userdb endpoint
+      already caught this and returned 404.
+"""
+
+import base64
+
+from mailu import models
+
+
+def test_basic_auth_invalid_base64_returns_401(app, client):
+    with app.app_context():
+        rv = client.get('/internal/auth/basic', headers={'Authorization': 'Basic x'})
+        assert rv.status_code == 401
+
+
+def test_basic_auth_missing_colon_returns_401(app, client):
+    with app.app_context():
+        encoded = base64.b64encode(b'foo').decode()
+        rv = client.get('/internal/auth/basic', headers={'Authorization': f'Basic {encoded}'})
+        assert rv.status_code == 401
+
+
+def test_dovecot_passdb_malformed_username_returns_404(app, client):
+    with app.app_context():
+        # no '@' -> not a storable IdnaEmail -> StatementError on the pk lookup
+        assert client.get('/internal/dovecot/passdb/foo').status_code == 404
+
+
+def test_dovecot_sieve_data_malformed_username_returns_404(app, client):
+    with app.app_context():
+        assert client.get('/internal/dovecot/sieve/data/default/foo').status_code == 404
+
+
+def test_dovecot_passdb_unknown_valid_user_still_404(app, client):
+    with app.app_context():
+        # a well-formed but non-existent address keeps returning a clean 404
+        assert client.get('/internal/dovecot/passdb/nobody@example.com').status_code == 404

--- a/towncrier/newsfragments/4057.bugfix
+++ b/towncrier/newsfragments/4057.bugfix
@@ -1,0 +1,1 @@
+Return a clean status instead of HTTP 500 when an internal endpoint receives a malformed username: /internal/auth/basic now falls through to 401 on a malformed Basic header, and the /internal/dovecot lookups return 404 on an address that is not a valid stored e-mail.


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Two internal endpoints returned HTTP 500 (an uncaught exception) on a client-supplied address that is not a valid stored e-mail, where a clean status was intended:

- `/internal/auth/basic` decoded the Basic credentials without guarding against a malformed header — invalid base64, or no `:` separator — raising `binascii.Error` / `ValueError`. The decode is now guarded and falls through to the generic 401. The analogous decode in `nginx.py` is already wrapped this way. (Reachable pre-auth as the `auth_request` for the WebDAV location when `WEBDAV != none`.)
- `/internal/dovecot/passdb`, `/dovecot/quota` and `/dovecot/sieve/data` looked the user up with an unguarded `User.query.get()`, so a username without `@` or with a non-IDNA domain raised a `StatementError`. They now go through a helper that catches it and returns 404, matching the sibling `/dovecot/userdb` endpoint which already does this.

Verified with a new headless regression test (`tests/anonmail/test_internal_malformed_input.py`): each malformed-input case returned 500 before and now returns 401/404; the full `tests/anonmail` suite passes (52 tests).

### Related issue(s)

- None — found while reading the code.

## Prerequisites

- [x] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
