### PR TITLE
ui: accept every valid localpart as an auto-forward destination

### DIFF
--- a/core/admin/mailu/ui/forms.py
+++ b/core/admin/mailu/ui/forms.py
@@ -10,7 +10,11 @@ import re
 import string
 import ipaddress
 
-LOCALPART_REGEX = r'^[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+(?:\.[a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-]+)*$'
+# Characters a localpart may contain (RFC 5322 dot-atom), kept in a single place
+# so that the fields creating an address and the ones referencing one agree.
+LOCALPART_CHARS = r'a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-'
+LOCALPART_REGEX = rf'^[{LOCALPART_CHARS}]+(?:\.[{LOCALPART_CHARS}]+)*$'
+EMAIL_ADDRESS_REGEX = rf'[{LOCALPART_CHARS}]+(?:\.[{LOCALPART_CHARS}]+)*@(?:[a-z0-9-]+\.)*[a-z]+'
 
 def checkStrippable(form, field):
     if field.data != field.data.strip(string.whitespace):
@@ -50,7 +54,7 @@ class MultipleEmailAddressesVerify(object):
         self.message = message
 
     def __call__(self, form, field):
-        pattern = re.compile(r'^([_a-z0-9\-\+]+)(\.[_a-z0-9\-\+]+)*@([a-z0-9\-]{1,}\.)*([a-z]{1,})(,([_a-z0-9\-\+]+)(\.[_a-z0-9\-\+]+)*@([a-z0-9\-]{1,}\.)*([a-z]{2,}))*$', re.IGNORECASE)
+        pattern = re.compile(rf'^{EMAIL_ADDRESS_REGEX}(,{EMAIL_ADDRESS_REGEX})*$', re.IGNORECASE)
         if not pattern.match(field.data.replace(" ", "")):
             raise validators.ValidationError(self.message)
 

--- a/tests/anonmail/test_4078_forward_destination_localpart.py
+++ b/tests/anonmail/test_4078_forward_destination_localpart.py
@@ -1,0 +1,65 @@
+"""Auto-forward destinations must accept the same localparts as the rest of Mailu (#4078)."""
+
+import re
+
+import pytest
+
+from mailu.ui import forms
+
+
+ATEXT_SPECIALS = "!#$%&'*+-/=?^_`{|}~"
+
+
+def validate_destination(app, destination):
+    """Run the real UserSettingsForm over a forward destination."""
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.test_request_context(
+        method='POST',
+        data={'forward_destination': destination, 'submit': 'Save settings'},
+    ):
+        form = forms.UserSettingsForm()
+        form.validate()
+        return not form.forward_destination.errors
+
+
+class TestForwardDestinationLocalpart:
+
+    def test_tilde_localpart_is_accepted(self, app):
+        """#4078: `~@domain.com` is a valid address and must be forwardable to."""
+        assert validate_destination(app, '~@example.com')
+
+    @pytest.mark.parametrize('char', list(ATEXT_SPECIALS))
+    def test_every_localpart_character_mailu_allows_is_accepted(self, app, char):
+        """Whatever a localpart may contain must also be usable as a destination.
+
+        LOCALPART_REGEX is what UserForm/AliasForm accept when *creating* an
+        address, so a destination validator that rejects a subset of it makes
+        addresses Mailu itself hands out unreachable.
+        """
+        localpart = f'a{char}b'
+        assert re.match(forms.LOCALPART_REGEX, localpart), 'test bug: not a Mailu localpart'
+
+        assert validate_destination(app, f'{localpart}@example.com')
+
+    @pytest.mark.parametrize('destination', [
+        'user@example.com',
+        'first.last@example.com',
+        'user+tag@example.com',
+        'user_name@sub.example.com',
+        'User@Example.COM',
+        'one@example.com,two@example.org',
+        'one@example.com, two@example.org',
+    ])
+    def test_previously_accepted_destinations_still_pass(self, app, destination):
+        assert validate_destination(app, destination)
+
+    @pytest.mark.parametrize('destination', [
+        'notanemail',
+        'user@',
+        '@example.com',
+        'user@@example.com',
+        'one@example.com,,two@example.org',
+        'one@example.com,notanemail',
+    ])
+    def test_invalid_destinations_are_still_rejected(self, app, destination):
+        assert not validate_destination(app, destination)

