### PR TITLE
Add favicon to documentation page

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -30,7 +30,7 @@ FROM nginx:1.29.0-alpine
 ARG version=master
 ARG pinned_version=master
 ENV VERSION=$version
-ENV TZ Etc/UTC
+ENV TZ=Etc/UTC
 LABEL version=$VERSION
 
 COPY ./nginx.conf /etc/nginx/conf.d/default.conf

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,6 +18,7 @@ pygments_style = 'sphinx'
 todo_include_todos = False
 html_theme = 'sphinx_rtd_theme'
 html_title = 'Mailu, Docker based mail server'
+html_favicon = 'assets/logomark.png'
 html_static_path = []
 htmlhelp_basename = 'Mailudoc'
 


### PR DESCRIPTION
## What type of PR?

documentation

## What does this PR do?

The documentation page currently doesn't have a favicon, so places like the browser tabs or search results show a blank space.
This PR references the existing (almost) square logomark. This should be sufficient for most target systems.
It also resolves a docker build lint warning.

Related documentation: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_favicon

If later a more sophisticated favicon setup is desired, see: https://sphinx-favicon.readthedocs.io/en/latest/