### PR TITLE
api: authenticate /alias/me with the caller's own credentials

### DIFF
--- a/core/admin/mailu/api/v1/__init__.py
+++ b/core/admin/mailu/api/v1/__init__.py
@@ -12,6 +12,12 @@ authorization = {
         'type': 'apiKey',
         'in': 'header',
         'name': 'Authorization'
+    },
+    # per-user credentials ('email:token'), used by the /alias/me endpoints
+    'Authentication': {
+        'type': 'apiKey',
+        'in': 'header',
+        'name': 'Authentication'
     }
 }
 

--- a/core/admin/mailu/api/v1/alias.py
+++ b/core/admin/mailu/api/v1/alias.py
@@ -1,5 +1,4 @@
 import flask
-import flask_login
 from flask_restx import Resource, fields, marshal
 from . import api, response_fields
 from .. import common
@@ -175,11 +174,11 @@ class AliasWithDest(Resource):
 class AnonAliases(Resource):
     @alias.doc('list_anonaliases')
     @alias.marshal_with(alias_fields, as_list=True, skip_none=True)
-    @alias.doc(security='Bearer')
-    @common.api_token_authorization
+    @alias.doc(security='Authentication')
+    @common.user_token_authorization
     def get(self):
         """List anonymous aliases created by the current user"""
-        user_email = flask.g.user.email if hasattr(flask.g, 'user') else flask_login.current_user.email
+        user_email = flask.g.user.email
         return models.Alias.query.filter_by(owner_email=user_email).all()
 
 
@@ -188,13 +187,13 @@ class AnonAlias(Resource):
     @alias.doc('delete_anonalias')
     @alias.response(200, 'Success', response_fields)
     @alias.response(400, 'Input validation exception', response_fields)
-    @alias.doc(security='Bearer')
-    @common.api_token_authorization
+    @alias.doc(security='Authentication')
+    @common.user_token_authorization
     def delete(self, alias):
         """Permanently delete the specified alias"""
         if not validators.email(alias):
             return {'code': 400, 'message': f'Provided alias (email address) {alias} is not a valid email address'}, 400
-        user_email = flask.g.user.email if hasattr(flask.g, 'user') else flask_login.current_user.email
+        user_email = flask.g.user.email
         alias_found = models.Alias.query.filter_by(email=alias, owner_email=user_email).first()
         if not alias_found:
             return {'code': 404, 'message': f'Alias {alias} cannot be found'}, 404
@@ -205,13 +204,14 @@ class AnonAlias(Resource):
     @alias.expect(alias_fields_update)
     @alias.doc('update_anonalias')
     @alias.response(200, 'Success', response_fields)
-    @common.api_token_authorization
+    @alias.doc(security='Authentication')
+    @common.user_token_authorization
     def patch(self, alias):
         """Modify an alias (toggle disabled, update note/hostname/destination)"""
         data = api.payload or {}
         if not validators.email(alias):
             return {'code': 400, 'message': f'Provided alias (email address) {alias} is not a valid email address'}, 400
-        user_email = flask.g.user.email if hasattr(flask.g, 'user') else flask_login.current_user.email
+        user_email = flask.g.user.email
         alias_found = models.Alias.query.filter_by(email=alias, owner_email=user_email).first()
         if not alias_found:
             return {'code': 404, 'message': f'Alias {alias} cannot be found'}, 404