--- a/towncrier/newsfragments/4078.bugfix
+++ b/towncrier/newsfragments/4078.bugfix
@@ -1,0 +1,1 @@
+Accept every localpart Mailu itself allows (``~``, ``!``, ``%``, ``?``, …) as an auto-forward destination; the user settings page previously rejected addresses that can be created as users or aliases and that the API already accepts.


### PR DESCRIPTION
## What type of PR?

Bug fix.

## What does this PR do?

Fixes #4078: the *Auto-forward → Destination* field on the user settings page rejects addresses that Mailu itself considers valid, e.g. `~@example.com`.

### Root cause

`MultipleEmailAddressesVerify` (`core/admin/mailu/ui/forms.py:53`) validates the destination against a hand-written pattern whose localpart class is `[_a-z0-9\-\+]`. That is a strict subset of what the rest of the code accepts:

| path | localpart rule | `~@example.com` |
|---|---|---|
| create a user / alias (`UserForm`, `UserSignupForm`, `AliasForm`) | `LOCALPART_REGEX` (`forms.py:13`), RFC 5322 dot-atom | accepted |
| alias destinations in the UI (`DestinationField.validator`, `forms.py:27`) | `^.+@([^.@][^@]+)$` | accepted |
| forward destination via the API (`api/v1/user.py:123`, `:226`) | `validators.email(dest)` | accepted |
| **forward destination in the UI** (`MultipleEmailAddressesVerify`) | `[_a-z0-9\-\+]` | **rejected** |

So an address that Mailu can create, and that can be set as a forward destination through the API, cannot be entered in the web UI. 17 of the 19 special characters permitted by `LOCALPART_REGEX` are affected (`! # $ % & ' * / = ? ^ \` { | } ~`); only `+`, `-` and `_` pass today.

### Fix

Derive both patterns from one shared character class so the two cannot drift apart again:

```python
LOCALPART_CHARS = r'a-zA-Z0-9!#$%&\'*+/=?^_`{|}~-'
LOCALPART_REGEX = rf'^[{LOCALPART_CHARS}]+(?:\.[{LOCALPART_CHARS}]+)*$'
EMAIL_ADDRESS_REGEX = rf'[{LOCALPART_CHARS}]+(?:\.[{LOCALPART_CHARS}]+)*@(?:[a-z0-9-]+\.)*[a-z]+'
```

`LOCALPART_REGEX` keeps its exact previous value (asserted in the tests), so address creation is untouched. The domain part, the case-insensitive match and the comma-separated list handling are unchanged.

### Behaviour change, in full

I diffed the old and the new pattern over 33 inputs; exactly three results change, all of them widening:

- `~@example.com` → now accepted (the reported bug)
- `a!b@example.com` and the other atext specials → now accepted
- `one@a.com,two@b.c` → now accepted: the old pattern required a 2+ character TLD for the *second and later* addresses while allowing a 1 character TLD for the first one. Both now use the same rule.

Nothing that was accepted before is rejected now, and invalid input stays rejected (`notanemail`, `user@`, `@example.com`, `user@@example.com`, `a..b@example.com`, `one@a.com,,two@b.com`, …).

## Tests

`tests/anonmail/test_4078_forward_destination_localpart.py` drives the real `UserSettingsForm` through a request context:

- `~@example.com` is accepted (RED before this change)
- every special character `LOCALPART_REGEX` allows is accepted as a destination localpart, parametrized (17 of these fail before the change)
- the previously accepted forms still pass (dots, `+tag`, subdomains, mixed case, comma lists with and without spaces)
- invalid destinations are still rejected

Run in a throwaway container against this branch, offline: **93 passed** (`tests/anonmail`, 60 before this PR + 33 new). Without the fix: 18 failed.

A towncrier fragment `4078.bugfix` is included.
