### PR TITLE
Fix roundcube admin link for multi-segment WEB_WEBMAIL paths

### DIFF
--- a/towncrier/newsfragments/3164.bugfix
+++ b/towncrier/newsfragments/3164.bugfix
@@ -1,0 +1,1 @@
+Fix the link back to the Mailu admin UI in roundcube being broken when WEB_WEBMAIL is set to a path with more than two segments

--- a/webmails/roundcube/config/config.inc.php
+++ b/webmails/roundcube/config/config.inc.php
@@ -57,7 +57,9 @@ $config['managesieve_mbox_encoding'] = 'UTF8';
 // roundcube customization
 $config['product_name'] = 'Mailu Webmail';
 {%- if ADMIN and WEB_ADMIN %}
-$config['support_url'] = '../..{{ WEB_ADMIN }}';
+{# This link must stay relative: roundcube's fix_paths() rewrites absolute paths to be skin-relative. -#}
+{# One "../" per WEB_WEBMAIL path segment climbs back to the web root regardless of its depth (see #3164). -#}
+$config['support_url'] = '{{ "../" * (WEB_WEBMAIL.strip("/").split("/")|length) }}{{ WEB_ADMIN.strip("/") }}';
 {%- endif %}
 $config['plugins'] = array({{ PLUGINS }});
 


### PR DESCRIPTION
## What type of PR?
bug-fix

## What does this PR do?
The Mailu admin button in roundcube used a relative support_url with a fixed two-level climb (`../..{{ WEB_ADMIN }}`). roundcube's `fix_paths()` rewrites absolute hrefs to be skin-relative, so the link must stay relative and is resolved by the browser against the webmail page URL (`WEB_WEBMAIL/`). When WEB_WEBMAIL has three or more path segments (e.g. `/webmail/sub/directory`), two `../` are not enough to reach the web root, so the button pointed to `/webmail/admin` instead of `/admin`.

This emits one `../` per WEB_WEBMAIL path segment so the link reaches the web root at any depth, then appends WEB_ADMIN. It is behaviour-preserving for the default single-segment `/webmail`.

### Related issue(s)
- Fixes #3164

## Prerequisites
- [x] Unless it's docs or a minor change: add changelog entry file.

Validated by rendering the template across WEB_WEBMAIL depths and simulating the browser's relative-URL resolution: the old value reproduces the reported `/webmail/admin` bug, the new one resolves to `/admin` at every depth and is unchanged for the default `/webmail`.