### PR TITLE
schemas: don't re-enable a disabled alias on merge-import

### DIFF
--- a/core/admin/mailu/schemas.py
+++ b/core/admin/mailu/schemas.py
@@ -1220,7 +1220,9 @@ class AliasSchema(BaseSchema):
     note = fields.String(allow_none=True)
     hostname = fields.String(allow_none=True)
     owner_email = fields.String(allow_none=True, dump_only=True)
-    disabled = fields.Boolean(load_default=False, dump_default=False)
+    # No load_default: in merge mode (config-import --update) an omitted field must
+    # keep the stored value. On create the model column default (False) applies.
+    disabled = fields.Boolean(dump_default=False)
 
 
 @mapped

--- a/tests/anonmail/test_config_import_disabled_alias.py
+++ b/tests/anonmail/test_config_import_disabled_alias.py
@@ -1,0 +1,80 @@
+""" Regression test: `flask mailu config-import --update` (merge mode) must leave
+    a field that the YAML omits unchanged.
+
+    AliasSchema.disabled declared `load_default=False`, so when an alias entry in
+    the imported YAML omitted `disabled`, marshmallow injected `disabled=False`
+    and the merge re-enabled an alias an admin had disabled. Every other column
+    relies on "field absent => keep existing value" (auto-generated fields never
+    set a load_default); disabled must behave the same.
+"""
+
+from mailu import models
+from mailu.schemas import MailuSchema
+
+
+def _update_import(source):
+    context = {'import': True, 'update': True, 'clear': False, 'callback': lambda *a, **k: None}
+    schema = MailuSchema(only=MailuSchema.Meta.order, context=context)
+    with models.db.session.no_autoflush:
+        schema.loads(source)
+    models.db.session.commit()
+
+
+def test_update_import_omitting_disabled_keeps_alias_disabled(app):
+    with app.app_context():
+        models.db.session.add(models.Domain(name='example.com'))
+        models.db.session.add(models.Alias(
+            localpart='info', domain_name='example.com',
+            destination=['alice@example.com'], disabled=True))
+        models.db.session.commit()
+        assert models.Alias.query.filter_by(email='info@example.com').first().disabled is True
+
+        # merge-import the same alias WITHOUT the `disabled` field
+        _update_import(
+            "alias:\n"
+            "  - email: info@example.com\n"
+            "    destination:\n"
+            "      - alice@example.com\n"
+        )
+
+        alias = models.Alias.query.filter_by(email='info@example.com').first()
+        assert alias.disabled is True, "merge-import re-enabled a disabled alias"
+
+
+def test_update_import_can_still_toggle_disabled_explicitly(app):
+    with app.app_context():
+        models.db.session.add(models.Domain(name='example.com'))
+        models.db.session.add(models.Alias(
+            localpart='info', domain_name='example.com',
+            destination=['alice@example.com'], disabled=True))
+        models.db.session.commit()
+
+        # an explicit `disabled: false` must still re-enable it
+        _update_import(
+            "alias:\n"
+            "  - email: info@example.com\n"
+            "    destination:\n"
+            "      - alice@example.com\n"
+            "    disabled: false\n"
+        )
+
+        alias = models.Alias.query.filter_by(email='info@example.com').first()
+        assert alias.disabled is False
+
+
+def test_import_creating_new_alias_defaults_disabled_false(app):
+    with app.app_context():
+        models.db.session.add(models.Domain(name='example.com'))
+        models.db.session.commit()
+
+        # a newly-created alias without `disabled` must default to enabled
+        _update_import(
+            "alias:\n"
+            "  - email: fresh@example.com\n"
+            "    destination:\n"
+            "      - alice@example.com\n"
+        )
+
+        alias = models.Alias.query.filter_by(email='fresh@example.com').first()
+        assert alias is not None
+        assert alias.disabled is False

--- a/towncrier/newsfragments/4059.bugfix
+++ b/towncrier/newsfragments/4059.bugfix
@@ -1,0 +1,1 @@
+Stop config-import --update from silently re-enabling a disabled alias when the imported entry omits the disabled field (merge mode now keeps the stored value).


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

`flask mailu config-import --update` (merge mode) is meant to leave any field the imported YAML omits unchanged — auto-generated schema fields never set a `load_default`, so an absent field keeps the value already stored. `AliasSchema.disabled` was the exception: it declared `load_default=False`, so importing an alias entry that omitted `disabled` injected `False` and silently **re-enabled an alias an admin had disabled** (e.g. an abusive anonymous alias), a data-integrity regression on every merge-import.

The fix drops the `load_default`. On create the model column default (`disabled = db.Column(..., nullable=False, default=False)`) still applies, and an explicit `disabled: true` / `disabled: false` in the YAML is still honoured.

Verified with a new headless test (`tests/anonmail/test_config_import_disabled_alias.py`): merge-import omitting `disabled` re-enabled the alias before and now keeps it disabled; an explicit toggle still works; a newly-imported alias still defaults to enabled. The full `tests/anonmail` suite passes (50 tests).

### Related issue(s)

- None — found while reading the code.

## Prerequisites

- [x] In case of feature or enhancement: documentation updated accordingly
- [ ] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
