### PR TITLE
Fix autoconfig on k9-mail

### DIFF
--- a/core/admin/mailu/internal/views/autoconfig.py
+++ b/core/admin/mailu/internal/views/autoconfig.py
@@ -10,7 +10,7 @@ def autoconfig_mozilla():
     hostname = app.config['HOSTNAME']
     xml = f'''<?xml version="1.0"?>
 <clientConfig version="1.1">
-<emailProvider id="%EMAILDOMAIN%">
+<emailProvider id="{hostname}">
 <domain>%EMAILDOMAIN%</domain>
 
 <displayName>Email</displayName>

--- a/towncrier/newsfragments/4075.bugfix
+++ b/towncrier/newsfragments/4075.bugfix
@@ -1,0 +1,1 @@
+Fix autoconfig on modern k9-mail


### PR DESCRIPTION
## What type of PR?

bug-fix

## What does this PR do?

Fix autoconfig on modern k9-mail. The id now needs to be a valid hostname and not a variable. See 
https://github.com/thunderbird/thunderbird-android/blob/release/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/RealAutoconfigParser.kt#L109

<img width="1080" height="2400" alt="Screenshot_20260725-200520 (1)" src="https://github.com/user-attachments/assets/a967eac9-dd17-468d-9d78-e0c7d03e06f7" />

other clients are less picky:
<img width="1920" height="1053" alt="Screenshot from 2026-07-25 19-04-05" src="https://github.com/user-attachments/assets/72f8fc68-9e9a-4b4f-b3b9-33592b8731f4" />


### Related issue(s)

## Prerequisites
Before we can consider review and merge, please make sure the following list is done and checked.
If an entry in not applicable, you can check it or remove it from the list.

- [ ] In case of feature or enhancement: documentation updated accordingly
- [x] Unless it's docs or a minor change: add [changelog](https://mailu.io/master/contributors/workflow.html#changelog) entry file.
