### PR TITLE
internal: scope allow_spoofing to the sender's own domain (#2686)

### DIFF
--- a/core/admin/mailu/internal/views/postfix.py
+++ b/core/admin/mailu/internal/views/postfix.py
@@ -159,7 +159,10 @@ def postfix_sender_login(sender):
     localpart = localpart[:next((i for i, ch in enumerate(localpart) if ch in flask.current_app.config.get('RECIPIENT_DELIMITER')), None)]
     destinations = set(models.Email.resolve_destination(localpart, domain_name, True) or [])
     destinations.update(wildcard_senders)
-    destinations.update(i[0] for i in models.User.query.filter_by(allow_spoofing=True).with_entities(models.User.email).all())
+    # allow_spoofing lets a user authenticate as other senders, but only within
+    # their own domain — scoping the lookup to the sender's domain prevents a
+    # domain manager from granting themselves cross-domain spoofing (#2686).
+    destinations.update(i[0] for i in models.User.query.filter_by(allow_spoofing=True, domain_name=domain_name).with_entities(models.User.email).all())
     if destinations:
         return flask.jsonify(",".join(idna_encode(destinations)))
     return flask.abort(404)

--- a/tests/anonmail/test_postfix.py
+++ b/tests/anonmail/test_postfix.py
@@ -80,6 +80,40 @@ class TestAnonmailPostfixIntegration:
             rv_postfix_disabled = client.get(f'/internal/postfix/alias/{alias_email}')
             assert rv_postfix_disabled.status_code == 404
 
+    def test_postfix_sender_login_spoofing_is_scoped_to_own_domain(self, app, client):
+        """ Regression for #2686.
+
+        ``allow_spoofing`` lets a user authenticate as other senders, but it must
+        only apply within that user's own domain. Otherwise a domain manager can
+        grant themselves ``allow_spoofing`` and send mail spoofing senders on
+        domains they do not manage. The /postfix/sender/login lookup therefore
+        only returns a spoofing user for senders in that user's domain.
+        """
+        with app.app_context():
+            models.db.session.add(models.Domain(name='attacker.com'))
+            models.db.session.add(models.Domain(name='victim.com'))
+
+            spoofer = models.User(localpart='spoofer', domain_name='attacker.com',
+                                  allow_spoofing=True)
+            spoofer.set_password('password')
+            coworker = models.User(localpart='coworker', domain_name='attacker.com')
+            coworker.set_password('password')
+            victim = models.User(localpart='victim', domain_name='victim.com')
+            victim.set_password('password')
+            models.db.session.add_all([spoofer, coworker, victim])
+            models.db.session.commit()
+
+            def logins_for(sender):
+                rv = client.get(f'/internal/postfix/sender/login/{sender}')
+                assert rv.status_code == 200, f'{sender} -> {rv.status_code}'
+                return set(rv.get_json().split(','))
+
+            # Same domain: the spoofer may still send as a coworker.
+            assert 'spoofer@attacker.com' in logins_for('coworker@attacker.com')
+
+            # Cross domain: the spoofer must NOT be a valid login for the victim.
+            assert 'spoofer@attacker.com' not in logins_for('victim@victim.com')
+
     def test_postfix_sees_alias_with_multiple_destinations(self, app, client, create_user_and_token, grant_domain_access):
         with app.app_context():
             d = models.Domain(name='example.com', anonmail_enabled=True)

--- a/towncrier/newsfragments/2686.bugfix
+++ b/towncrier/newsfragments/2686.bugfix
@@ -1,0 +1,1 @@
+Scope the ``allow_spoofing`` permission to the user's own domain, so a domain manager can no longer grant themselves (or a user they create) the ability to send mail spoofing senders on domains they do not manage


### PR DESCRIPTION
## What type of PR?

bug-fix (security)

## What does this PR do?

`allow_spoofing` was consumed with no domain scoping in the `/postfix/sender/login/<sender>` lookup: it unioned in *every* user with `allow_spoofing=True` for *any* requested sender, making it an instance-wide "authenticate as any sender on any domain" capability. Since the flag is an ordinary `UserForm` field written by `user_create`/`user_edit` (guarded only by `@access.domain_admin`), a domain manager could enable it for themselves (or a user they create) and then send DKIM/SPF-authenticated mail spoofing domains they do not manage.

This scopes the lookup to the sender's own domain (`domain_name=domain_name`) — the same-domain direction you preferred over gating the field to global admins. `allow_spoofing` now means "may authenticate as other senders within my own domain".

Tested with a new anonmail regression test (`test_postfix_sender_login_spoofing_is_scoped_to_own_domain`): a spoofing user in `attacker.com` is still a valid login for `coworker@attacker.com`, but is no longer returned for `victim@victim.com` — red before the change, green after. The full `tests/anonmail` suite (55) stays green.

### Related issue(s)
- closes #2686

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [x] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