--- a/tests/anonmail/test_4061_alias_me_auth.py
+++ b/tests/anonmail/test_4061_alias_me_auth.py
@@ -1,0 +1,143 @@
+"""Regression tests for #4061.
+
+The `/api/v1/alias/me*` endpoints read `flask.g.user`, which only
+`common.user_token_authorization` sets. They were decorated with
+`common.api_token_authorization` instead, so the documented caller (a global
+`API_TOKEN` bearer) hit `flask_login.current_user` — an `AnonymousUserMixin`
+with no `.email` — and the request died with a 500.
+"""
+
+import pytest
+
+from mailu import models
+
+
+TOKEN = 'a' * 32
+
+
+@pytest.fixture
+def anon_alias(app, create_user_and_token):
+    """A user owning one anonymous alias, plus a second user owning another."""
+    def _setup():
+        models.db.session.add(models.Domain(name='example.com', anonmail_enabled=True))
+        models.db.session.commit()
+
+        user, _ = create_user_and_token(email='owner@example.com')
+        other, _ = create_user_and_token(email='other@example.com')
+
+        mine = models.Alias(
+            localpart='mine', domain_name='example.com',
+            destination=[user.email], owner_email=user.email, wildcard=False,
+        )
+        theirs = models.Alias(
+            localpart='theirs', domain_name='example.com',
+            destination=[other.email], owner_email=other.email, wildcard=False,
+        )
+        models.db.session.add_all([mine, theirs])
+        models.db.session.commit()
+        return user, other, mine.email, theirs.email
+    return _setup
+
+
+def user_auth(email):
+    return {'Authentication': f'{email}:{TOKEN}'}
+
+
+class TestAliasMeAuthentication:
+
+    def test_get_me_with_user_token(self, app, client, anon_alias):
+        """The per-user token is the auth these endpoints were written for."""
+        with app.app_context():
+            user, _other, mine, _theirs = anon_alias()
+
+            rv = client.get('/api/v1/alias/me', headers=user_auth(user.email))
+
+            assert rv.status_code == 200
+            assert [a['email'] for a in rv.get_json()] == [mine]
+
+    def test_get_me_does_not_leak_other_users_aliases(self, app, client, anon_alias):
+        with app.app_context():
+            user, _other, _mine, theirs = anon_alias()
+
+            rv = client.get('/api/v1/alias/me', headers=user_auth(user.email))
+
+            assert rv.status_code == 200
+            assert theirs not in [a['email'] for a in rv.get_json()]
+
+    def test_patch_me_with_user_token(self, app, client, anon_alias):
+        with app.app_context():
+            user, _other, mine, _theirs = anon_alias()
+
+            rv = client.patch(f'/api/v1/alias/me/{mine}', json={'comment': 'note'},
+                              headers=user_auth(user.email))
+
+            assert rv.status_code == 200
+            assert models.Alias.query.filter_by(email=mine).first().comment == 'note'
+
+    def test_delete_me_with_user_token(self, app, client, anon_alias):
+        with app.app_context():
+            user, _other, mine, _theirs = anon_alias()
+
+            rv = client.delete(f'/api/v1/alias/me/{mine}', headers=user_auth(user.email))
+
+            assert rv.status_code == 200
+            assert models.Alias.query.filter_by(email=mine).first() is None
+
+    def test_patch_me_cannot_touch_another_users_alias(self, app, client, anon_alias):
+        with app.app_context():
+            user, _other, _mine, theirs = anon_alias()
+
+            rv = client.patch(f'/api/v1/alias/me/{theirs}', json={'comment': 'stolen'},
+                              headers=user_auth(user.email))
+
+            assert rv.status_code == 404
+            assert models.Alias.query.filter_by(email=theirs).first().comment != 'stolen'
+
+    def test_delete_me_cannot_touch_another_users_alias(self, app, client, anon_alias):
+        with app.app_context():
+            user, _other, _mine, theirs = anon_alias()
+
+            rv = client.delete(f'/api/v1/alias/me/{theirs}', headers=user_auth(user.email))
+
+            assert rv.status_code == 404
+            assert models.Alias.query.filter_by(email=theirs).first() is not None
+
+
+class TestAliasMeNoLongerCrashes:
+    """The reported symptom: a caller without a usable identity got a 500."""
+
+    @pytest.mark.parametrize('request_call', [
+        lambda c, h: c.get('/api/v1/alias/me', headers=h),
+        lambda c, h: c.delete('/api/v1/alias/me/mine@example.com', headers=h),
+        lambda c, h: c.patch('/api/v1/alias/me/mine@example.com', json={}, headers=h),
+    ], ids=['get', 'delete', 'patch'])
+    def test_admin_bearer_token_is_rejected_not_a_500(self, app, client, anon_alias, request_call):
+        with app.app_context():
+            anon_alias()
+            headers = {'Authorization': f'Bearer {app.config["API_TOKEN"]}'}
+
+            rv = request_call(client, headers)
+
+            assert rv.status_code == 401
+
+    @pytest.mark.parametrize('request_call', [
+        lambda c, h: c.get('/api/v1/alias/me', headers=h),
+        lambda c, h: c.delete('/api/v1/alias/me/mine@example.com', headers=h),
+        lambda c, h: c.patch('/api/v1/alias/me/mine@example.com', json={}, headers=h),
+    ], ids=['get', 'delete', 'patch'])
+    def test_unauthenticated_is_rejected_not_a_500(self, app, client, anon_alias, request_call):
+        with app.app_context():
+            anon_alias()
+
+            rv = request_call(client, {})
+
+            assert rv.status_code == 401
+
+    def test_bad_user_token_is_rejected(self, app, client, anon_alias):
+        with app.app_context():
+            user, _other, _mine, _theirs = anon_alias()
+
+            rv = client.get('/api/v1/alias/me',
+                            headers={'Authentication': f'{user.email}:{"b" * 32}'})
+
+            assert rv.status_code == 403

--- a/tests/anonmail/test_postfix.py
+++ b/tests/anonmail/test_postfix.py
@@ -71,9 +71,8 @@ class TestAnonmailPostfixIntegration:
             # 4. Disable the alias and verify Postfix no longer sees it
             # We can use the PATCH /api/v1/alias/me/<alias> endpoint to disable it
             patch_payload = {'disabled': True}
-            # disable using the global API token (the /me endpoints require API token auth)
-            headers_api = {'Authorization': f'Bearer {app.config["API_TOKEN"]}'}
-            rv_patch = client.patch(f'/api/v1/alias/me/{alias_email}', json=patch_payload, headers=headers_api)
+            # disable as the owning user: /me acts on the caller's own aliases
+            rv_patch = client.patch(f'/api/v1/alias/me/{alias_email}', json=patch_payload, headers=headers)
             assert rv_patch.status_code == 200
 
             # Now Postfix should get a 404 for this alias

--- a/towncrier/newsfragments/4061.bugfix
+++ b/towncrier/newsfragments/4061.bugfix
@@ -1,0 +1,1 @@
+Fix the /api/v1/alias/me endpoints returning HTTP 500: they now authenticate the caller with their own credentials (the 'Authentication: email:token' header) instead of the global API token, which never identified a user.


### PR DESCRIPTION
Closes #4061.

As requested in https://github.com/Mailu/Mailu/issues/4061#issuecomment-5107331847 — switches the three `/api/v1/alias/me*` endpoints to per-user authentication, with tests.

## What was wrong

`GET /alias/me`, `DELETE /alias/me/<alias>` and `PATCH /alias/me/<alias>` resolve the caller through `flask.g.user`, which only `common.user_token_authorization` sets. They were decorated with `common.api_token_authorization`, which validates the global `API_TOKEN` and never sets `flask.g.user`. The fallback then reached `flask_login.current_user` — an `AnonymousUserMixin` with no `.email` — so every call raised `AttributeError: 'AnonymousUserMixin' object has no attribute 'email'` → HTTP 500.

## The change

- The three handlers now use `common.user_token_authorization`, matching their sibling `POST /api/alias/random/new`, which shares the same `flask.g.user` model.
- Dropped the `if hasattr(flask.g, 'user') else flask_login.current_user.email` fallback. It is unreachable now: `user_token_authorization` sets `flask.g.user` on **both** paths — the `Authentication: email:token` header and the logged-in-session path (`flask_login.current_user` when already authenticated). Session-cookie callers keep working.
- Declared an `Authentication` security scheme on the v1 API so the Swagger page advertises the header these endpoints actually accept, instead of `Bearer`.

`/alias/domains/available` was left on the admin token — it never touches `flask.g.user` and was not affected.

## One existing test had to change — worth a look

`tests/anonmail/test_postfix.py::test_postfix_sees_generated_alias` disabled its alias by `PATCH /api/v1/alias/me/<alias>` with the **global API token**, commented "the /me endpoints require API token auth", and passed on master. That was an artifact of the test harness, not evidence the Bearer path worked:

The test wraps all of its requests in a single `with app.app_context():`. `flask.g` is bound to the app context, not the request, so the `flask.g.user` set by the earlier `POST /api/alias/random/new` (which *does* use `user_token_authorization`) **survived into the later PATCH**. The `hasattr` fallback then silently reused that leftover identity. I verified this directly against unmodified master:

```
BEFORE any request: hasattr(g,"user") = False
after user-token request: 201
AFTER request:  hasattr(g,"user") = True -> test1@example.com
```

In production every request gets a fresh app context, so `flask.g.user` is unset — which is exactly the reported 500. The same PATCH, issued as the first call in a fresh context with a Bearer token, raises the `AttributeError` on master.

That step now authenticates as the owning user. I mention it because it means the one place in the tree that appeared to exercise the Bearer path never actually did.

## Tests

New `tests/anonmail/test_4061_alias_me_auth.py` (13 cases), red before the fix and green after:

- all three endpoints work with `Authentication: email:token` (list / patch / delete);
- `/me` returns only the caller's own aliases, and patch/delete on another user's alias give 404 without modifying it;
- the reported symptom is gone: an admin Bearer token and an unauthenticated call now get 401 on all three endpoints rather than a 500;
- an invalid user token gives 403.

Full `tests/anonmail` suite: **73 passed** (60 on master + the 13 new), no other test touched. Run headless in a container against in-memory SQLite, no mailstack.

Newsfragment: `towncrier/newsfragments/4061.bugfix`.

## Note on compatibility

This changes an endpoint's accepted credentials, which is the point of the issue, so it is worth stating plainly: a caller that today sends the global API token to `/alias/me*` gets 401 instead of 500. Nothing in the tree calls these endpoints with a Bearer token (the only such caller was the test above), and no request that previously *succeeded* stops working — on master there was no success path for the admin token here.
