### PR TITLE
Add hardened SCIM 2.0 provisioning

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -465,8 +465,8 @@ jobs:
 # This job runs the headless admin unit tests (anonmail and SCIM) inside the freshly
 # built admin image, so they exercise the exact python interpreter and pinned
 # dependencies that ship in the image instead of a separately installed set. They
-# cover the Flask-Admin models/views/API layer against an in-memory SQLite
-# database, which the docker-compose tests above do not.
+# cover the Flask-Admin models/views/API layer against SQLite, plus the
+# load-bearing SCIM graph races against MariaDB REPEATABLE READ.
   unit-tests:
     name: admin unit tests
     if: contains(inputs.architecture, 'linux/amd64')
@@ -476,6 +476,21 @@ jobs:
       packages: read
     needs:
       - build
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_DATABASE: mailu_scim_test
+          MARIADB_USER: mailu
+          MARIADB_PASSWORD: mailu-test-password
+          MARIADB_ROOT_PASSWORD: mailu-test-root-password
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="healthcheck.sh --connect --innodb_initialized"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
     steps:
       - uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
@@ -496,7 +511,21 @@ jobs:
             -w /app \
             -e PYTHONDONTWRITEBYTECODE=1 \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/scim_test.py"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/address_registry_test.py tests/auth_generation_model_test.py tests/session_authority_test.py tests/scim_group_adopt_test.py tests/scim_identity_model_test.py tests/scim_identity_test.py tests/scim_test.py"
+      - name: Run MariaDB SCIM graph race tests
+        run: |
+          docker run --rm --network host \
+            -v ${{ github.workspace }}/tests:/app/tests:ro \
+            -w /app \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -e SQLALCHEMY_DATABASE_URI=mysql+mysqlconnector://mailu:mailu-test-password@127.0.0.1:3306/mailu_scim_test \
+            -e REDIS_ADDRESS=localhost \
+            -e MEMORY_SESSIONS=true \
+            -e RATELIMIT_STORAGE_URL=memory:// \
+            -e API_TOKEN=not-empty \
+            -e SECRET_KEY=test-secret \
+            ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py -k mysql_"
 
   deploy:
     name: Deploy images

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -511,7 +511,7 @@ jobs:
             -w /app \
             -e PYTHONDONTWRITEBYTECODE=1 \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/address_registry_test.py tests/auth_generation_model_test.py tests/session_authority_test.py tests/scim_group_adopt_test.py tests/scim_identity_model_test.py tests/scim_identity_test.py tests/scim_test.py"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/address_registry_test.py tests/auth_generation_model_test.py tests/config_import_reconcile_test.py tests/session_authority_test.py tests/scim_group_adopt_test.py tests/scim_identity_model_test.py tests/scim_identity_test.py tests/scim_test.py"
       - name: Run MariaDB SCIM graph race tests
         run: |
           docker run --rm --network host \

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -466,7 +466,8 @@ jobs:
 # built admin image, so they exercise the exact python interpreter and pinned
 # dependencies that ship in the image instead of a separately installed set. They
 # cover the Flask-Admin models/views/API layer against SQLite, plus the
-# load-bearing SCIM graph races against MariaDB REPEATABLE READ.
+# load-bearing SCIM graph races against MariaDB using Mailu's configured
+# transaction isolation.
   unit-tests:
     name: admin unit tests
     if: contains(inputs.architecture, 'linux/amd64')
@@ -511,14 +512,28 @@ jobs:
             -w /app \
             -e PYTHONDONTWRITEBYTECODE=1 \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/address_registry_test.py tests/auth_generation_model_test.py tests/config_import_reconcile_test.py tests/session_authority_test.py tests/scim_group_adopt_test.py tests/scim_identity_model_test.py tests/scim_identity_test.py tests/scim_test.py"
-      - name: Run MariaDB SCIM graph race tests
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/address_registry_test.py tests/auth_generation_model_test.py tests/configuration_test.py tests/config_import_reconcile_test.py tests/session_authority_test.py tests/scim_group_adopt_test.py tests/scim_identity_model_test.py tests/scim_identity_test.py tests/scim_test.py"
+      - name: Run MariaDB SCIM graph race tests with mysqlconnector
         run: |
           docker run --rm --network host \
             -v ${{ github.workspace }}/tests:/app/tests:ro \
             -w /app \
             -e PYTHONDONTWRITEBYTECODE=1 \
             -e SQLALCHEMY_DATABASE_URI=mysql+mysqlconnector://mailu:mailu-test-password@127.0.0.1:3306/mailu_scim_test \
+            -e REDIS_ADDRESS=localhost \
+            -e MEMORY_SESSIONS=true \
+            -e RATELIMIT_STORAGE_URL=memory:// \
+            -e API_TOKEN=not-empty \
+            -e SECRET_KEY=test-secret \
+            ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py -k mysql_"
+      - name: Run MariaDB SCIM graph race tests with mariadbconnector
+        run: |
+          docker run --rm --network host \
+            -v ${{ github.workspace }}/tests:/app/tests:ro \
+            -w /app \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -e SQLALCHEMY_DATABASE_URI=mariadb+mariadbconnector://mailu:mailu-test-password@127.0.0.1:3306/mailu_scim_test \
             -e REDIS_ADDRESS=localhost \
             -e MEMORY_SESSIONS=true \
             -e RATELIMIT_STORAGE_URL=memory:// \

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -462,7 +462,7 @@ jobs:
           MAILU_VERSION: ${{ env.MAILU_VERSION }}-build
           PINNED_MAILU_VERSION: ${{ env.PINNED_MAILU_VERSION }}-build
 
-# This job runs the headless admin unit tests (tests/anonmail) inside the freshly
+# This job runs the headless admin unit tests (anonmail and SCIM) inside the freshly
 # built admin image, so they exercise the exact python interpreter and pinned
 # dependencies that ship in the image instead of a separately installed set. They
 # cover the Flask-Admin models/views/API layer against an in-memory SQLite
@@ -489,14 +489,14 @@ jobs:
         uses: ASzc/change-string-case-action@v6
         with:
           string: ${{ github.repository_owner }}
-      - name: Run tests/anonmail inside the admin image
+      - name: Run admin unit tests inside the admin image
         run: |
           docker run --rm \
             -v ${{ github.workspace }}/tests:/app/tests:ro \
             -w /app \
             -e PYTHONDONTWRITEBYTECODE=1 \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/scim_test.py"
 
   deploy:
     name: Deploy images

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -583,7 +583,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or cycle_frontier or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or cycle_full_scan or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
       - name: Run MariaDB populated migration tests with mariadbconnector
         run: |
           docker run --rm --network host \
@@ -612,7 +612,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or cycle_frontier or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or cycle_full_scan or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
 
   deploy:
     name: Deploy images

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -583,7 +583,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
       - name: Run MariaDB populated migration tests with mariadbconnector
         run: |
           docker run --rm --network host \
@@ -612,7 +612,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
 
   deploy:
     name: Deploy images

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -583,7 +583,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py -k 'mysql_ or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
       - name: Run MariaDB populated migration tests with mariadbconnector
         run: |
           docker run --rm --network host \
@@ -612,7 +612,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py -k 'mysql_ or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
 
   deploy:
     name: Deploy images

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -465,9 +465,9 @@ jobs:
 # This job runs the headless admin unit tests (anonmail and SCIM) inside the freshly
 # built admin image, so they exercise the exact python interpreter and pinned
 # dependencies that ship in the image instead of a separately installed set. They
-# cover the Flask-Admin models/views/API layer against SQLite, plus the
-# load-bearing SCIM graph races against MariaDB using Mailu's configured
-# transaction isolation.
+# cover the Flask-Admin models/views/API layer against SQLite, the persistent
+# SCIM identity contracts against PostgreSQL, plus real populated Alembic
+# upgrades and load-bearing graph races against both MariaDB connector paths.
   unit-tests:
     name: admin unit tests
     if: contains(inputs.architecture, 'linux/amd64')
@@ -492,6 +492,19 @@ jobs:
           --health-interval=5s
           --health-timeout=5s
           --health-retries=20
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: mailu_scim_test
+          POSTGRES_USER: mailu
+          POSTGRES_PASSWORD: mailu-test-password
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U mailu -d mailu_scim_test"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
     steps:
       - uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
@@ -512,8 +525,52 @@ jobs:
             -w /app \
             -e PYTHONDONTWRITEBYTECODE=1 \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/address_registry_test.py tests/auth_generation_model_test.py tests/configuration_test.py tests/config_import_reconcile_test.py tests/session_authority_test.py tests/scim_group_adopt_test.py tests/scim_identity_model_test.py tests/scim_identity_test.py tests/scim_test.py"
-      - name: Run MariaDB SCIM graph race tests with mysqlconnector
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/anonmail tests/address_registry_test.py tests/auth_generation_model_test.py tests/configuration_test.py tests/config_import_reconcile_test.py tests/session_authority_test.py tests/scim_group_adopt_test.py tests/scim_identity_model_test.py tests/scim_identity_test.py tests/scim_managed_alias_surface_test.py tests/scim_test.py"
+      - name: Run PostgreSQL populated migration tests
+        run: |
+          docker run --rm --network host \
+            -v ${{ github.workspace }}/tests:/app/tests:ro \
+            -w /app \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -e SQLALCHEMY_DATABASE_URI=postgresql://mailu:mailu-test-password@127.0.0.1:5432/mailu_scim_test \
+            -e MAILU_NATIVE_MIGRATION_TEST=1 \
+            -e REDIS_ADDRESS=localhost \
+            -e MEMORY_SESSIONS=true \
+            -e RATELIMIT_STORAGE_URL=memory:// \
+            -e API_TOKEN=not-empty \
+            -e SECRET_KEY=test-secret \
+            ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_native_migration_test.py"
+      - name: Run PostgreSQL SCIM tests
+        run: |
+          docker run --rm --network host \
+            -v ${{ github.workspace }}/tests:/app/tests:ro \
+            -w /app \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -e SQLALCHEMY_DATABASE_URI=postgresql://mailu:mailu-test-password@127.0.0.1:5432/mailu_scim_test \
+            -e REDIS_ADDRESS=localhost \
+            -e MEMORY_SESSIONS=true \
+            -e RATELIMIT_STORAGE_URL=memory:// \
+            -e API_TOKEN=not-empty \
+            -e SECRET_KEY=test-secret \
+            ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/address_registry_test.py tests/auth_generation_model_test.py tests/config_import_reconcile_test.py tests/session_authority_test.py tests/scim_group_adopt_test.py tests/scim_identity_model_test.py tests/scim_identity_test.py tests/scim_managed_alias_surface_test.py tests/scim_test.py"
+      - name: Run MariaDB populated migration tests with mysqlconnector
+        run: |
+          docker run --rm --network host \
+            -v ${{ github.workspace }}/tests:/app/tests:ro \
+            -w /app \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -e SQLALCHEMY_DATABASE_URI=mysql+mysqlconnector://mailu:mailu-test-password@127.0.0.1:3306/mailu_scim_test \
+            -e MAILU_NATIVE_MIGRATION_TEST=1 \
+            -e REDIS_ADDRESS=localhost \
+            -e MEMORY_SESSIONS=true \
+            -e RATELIMIT_STORAGE_URL=memory:// \
+            -e API_TOKEN=not-empty \
+            -e SECRET_KEY=test-secret \
+            ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_native_migration_test.py"
+      - name: Run MariaDB graph tests with mysqlconnector
         run: |
           docker run --rm --network host \
             -v ${{ github.workspace }}/tests:/app/tests:ro \
@@ -526,8 +583,23 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py -k mysql_"
-      - name: Run MariaDB SCIM graph race tests with mariadbconnector
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py -k 'mysql_ or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+      - name: Run MariaDB populated migration tests with mariadbconnector
+        run: |
+          docker run --rm --network host \
+            -v ${{ github.workspace }}/tests:/app/tests:ro \
+            -w /app \
+            -e PYTHONDONTWRITEBYTECODE=1 \
+            -e SQLALCHEMY_DATABASE_URI=mariadb+mariadbconnector://mailu:mailu-test-password@127.0.0.1:3306/mailu_scim_test \
+            -e MAILU_NATIVE_MIGRATION_TEST=1 \
+            -e REDIS_ADDRESS=localhost \
+            -e MEMORY_SESSIONS=true \
+            -e RATELIMIT_STORAGE_URL=memory:// \
+            -e API_TOKEN=not-empty \
+            -e SECRET_KEY=test-secret \
+            ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_native_migration_test.py"
+      - name: Run MariaDB graph tests with mariadbconnector
         run: |
           docker run --rm --network host \
             -v ${{ github.workspace }}/tests:/app/tests:ro \
@@ -540,7 +612,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py -k mysql_"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py -k 'mysql_ or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
 
   deploy:
     name: Deploy images

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -583,7 +583,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or cycle_frontier or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
       - name: Run MariaDB populated migration tests with mariadbconnector
         run: |
           docker run --rm --network host \
@@ -612,7 +612,7 @@ jobs:
             -e API_TOKEN=not-empty \
             -e SECRET_KEY=test-secret \
             ghcr.io/${{ steps.string.outputs.lowercase }}/admin:${{ inputs.mailu_version }}-build \
-            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
+            sh -c "pip install --no-cache-dir pytest && python -m pytest -v -p no:cacheprovider tests/scim_identity_model_test.py tests/scim_group_adopt_test.py tests/scim_test.py -k 'mysql_ or graph_validation_probe or graph_batch or graph_replace_rolls_back_after_staging or cycle_frontier or group_mutation_post_commit or routing_committed_before_graph_lock or alias_update_losing_adoption_lock_is_rejected'"
 
   deploy:
     name: Deploy images

--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -45,6 +45,8 @@ def create_app_from_config(config):
     # Initialize application extensions
     config.init_app(app)
     models.db.init_app(app)
+    with app.app_context():
+        models.configure_database_engine(models.db.engine)
     utils.session.init_app(app)
     utils.limiter.init_app(app)
     utils.babel.init_app(app, locale_selector=utils.get_locale)
@@ -124,4 +126,3 @@ def create_app():
     """
     config = configuration.ConfigManager()
     return create_app_from_config(config)
-

--- a/core/admin/mailu/__init__.py
+++ b/core/admin/mailu/__init__.py
@@ -49,7 +49,7 @@ def create_app_from_config(config):
     utils.limiter.init_app(app)
     utils.babel.init_app(app, locale_selector=utils.get_locale)
     utils.login.init_app(app)
-    utils.login.user_loader(models.User.get)
+    utils.login.user_loader(utils.load_session_user)
     utils.proxy.init_app(app)
     utils.migrate.init_app(app, models.db)
 

--- a/core/admin/mailu/api/__init__.py
+++ b/core/admin/mailu/api/__init__.py
@@ -2,6 +2,7 @@ from flask import redirect, url_for, Blueprint
 from flask_restx import apidoc
 from . import v1 as APIv1
 from . import simplelogin
+from . import scim
 
 def register(app, web_api_root):
 
@@ -12,6 +13,7 @@ def register(app, web_api_root):
     if app.config['API_TOKEN'] != '':
         # Register SimpleLogin-compatible endpoint (non-versioned for Bitwarden)
         app.register_blueprint(simplelogin.blueprint, url_prefix=f'{web_api_root}')
+        app.register_blueprint(scim.blueprint, url_prefix=f'{web_api_root}/scim/v2')
         app.register_blueprint(APIv1.blueprint, url_prefix=f'{web_api_root}/v{int(APIv1.VERSION)}')
 
         # add redirect to current api version

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -52,12 +52,15 @@ def _payload():
     return data, None
 
 
-def _parse_positive_int(value, default, *, minimum=0):
+def _parse_positive_int(value, default, *, minimum=0, maximum=None):
     try:
         parsed = int(value)
     except (TypeError, ValueError):
         return None
-    return max(parsed, minimum)
+    parsed = max(parsed, minimum)
+    if maximum is not None:
+        parsed = min(parsed, maximum)
+    return parsed
 
 
 def _string_value(value):
@@ -173,9 +176,11 @@ def _apply_user_data(user, data, *, replacing=False):
 
 
 def _patch_user(user, data):
-    operations = data.get('Operations') or data.get('operations') or []
+    operations = data.get('Operations') or data.get('operations')
     if not isinstance(operations, list):
         return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
+    if not operations:
+        return _scim_error(400, 'Operations must not be empty', 'invalidValue')
     for operation in operations:
         if not isinstance(operation, dict):
             return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax')
@@ -313,7 +318,7 @@ def unsupported_groups(group_id=None):
 @blueprint.route('/Users', methods=['GET'])
 def list_users():
     start_index = _parse_positive_int(flask.request.args.get('startIndex', 1), 1, minimum=1)
-    count = _parse_positive_int(flask.request.args.get('count', 100), 100, minimum=0)
+    count = _parse_positive_int(flask.request.args.get('count', 100), 100, minimum=0, maximum=200)
     if start_index is None or count is None:
         return _scim_error(400, 'startIndex and count must be integers', 'invalidValue')
     query = models.User.query.order_by(models.User._email)

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -12,6 +12,8 @@ SCIM_GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group'
 SCIM_LIST_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:ListResponse'
 SCIM_PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'
 SCIM_ERROR_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:Error'
+SCIM_BULK_REQUEST_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest'
+SCIM_BULK_RESPONSE_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:BulkResponse'
 
 blueprint = flask.Blueprint('scim', __name__)
 
@@ -30,6 +32,34 @@ def _scim_response(payload, status=200):
     response.status_code = status
     response.headers['Content-Type'] = 'application/scim+json'
     return response
+
+
+def _response_payload(response):
+    if isinstance(response, tuple):
+        response = response[0]
+    if response.status_code == 204:
+        return None
+    return response.get_json(silent=True)
+
+
+def _resource_version(resource):
+    value = getattr(resource, 'updated_at', None) or getattr(resource, 'created_at', None)
+    if not value:
+        return None
+    return f'W/"{value.isoformat()}"'
+
+
+def _resource_meta(resource_type, collection, resource_id, model):
+    meta = {
+        'resourceType': resource_type,
+        'location': _resource_location(collection, resource_id),
+    }
+    if getattr(model, 'created_at', None):
+        meta['created'] = model.created_at.isoformat()
+    version = _resource_version(model)
+    if version:
+        meta['version'] = version
+    return meta
 
 
 def _scim_error(status, detail, scim_type=None):
@@ -155,12 +185,127 @@ def _make_user_resource(user):
             'primary': True,
             'type': 'work',
         }],
-        'meta': {
-            'resourceType': 'User',
-            'location': _resource_location('Users', email),
-        },
+        'meta': _resource_meta('User', 'Users', email, user),
     }
     return payload
+
+
+def _get_group(group_id):
+    return models.db.session.get(models.Alias, group_id.lower())
+
+
+def _member_values(data):
+    members = data.get('members', [])
+    if members in (None, ''):
+        return [], None
+    if not isinstance(members, list):
+        return None, _scim_error(400, 'members must be a list', 'invalidValue')
+    values = []
+    for member in members:
+        if isinstance(member, str):
+            value = member
+        elif isinstance(member, dict):
+            value = member.get('value')
+        else:
+            return None, _scim_error(400, 'members must contain strings or objects', 'invalidValue')
+        if not isinstance(value, str) or not value.strip():
+            return None, _scim_error(400, 'member values must be non-empty strings', 'invalidValue')
+        value = value.strip().lower()
+        if not validators.email(value):
+            return None, _scim_error(400, f'{value!r} is not a valid member email address', 'invalidValue')
+        if value not in values:
+            values.append(value)
+    return values, None
+
+
+def _group_email(data):
+    for key in ('id', 'displayName'):
+        value = data.get(key)
+        if value not in (None, ''):
+            if not isinstance(value, str):
+                return None, _scim_error(400, f'{key} must be a string', 'invalidValue')
+            return value.strip().lower(), None
+    return '', None
+
+
+def _make_group_resource(group):
+    email = group.email
+    return {
+        'schemas': [SCIM_GROUP_SCHEMA],
+        'id': email,
+        'displayName': group.comment or email,
+        'members': [{
+            'value': destination,
+            'display': destination,
+            '$ref': _resource_location('Users', destination),
+        } for destination in group.destination],
+        'meta': _resource_meta('Group', 'Groups', email, group),
+    }
+
+
+def _validate_alias_domain(email):
+    if not validators.email(email):
+        return None, _scim_error(400, f'{email!r} is not a valid email address', 'invalidValue')
+    localpart, domain_name = email.rsplit('@', 1)
+    domain = models.db.session.get(models.Domain, domain_name)
+    if not domain:
+        return None, _scim_error(404, f'Domain {domain_name} does not exist')
+    if domain.max_aliases != -1 and len(domain.aliases) >= domain.max_aliases:
+        return None, _scim_error(409, f'Too many aliases for domain {domain_name}', 'uniqueness')
+    return (localpart, domain), None
+
+
+def _apply_group_data(group, data, *, replacing=False):
+    if 'displayName' in data and data.get('displayName') != group.email:
+        group.comment = _string_value(data.get('displayName')).strip()
+    if replacing or 'members' in data:
+        members, error = _member_values(data)
+        if error:
+            return error
+        group.destination = members
+    return None
+
+
+def _patch_group(group, data):
+    operations = data['Operations'] if 'Operations' in data else data.get('operations')
+    if not isinstance(operations, list):
+        return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
+    if not operations:
+        return _scim_error(400, 'Operations must not be empty', 'invalidValue')
+    for operation in operations:
+        if not isinstance(operation, dict):
+            return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax')
+        op = _string_value(operation.get('op') or 'replace').lower()
+        path = _string_value(operation.get('path')).lower()
+        value = operation.get('value')
+        if op not in ('add', 'replace', 'remove'):
+            return _scim_error(400, f'Patch operation {op!r} is not supported', 'mutability')
+        if path in ('displayname', '') and op in ('add', 'replace'):
+            if path == 'displayname':
+                group.comment = _string_value(value).strip()
+                continue
+            if isinstance(value, dict) and 'displayName' in value:
+                group.comment = _string_value(value.get('displayName')).strip()
+                continue
+        if path in ('members', ''):
+            if path == 'members':
+                member_data = {'members': value if isinstance(value, list) else [value]}
+            elif isinstance(value, dict) and 'members' in value:
+                member_data = {'members': value.get('members')}
+            else:
+                return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath')
+            members, error = _member_values(member_data)
+            if error:
+                return error
+            if op == 'remove':
+                group.destination = [member for member in group.destination if member not in members]
+            elif op == 'add':
+                group.destination = group.destination + [member for member in members if member not in group.destination]
+            else:
+                group.destination = members
+            continue
+        return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath')
+    return None
 
 
 def _validate_user_domain(email):
@@ -283,11 +428,11 @@ def service_provider_config():
     return _scim_response({
         'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'],
         'patch': {'supported': True},
-        'bulk': {'supported': False, 'maxOperations': 0, 'maxPayloadSize': 0},
+        'bulk': {'supported': True, 'maxOperations': 100, 'maxPayloadSize': 1048576},
         'filter': {'supported': True, 'maxResults': 200},
         'changePassword': {'supported': True},
         'sort': {'supported': False},
-        'etag': {'supported': False},
+        'etag': {'supported': True},
         'authenticationSchemes': [{
             'type': 'oauthbearertoken',
             'name': 'Bearer',
@@ -300,54 +445,189 @@ def service_provider_config():
 
 @blueprint.route('/ResourceTypes', methods=['GET'])
 def resource_types():
-    return _scim_response({
-        'schemas': [SCIM_LIST_SCHEMA],
-        'totalResults': 1,
-        'startIndex': 1,
-        'itemsPerPage': 1,
-        'Resources': [{
+    resources = [
+        {
             'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
             'id': 'User',
             'name': 'User',
             'endpoint': '/Users',
             'schema': SCIM_USER_SCHEMA,
             'meta': {'resourceType': 'ResourceType', 'location': _resource_location('ResourceTypes', 'User')},
-        }],
+        },
+        {
+            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
+            'id': 'Group',
+            'name': 'Group',
+            'endpoint': '/Groups',
+            'schema': SCIM_GROUP_SCHEMA,
+            'meta': {'resourceType': 'ResourceType', 'location': _resource_location('ResourceTypes', 'Group')},
+        },
+    ]
+    return _scim_response({
+        'schemas': [SCIM_LIST_SCHEMA],
+        'totalResults': len(resources),
+        'startIndex': 1,
+        'itemsPerPage': len(resources),
+        'Resources': resources,
     })
 
 
 @blueprint.route('/Schemas', methods=['GET'])
 def schemas():
-    return _scim_response({
-        'schemas': [SCIM_LIST_SCHEMA],
-        'totalResults': 1,
-        'startIndex': 1,
-        'itemsPerPage': 1,
-        'Resources': [{
+    resources = [
+        {
             'id': SCIM_USER_SCHEMA,
             'name': 'User',
             'description': 'Mailu SCIM user schema subset',
             'attributes': [],
             'meta': {'resourceType': 'Schema', 'location': _resource_location('Schemas', SCIM_USER_SCHEMA)},
-        }],
+        },
+        {
+            'id': SCIM_GROUP_SCHEMA,
+            'name': 'Group',
+            'description': 'Mailu SCIM group schema subset backed by aliases',
+            'attributes': [],
+            'meta': {'resourceType': 'Schema', 'location': _resource_location('Schemas', SCIM_GROUP_SCHEMA)},
+        },
+    ]
+    return _scim_response({
+        'schemas': [SCIM_LIST_SCHEMA],
+        'totalResults': len(resources),
+        'startIndex': 1,
+        'itemsPerPage': len(resources),
+        'Resources': resources,
     })
+
+
+def _list_groups_response():
+    start_index = _parse_positive_int(flask.request.args.get('startIndex', 1), 1, minimum=1)
+    count = _parse_positive_int(flask.request.args.get('count', 100), 100, minimum=0, maximum=200)
+    if start_index is None or count is None:
+        return _scim_error(400, 'startIndex and count must be integers', 'invalidValue')
+    query = models.Alias.query.order_by(models.Alias._email)
+
+    filter_value = flask.request.args.get('filter')
+    if filter_value:
+        prefix = 'displayName eq '
+        if not filter_value.startswith(prefix):
+            return _scim_error(400, 'Only displayName eq filters are supported', 'invalidFilter')
+        email = filter_value[len(prefix):].strip().strip('"').lower()
+        query = query.filter_by(email=email)
+
+    total = query.count()
+    groups = query.offset(start_index - 1).limit(count).all() if count else []
+    return _scim_response({
+        'schemas': [SCIM_LIST_SCHEMA],
+        'totalResults': total,
+        'startIndex': start_index,
+        'itemsPerPage': len(groups),
+        'Resources': [_make_group_resource(group) for group in groups],
+    })
+
+
+def _create_group_response(data):
+    email, error = _group_email(data)
+    if error:
+        return error
+    if not email:
+        return _scim_error(400, 'displayName is required', 'invalidValue')
+    if _get_group(email):
+        return _scim_error(409, f'Group {email} already exists', 'uniqueness')
+    domain_data, error = _validate_alias_domain(email)
+    if error:
+        return error
+    localpart, domain = domain_data
+    group = models.Alias(localpart=localpart, domain=domain, destination=[])
+    error = _apply_group_data(group, data, replacing=True)
+    if error:
+        return error
+    models.db.session.add(group)
+    models.db.session.commit()
+    return _scim_response(_make_group_resource(group), 201)
+
+
+def _get_group_response(group_id):
+    group = _get_group(group_id)
+    if not group:
+        return _scim_error(404, f'Group {group_id} cannot be found')
+    return _scim_response(_make_group_resource(group))
+
+
+def _replace_group_response(group_id, data):
+    group = _get_group(group_id)
+    if not group:
+        return _scim_error(404, f'Group {group_id} cannot be found')
+    new_email, error = _group_email(data)
+    if error:
+        return error
+    if new_email and new_email != group.email:
+        return _scim_error(400, 'Changing group id/displayName is not supported', 'mutability')
+    error = _apply_group_data(group, data, replacing=True)
+    if error:
+        return error
+    models.db.session.add(group)
+    models.db.session.commit()
+    return _scim_response(_make_group_resource(group))
+
+
+def _patch_group_response(group_id, data):
+    group = _get_group(group_id)
+    if not group:
+        return _scim_error(404, f'Group {group_id} cannot be found')
+    error = _patch_group(group, data)
+    if error:
+        return error
+    models.db.session.add(group)
+    models.db.session.commit()
+    return _scim_response(_make_group_resource(group))
+
+
+def _delete_group_response(group_id):
+    group = _get_group(group_id)
+    if not group:
+        return '', 204
+    models.db.session.delete(group)
+    models.db.session.commit()
+    return '', 204
 
 
 @blueprint.route('/Groups', methods=['GET'])
 def list_groups():
-    return _scim_response({
-        'schemas': [SCIM_LIST_SCHEMA],
-        'totalResults': 0,
-        'startIndex': 1,
-        'itemsPerPage': 0,
-        'Resources': [],
-    })
+    return _list_groups_response()
 
 
 @blueprint.route('/Groups', methods=['POST'])
-@blueprint.route('/Groups/<path:group_id>', methods=['GET', 'PUT', 'PATCH', 'DELETE'])
-def unsupported_groups(group_id=None):
-    return _scim_error(501, 'Mailu SCIM currently provisions users only; groups are not supported')
+def create_group():
+    data, error = _payload()
+    if error:
+        return error
+    return _create_group_response(data)
+
+
+@blueprint.route('/Groups/<path:group_id>', methods=['GET'])
+def get_group(group_id):
+    return _get_group_response(group_id)
+
+
+@blueprint.route('/Groups/<path:group_id>', methods=['PUT'])
+def replace_group(group_id):
+    data, error = _payload()
+    if error:
+        return error
+    return _replace_group_response(group_id, data)
+
+
+@blueprint.route('/Groups/<path:group_id>', methods=['PATCH'])
+def patch_group(group_id):
+    data, error = _payload()
+    if error:
+        return error
+    return _patch_group_response(group_id, data)
+
+
+@blueprint.route('/Groups/<path:group_id>', methods=['DELETE'])
+def delete_group(group_id):
+    return _delete_group_response(group_id)
 
 
 @blueprint.route('/Users', methods=['GET'])
@@ -377,11 +657,7 @@ def list_users():
     })
 
 
-@blueprint.route('/Users', methods=['POST'])
-def create_user():
-    data, error = _payload()
-    if error:
-        return error
+def _create_user_response(data):
     email, error = _user_email(data)
     if error:
         return error
@@ -414,14 +690,10 @@ def get_user(user_id):
     return _scim_response(_make_user_resource(user))
 
 
-@blueprint.route('/Users/<path:user_id>', methods=['PUT'])
-def replace_user(user_id):
+def _replace_user_response(user_id, data):
     user = _get_user(user_id)
     if not user:
         return _scim_error(404, f'User {user_id} cannot be found')
-    data, error = _payload()
-    if error:
-        return error
     new_email, error = _user_email(data)
     if error:
         return error
@@ -435,14 +707,10 @@ def replace_user(user_id):
     return _scim_response(_make_user_resource(user))
 
 
-@blueprint.route('/Users/<path:user_id>', methods=['PATCH'])
-def patch_user(user_id):
+def _patch_user_response(user_id, data):
     user = _get_user(user_id)
     if not user:
         return _scim_error(404, f'User {user_id} cannot be found')
-    data, error = _payload()
-    if error:
-        return error
     error = _patch_user(user, data)
     if error:
         return error
@@ -451,8 +719,7 @@ def patch_user(user_id):
     return _scim_response(_make_user_resource(user))
 
 
-@blueprint.route('/Users/<path:user_id>', methods=['DELETE'])
-def delete_user(user_id):
+def _delete_user_response(user_id):
     user = _get_user(user_id)
     if not user:
         return '', 204
@@ -460,3 +727,128 @@ def delete_user(user_id):
     models.db.session.add(user)
     models.db.session.commit()
     return '', 204
+
+@blueprint.route('/Users', methods=['POST'])
+def create_user():
+    data, error = _payload()
+    if error:
+        return error
+    return _create_user_response(data)
+
+
+@blueprint.route('/Users/<path:user_id>', methods=['PUT'])
+def replace_user(user_id):
+    data, error = _payload()
+    if error:
+        return error
+    return _replace_user_response(user_id, data)
+
+
+@blueprint.route('/Users/<path:user_id>', methods=['PATCH'])
+def patch_user(user_id):
+    data, error = _payload()
+    if error:
+        return error
+    return _patch_user_response(user_id, data)
+
+
+@blueprint.route('/Users/<path:user_id>', methods=['DELETE'])
+def delete_user(user_id):
+    return _delete_user_response(user_id)
+
+
+def _bulk_response(operation, bulk_ids):
+    method = _string_value(operation.get('method')).upper()
+    path = _string_value(operation.get('path')).lstrip('/')
+    data = operation.get('data') or {}
+    if not method or not path:
+        return {'status': '400', 'response': _response_payload(_scim_error(400, 'Bulk operations require method and path', 'invalidValue'))}, None
+    if not isinstance(data, dict):
+        return {'status': '400', 'response': _response_payload(_scim_error(400, 'Bulk operation data must be an object', 'invalidSyntax'))}, None
+
+    for key, value in list(data.items()):
+        if isinstance(value, str) and value.startswith('bulkId:'):
+            data[key] = bulk_ids.get(value[7:], value)
+
+    parts = path.split('/', 1)
+    collection = parts[0]
+    resource_id = parts[1] if len(parts) > 1 else None
+    if collection == 'Users':
+        if method == 'POST' and resource_id is None:
+            response = _create_user_response(data)
+        elif method == 'GET' and resource_id:
+            response = get_user(resource_id)
+        elif method == 'PUT' and resource_id:
+            response = _replace_user_response(resource_id, data)
+        elif method == 'PATCH' and resource_id:
+            response = _patch_user_response(resource_id, data)
+        elif method == 'DELETE' and resource_id:
+            response = _delete_user_response(resource_id)
+        else:
+            response = _scim_error(400, f'Unsupported bulk path {path!r}', 'invalidPath')
+    elif collection == 'Groups':
+        if method == 'POST' and resource_id is None:
+            response = _create_group_response(data)
+        elif method == 'GET' and resource_id:
+            response = _get_group_response(resource_id)
+        elif method == 'PUT' and resource_id:
+            response = _replace_group_response(resource_id, data)
+        elif method == 'PATCH' and resource_id:
+            response = _patch_group_response(resource_id, data)
+        elif method == 'DELETE' and resource_id:
+            response = _delete_group_response(resource_id)
+        else:
+            response = _scim_error(400, f'Unsupported bulk path {path!r}', 'invalidPath')
+    else:
+        response = _scim_error(400, f'Unsupported bulk path {path!r}', 'invalidPath')
+
+    if isinstance(response, tuple):
+        status = response[1]
+        payload = None
+        location = None
+    else:
+        status = response.status_code
+        payload = _response_payload(response)
+        location = payload.get('meta', {}).get('location') if isinstance(payload, dict) else None
+    item = {'status': str(status)}
+    if operation.get('bulkId'):
+        item['bulkId'] = operation['bulkId']
+    if location:
+        item['location'] = location
+    if payload is not None:
+        item['response'] = payload
+    resource_id = payload.get('id') if isinstance(payload, dict) else None
+    return item, resource_id
+
+
+@blueprint.route('/Bulk', methods=['POST'])
+def bulk():
+    data, error = _payload()
+    if error:
+        return error
+    operations = data.get('Operations') or data.get('operations')
+    if not isinstance(operations, list):
+        return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
+    if len(operations) > 100:
+        return _scim_error(413, 'Too many bulk operations', 'tooMany')
+    fail_on_errors = _parse_positive_int(data.get('failOnErrors', len(operations)), len(operations), minimum=0)
+    responses = []
+    errors = 0
+    bulk_ids = {}
+    for operation in operations:
+        if not isinstance(operation, dict):
+            responses.append({'status': '400', 'response': _response_payload(_scim_error(400, 'Bulk operations must be objects', 'invalidSyntax'))})
+            errors += 1
+        else:
+            response, resource_id = _bulk_response(operation, bulk_ids)
+            responses.append(response)
+            if operation.get('bulkId') and resource_id:
+                bulk_ids[operation['bulkId']] = resource_id
+            if int(response['status']) >= 400:
+                errors += 1
+        if fail_on_errors and errors >= fail_on_errors:
+            break
+    return _scim_response({
+        'schemas': [SCIM_BULK_RESPONSE_SCHEMA],
+        'Operations': responses,
+    })

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -71,6 +71,14 @@ def _string_value(value):
     return str(value)
 
 
+def _password_value(value):
+    if value in (None, ''):
+        return None, None
+    if not isinstance(value, str):
+        return None, _scim_error(400, 'password must be a string', 'invalidValue')
+    return value, None
+
+
 def _active_value(value):
     if isinstance(value, bool):
         return value, None
@@ -170,8 +178,11 @@ def _apply_user_data(user, data, *, replacing=False):
     display_name = _display_name(data)
     if display_name:
         user.displayed_name = display_name
-    if data.get('password'):
-        user.set_password(data['password'])
+    password, error = _password_value(data.get('password'))
+    if error:
+        return error
+    if password:
+        user.set_password(password)
     return None
 
 
@@ -222,10 +233,16 @@ def _patch_user(user, data):
                 handled = True
         if path in ('password', ''):
             if path == 'password' and value:
-                user.set_password(_string_value(value))
+                password, error = _password_value(value)
+                if error:
+                    return error
+                user.set_password(password)
                 handled = True
             elif isinstance(value, dict) and value.get('password'):
-                user.set_password(_string_value(value['password']))
+                password, error = _password_value(value['password'])
+                if error:
+                    return error
+                user.set_password(password)
                 handled = True
         if not handled:
             return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath')
@@ -356,8 +373,11 @@ def create_user():
     if error:
         return error
     localpart, domain = domain_data
+    password, error = _password_value(data.get('password'))
+    if error:
+        return error
     user = models.User(localpart=localpart, domain=domain)
-    user.set_password(data.get('password') or secrets.token_urlsafe())
+    user.set_password(password or secrets.token_urlsafe())
     error = _apply_user_data(user, data, replacing=True)
     if error:
         return error

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -1,10 +1,18 @@
+import hashlib
+import json
+import re
 import secrets
+import urllib.parse
 
 import flask
+import sqlalchemy
 import validators
+from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from werkzeug.exceptions import HTTPException
+from werkzeug.http import parse_etags, unquote_etag
 
 from . import common
-from .. import models
+from .. import models, utils
 
 
 SCIM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User'
@@ -14,8 +22,97 @@ SCIM_PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'
 SCIM_ERROR_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:Error'
 SCIM_BULK_REQUEST_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest'
 SCIM_BULK_RESPONSE_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:BulkResponse'
+SCIM_SCHEMA_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Schema'
 
 blueprint = flask.Blueprint('scim', __name__)
+_IF_MATCH_FROM_REQUEST = object()
+SCIM_MAX_BULK_OPERATIONS = 100
+SCIM_MAX_BULK_PAYLOAD_SIZE = 1048576
+_FILTER_PATTERN = re.compile(r'^\s*([A-Za-z][A-Za-z0-9.]*)\s+eq\s+"([^"]*)"\s*$', re.IGNORECASE)
+_MEMBER_FILTER_PATTERN = re.compile(
+    r'^\s*members\s*\[\s*value\s+eq\s+"([^"]+)"\s*\]\s*$',
+    re.IGNORECASE,
+)
+_PROJECTION_SEGMENT_PATTERN = re.compile(r'^[A-Za-z][A-Za-z0-9_-]*$')
+_INVALID_PERCENT_ESCAPE = re.compile(r'%(?![0-9A-Fa-f]{2})')
+_SCIM_KEY_CASES = {
+    key.lower(): key
+    for key in (
+        'Operations',
+        'active',
+        'bulkId',
+        'data',
+        'displayName',
+        'emails',
+        'externalId',
+        'failOnErrors',
+        'familyName',
+        'formatted',
+        'givenName',
+        'id',
+        'members',
+        'method',
+        'name',
+        'op',
+        'password',
+        'path',
+        'primary',
+        'schemas',
+        'type',
+        'userName',
+        'value',
+        'version',
+    )
+}
+_USER_PROJECTION_PATHS = {
+    ('active',),
+    ('displayname',),
+    ('emails',),
+    ('emails', 'primary'),
+    ('emails', 'type'),
+    ('emails', 'value'),
+    ('id',),
+    ('meta',),
+    ('meta', 'location'),
+    ('meta', 'resourcetype'),
+    ('meta', 'version'),
+    ('name',),
+    ('name', 'formatted'),
+    ('password',),
+    ('schemas',),
+    ('username',),
+}
+_GROUP_PROJECTION_PATHS = {
+    ('displayname',),
+    ('id',),
+    ('members',),
+    ('members', 'display'),
+    ('members', 'value'),
+    ('meta',),
+    ('meta', 'location'),
+    ('meta', 'resourcetype'),
+    ('meta', 'version'),
+    ('schemas',),
+}
+_USER_PROJECTION_ENDPOINTS = {
+    'create_user',
+    'get_user',
+    'list_users',
+    'patch_user',
+    'replace_user',
+}
+_GROUP_PROJECTION_ENDPOINTS = {
+    'create_group',
+    'get_group',
+    'list_groups',
+    'patch_group',
+    'replace_group',
+}
+_MISSING_PROJECTION_PATH = object()
+
+
+class _AmbiguousScimKeys(ValueError):
+    pass
 
 
 def _base_url():
@@ -24,13 +121,161 @@ def _base_url():
 
 
 def _resource_location(resource, resource_id):
-    return f'{_base_url()}/{resource}/{resource_id}'
+    encoded_id = urllib.parse.quote(str(resource_id), safe='@')
+    return f'{_base_url()}/{resource}/{encoded_id}'
+
+
+def _projection_context():
+    endpoint = (flask.request.endpoint or '').rsplit('.', 1)[-1]
+    if endpoint in _USER_PROJECTION_ENDPOINTS:
+        return SCIM_USER_SCHEMA, _USER_PROJECTION_PATHS
+    if endpoint in _GROUP_PROJECTION_ENDPOINTS:
+        return SCIM_GROUP_SCHEMA, _GROUP_PROJECTION_PATHS
+    return None
+
+
+def _projection_path(value, schema, allowed_paths):
+    path = value.strip()
+    prefix = f'{schema}:'
+    if path.casefold().startswith('urn:'):
+        if not path.casefold().startswith(prefix.casefold()):
+            return None
+        path = path[len(prefix):]
+    elif ':' in path:
+        return None
+    parts = path.split('.')
+    if (
+        not path
+        or any(not _PROJECTION_SEGMENT_PATTERN.fullmatch(part) for part in parts)
+    ):
+        return None
+    normalized = tuple(
+        _SCIM_KEY_CASES.get(part.casefold(), part).casefold()
+        for part in parts
+    )
+    return normalized if normalized in allowed_paths else None
+
+
+def _projection_parameters():
+    context = _projection_context()
+    if context is None:
+        return None, None, None
+    schema, allowed_paths = context
+    included_values = flask.request.args.getlist('attributes')
+    excluded_values = flask.request.args.getlist('excludedAttributes')
+    if included_values and excluded_values:
+        return None, None, 'attributes and excludedAttributes are mutually exclusive'
+    mode = 'include' if included_values else ('exclude' if excluded_values else None)
+    raw_values = included_values or excluded_values
+    if not raw_values:
+        return None, None, None
+    paths = []
+    for raw_value in raw_values:
+        for raw_path in raw_value.split(','):
+            path = _projection_path(raw_path, schema, allowed_paths)
+            if path is None:
+                return (
+                    None,
+                    None,
+                    'Attribute projection paths must be non-empty attribute paths',
+                )
+            if path not in paths:
+                paths.append(path)
+    return mode, paths, None
+
+
+def _projection_tree(paths):
+    tree = {}
+    for path in paths:
+        node = tree
+        for index, part in enumerate(path):
+            if part in node and node[part] is None:
+                break
+            if index == len(path) - 1:
+                node[part] = None
+            else:
+                node = node.setdefault(part, {})
+    return tree
+
+
+def _project_value(value, tree, *, include):
+    if not tree:
+        return value
+    if isinstance(value, list):
+        return [
+            _project_value(item, tree, include=include)
+            for item in value
+        ]
+    if not isinstance(value, dict):
+        return value
+    projected = {}
+    for key, item in value.items():
+        selected = tree.get(key.casefold(), _MISSING_PROJECTION_PATH)
+        if include:
+            if selected is not _MISSING_PROJECTION_PATH:
+                projected[key] = (
+                    item
+                    if selected is None
+                    else _project_value(item, selected, include=True)
+                )
+        elif selected is _MISSING_PROJECTION_PATH:
+            projected[key] = item
+        elif selected is not None:
+            projected[key] = _project_value(item, selected, include=False)
+    return projected
+
+
+def _always_returned(resource):
+    return {'schemas', 'id'}
+
+
+def _project_resource(resource, mode, paths):
+    if not isinstance(resource, dict):
+        return resource
+    tree = _projection_tree(paths)
+    projected = _project_value(resource, tree, include=mode == 'include')
+    for key in _always_returned(resource):
+        for source_key, value in resource.items():
+            if source_key.casefold() == key.casefold():
+                projected[source_key] = value
+                break
+    return projected
+
+
+def _project_payload(payload):
+    if _projection_context() is None or not isinstance(payload, dict):
+        return payload
+    mode, paths, error = _projection_parameters()
+    if error or mode is None:
+        return payload
+    if isinstance(payload.get('Resources'), list):
+        projected = dict(payload)
+        projected['Resources'] = [
+            _project_resource(resource, mode, paths)
+            for resource in payload['Resources']
+        ]
+        return projected
+    return _project_resource(payload, mode, paths)
 
 
 def _scim_response(payload, status=200):
+    original_payload = payload
+    if 200 <= status < 300:
+        payload = _project_payload(payload)
     response = flask.jsonify(payload)
     response.status_code = status
     response.headers['Content-Type'] = 'application/scim+json'
+    if isinstance(original_payload, dict):
+        meta = original_payload.get('meta')
+        if isinstance(meta, dict):
+            version = meta.get('version')
+            location = meta.get('location')
+            if isinstance(version, str):
+                response.headers['ETag'] = version
+            if isinstance(location, str):
+                response.headers['Content-Location'] = location
+                if status == 201:
+                    response.headers['Location'] = location
     return response
 
 
@@ -42,11 +287,33 @@ def _response_payload(response):
     return response.get_json(silent=True)
 
 
+def _not_modified(version):
+    response = flask.Response(status=304)
+    response.headers['ETag'] = version
+    return response
+
+
 def _resource_version(resource):
-    value = getattr(resource, 'updated_at', None) or getattr(resource, 'created_at', None)
-    if not value:
-        return None
-    return f'W/"{value.isoformat()}"'
+    if isinstance(resource, models.User):
+        state = {
+            'active': resource.enabled,
+            'displayName': resource.displayed_name,
+            'id': resource.email,
+            'password': resource.password,
+        }
+    elif isinstance(resource, models.Alias):
+        state = {
+            'displayName': resource.comment,
+            'id': resource.email,
+            'members': list(resource.destination),
+        }
+    else:
+        state = {
+            'created': getattr(resource, 'created_at', None),
+            'updated': getattr(resource, 'updated_at', None),
+        }
+    encoded = json.dumps(state, default=str, separators=(',', ':'), sort_keys=True).encode()
+    return f'"{hashlib.sha256(encoded).hexdigest()}"'
 
 
 def _resource_meta(resource_type, collection, resource_id, model):
@@ -54,12 +321,77 @@ def _resource_meta(resource_type, collection, resource_id, model):
         'resourceType': resource_type,
         'location': _resource_location(collection, resource_id),
     }
-    if getattr(model, 'created_at', None):
-        meta['created'] = model.created_at.isoformat()
     version = _resource_version(model)
     if version:
         meta['version'] = version
     return meta
+
+
+def _get_for_update(model, resource_id):
+    session = models.db.session()
+    if models.db.engine.dialect.name == 'sqlite':
+        session.execute(sqlalchemy.text('BEGIN IMMEDIATE'))
+        return session.get(model, resource_id, populate_existing=True)
+    return session.get(
+        model,
+        resource_id,
+        populate_existing=True,
+        with_for_update=True,
+    )
+
+
+def _locked_resource(model, resource_id):
+    try:
+        return _get_for_update(model, resource_id), None
+    except SQLAlchemyError:
+        models.db.session.rollback()
+        flask.current_app.logger.exception('SCIM database lock failed')
+        return None, _scim_error(500, 'The SCIM resource could not be locked')
+
+
+def _if_match_error(resource, value=_IF_MATCH_FROM_REQUEST):
+    if value is _IF_MATCH_FROM_REQUEST:
+        value = flask.request.headers.get('If-Match')
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return _scim_error(400, 'version must be an entity-tag string', 'invalidValue')
+    if resource is None:
+        return _scim_error(412, 'If-Match does not match the current resource version')
+    candidates = parse_etags(value)
+    current = _resource_version(resource)
+    current_opaque, current_is_weak = unquote_etag(current)
+    if candidates.star_tag or (not current_is_weak and candidates.contains(current_opaque)):
+        return None
+    return _scim_error(412, 'If-Match does not match the current resource version')
+
+
+def _conditional_read_response(resource):
+    error = _if_match_error(resource)
+    if error:
+        return error
+    value = flask.request.headers.get('If-None-Match')
+    if value is None:
+        return None
+    candidates = parse_etags(value)
+    current = _resource_version(resource)
+    current_opaque, _ = unquote_etag(current)
+    if candidates.star_tag or candidates.contains_weak(current_opaque):
+        return _not_modified(current)
+    return None
+
+
+def _if_none_match_error(resource, value=_IF_MATCH_FROM_REQUEST):
+    if value is _IF_MATCH_FROM_REQUEST:
+        value = flask.request.headers.get('If-None-Match')
+    if value is None or resource is None:
+        return None
+    candidates = parse_etags(value)
+    current = _resource_version(resource)
+    current_opaque, _ = unquote_etag(current)
+    if candidates.star_tag or candidates.contains_weak(current_opaque):
+        return _scim_error(412, 'If-None-Match matches the current resource version')
+    return None
 
 
 def _scim_error(status, detail, scim_type=None):
@@ -73,6 +405,40 @@ def _scim_error(status, detail, scim_type=None):
     return _scim_response(payload, status)
 
 
+def _commit_error():
+    try:
+        models.db.session.commit()
+    except SQLAlchemyError:
+        models.db.session.rollback()
+        flask.current_app.logger.exception('SCIM database commit failed')
+        return _scim_error(500, 'The SCIM resource change could not be committed')
+    return None
+
+
+def _commit_user_change(user, *, prune_sessions):
+    if prune_sessions:
+        try:
+            utils.MailuSessionExtension.prune_sessions(uid=user.email)
+        except Exception:
+            models.db.session.rollback()
+            flask.current_app.logger.exception('SCIM session revocation failed')
+            return _scim_error(500, 'Existing sessions could not be revoked')
+    return _commit_error()
+
+
+@blueprint.errorhandler(HTTPException)
+def _http_error(error):
+    detail = getattr(error, 'description', None) or str(error)
+    return _scim_error(error.code or 500, detail)
+
+
+@blueprint.errorhandler(SQLAlchemyError)
+def _database_error(_error):
+    models.db.session.rollback()
+    flask.current_app.logger.exception('Unhandled SCIM database error')
+    return _scim_error(500, 'The SCIM database operation failed')
+
+
 def _payload():
     data = flask.request.get_json(silent=True)
     if data is None:
@@ -81,7 +447,38 @@ def _payload():
         return {}, None
     if not isinstance(data, dict):
         return None, _scim_error(400, 'Request body must be a JSON object', 'invalidSyntax')
-    return data, None
+    try:
+        return _normalize_scim_keys(data), None
+    except _AmbiguousScimKeys as error:
+        return None, _scim_error(400, str(error), 'invalidSyntax')
+
+
+def _normalize_scim_keys(value):
+    if isinstance(value, list):
+        return [_normalize_scim_keys(item) for item in value]
+    if isinstance(value, dict):
+        normalized = {}
+        source_keys = {}
+        for key, item in value.items():
+            normalized_key = (
+                _SCIM_KEY_CASES.get(key.casefold(), key)
+                if isinstance(key, str)
+                else key
+            )
+            collision_key = (
+                normalized_key.casefold()
+                if isinstance(normalized_key, str)
+                else normalized_key
+            )
+            if collision_key in source_keys:
+                raise _AmbiguousScimKeys(
+                    f'Attributes {source_keys[collision_key]!r} and {key!r} '
+                    'are case-equivalent'
+                )
+            source_keys[collision_key] = key
+            normalized[normalized_key] = _normalize_scim_keys(item)
+        return normalized
+    return value
 
 
 def _parse_positive_int(value, default, *, minimum=0, maximum=None):
@@ -95,12 +492,46 @@ def _parse_positive_int(value, default, *, minimum=0, maximum=None):
     return parsed
 
 
+def _equality_filter(value, supported_attribute):
+    match = _FILTER_PATTERN.fullmatch(value)
+    if not match or match.group(1).lower() != supported_attribute.lower():
+        return None, _scim_error(
+            400,
+            f'Only {supported_attribute} eq filters with a quoted value are supported',
+            'invalidFilter',
+        )
+    return match.group(2), None
+
+
+def _schema_error(data, expected):
+    schemas = data.get('schemas')
+    if (
+        not isinstance(schemas, list)
+        or len(schemas) != 1
+        or not isinstance(schemas[0], str)
+        or schemas[0].casefold() != expected.casefold()
+    ):
+        return _scim_error(
+            400,
+            f'schemas must contain exactly {expected}',
+            'invalidValue',
+        )
+    return None
+
+
 def _string_value(value):
     if value is None:
         return ''
     if isinstance(value, str):
         return value
     return str(value)
+
+
+def _schema_path(path, schema):
+    prefix = f'{schema}:'
+    if path.lower().startswith(prefix.lower()):
+        return path[len(prefix):]
+    return path
 
 
 def _password_value(value):
@@ -123,21 +554,27 @@ def _active_value(value):
     return None, _scim_error(400, 'active must be a boolean', 'invalidValue')
 
 
-def _user_email(data):
+def _user_email(data, *, require_user_name=False, conflict_scim_type='invalidValue'):
+    values = []
     user_name = data.get('userName')
+    if require_user_name and (
+        not isinstance(user_name, str)
+        or not user_name.strip()
+    ):
+        return None, _scim_error(400, 'userName is required', 'invalidValue')
     if user_name not in (None, ''):
         if not isinstance(user_name, str):
             return None, _scim_error(400, 'userName must be a string', 'invalidValue')
         user_name = user_name.strip().lower()
         if user_name:
-            return user_name, None
+            values.append(user_name)
 
     emails = data.get('emails') or []
     if not isinstance(emails, list):
         return None, _scim_error(400, 'emails must be a list', 'invalidValue')
     for email in emails:
         if not isinstance(email, dict):
-            continue
+            return None, _scim_error(400, 'emails must contain objects', 'invalidValue')
         value = email.get('value')
         if value in (None, ''):
             continue
@@ -145,27 +582,52 @@ def _user_email(data):
             return None, _scim_error(400, 'email values must be strings', 'invalidValue')
         value = value.strip().lower()
         if value:
-            return value, None
-    return '', None
+            values.append(value)
+    unique_values = list(dict.fromkeys(values))
+    if len(unique_values) > 1:
+        return None, _scim_error(
+            400,
+            'userName and emails must identify the same mailbox',
+            conflict_scim_type,
+        )
+    return (unique_values[0] if unique_values else ''), None
 
 
 def _display_name(data):
     if data.get('displayName') is not None:
-        display_name = _string_value(data.get('displayName')).strip()
+        if not isinstance(data['displayName'], str):
+            return None, _scim_error(400, 'displayName must be a string', 'invalidValue')
+        display_name = data['displayName'].strip()
         if display_name:
-            return display_name
+            return display_name, None
     name = data.get('name') or {}
     if not isinstance(name, dict):
-        return ''
-    formatted = _string_value(name.get('formatted')).strip()
+        return None, _scim_error(400, 'name must be an object', 'invalidValue')
+    for attribute in ('formatted', 'givenName', 'familyName'):
+        if name.get(attribute) is not None and not isinstance(name[attribute], str):
+            return None, _scim_error(400, f'name.{attribute} must be a string', 'invalidValue')
+    formatted = (name.get('formatted') or '').strip()
     if formatted:
-        return formatted
-    parts = [_string_value(name.get('givenName')).strip(), _string_value(name.get('familyName')).strip()]
-    return ' '.join(part for part in parts if part)
+        return formatted, None
+    parts = [(name.get('givenName') or '').strip(), (name.get('familyName') or '').strip()]
+    return ' '.join(part for part in parts if part), None
+
+
+def _resource_id(value, resource_type):
+    if not isinstance(value, str) or not validators.email(value):
+        return None, _scim_error(
+            400,
+            f'{resource_type} id must be a valid email address',
+            'invalidValue',
+        )
+    return value.lower(), None
 
 
 def _get_user(user_id):
-    return models.db.session.get(models.User, user_id.lower())
+    if not isinstance(user_id, str) or not validators.email(user_id):
+        return None
+    user_id = user_id.lower()
+    return models.db.session.get(models.User, user_id)
 
 
 def _make_user_resource(user):
@@ -173,7 +635,6 @@ def _make_user_resource(user):
     payload = {
         'schemas': [SCIM_USER_SCHEMA],
         'id': email,
-        'externalId': email,
         'userName': email,
         'active': user.enabled,
         'displayName': user.displayed_name or email,
@@ -191,7 +652,10 @@ def _make_user_resource(user):
 
 
 def _get_group(group_id):
-    return models.db.session.get(models.Alias, group_id.lower())
+    if not isinstance(group_id, str) or not validators.email(group_id):
+        return None
+    group_id = group_id.lower()
+    return models.db.session.get(models.Alias, group_id)
 
 
 def _member_values(data):
@@ -237,17 +701,21 @@ def _make_group_resource(group):
         'members': [{
             'value': destination,
             'display': destination,
-            '$ref': _resource_location('Users', destination),
         } for destination in group.destination],
         'meta': _resource_meta('Group', 'Groups', email, group),
     }
 
 
-def _validate_alias_domain(email):
+def _validate_alias_domain(email, *, for_update=False):
     if not validators.email(email):
         return None, _scim_error(400, f'{email!r} is not a valid email address', 'invalidValue')
     localpart, domain_name = email.rsplit('@', 1)
-    domain = models.db.session.get(models.Domain, domain_name)
+    if for_update:
+        domain, error = _locked_resource(models.Domain, domain_name)
+        if error:
+            return None, error
+    else:
+        domain = models.db.session.get(models.Domain, domain_name)
     if not domain:
         return None, _scim_error(404, f'Domain {domain_name} does not exist')
     if domain.max_aliases != -1 and len(domain.aliases) >= domain.max_aliases:
@@ -256,8 +724,12 @@ def _validate_alias_domain(email):
 
 
 def _apply_group_data(group, data, *, replacing=False):
-    if 'displayName' in data and data.get('displayName') != group.email:
-        group.comment = _string_value(data.get('displayName')).strip()
+    if 'displayName' in data:
+        if not isinstance(data['displayName'], str):
+            return _scim_error(400, 'displayName must be a string', 'invalidValue')
+        group.comment = '' if data['displayName'].strip().lower() == group.email else data['displayName'].strip()
+    elif replacing:
+        group.comment = ''
     if replacing or 'members' in data:
         members, error = _member_values(data)
         if error:
@@ -272,47 +744,102 @@ def _patch_group(group, data):
         return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
     if not operations:
         return _scim_error(400, 'Operations must not be empty', 'invalidValue')
+    comment = group.comment or ''
+    members = list(group.destination)
     for operation in operations:
         if not isinstance(operation, dict):
             return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax')
-        op = _string_value(operation.get('op') or 'replace').lower()
-        path = _string_value(operation.get('path')).lower()
+        op_value = operation.get('op')
+        if not isinstance(op_value, str) or not op_value:
+            return _scim_error(400, 'Patch op must be a non-empty string', 'invalidSyntax')
+        op = op_value.lower()
+        path_value = operation.get('path')
+        if path_value is not None and not isinstance(path_value, str):
+            return _scim_error(400, 'Patch path must be a string', 'invalidPath')
+        path = _schema_path((path_value or '').strip(), SCIM_GROUP_SCHEMA)
+        path_lower = path.lower()
         value = operation.get('value')
         if op not in ('add', 'replace', 'remove'):
             return _scim_error(400, f'Patch operation {op!r} is not supported', 'mutability')
-        if path in ('displayname', '') and op in ('add', 'replace'):
-            if path == 'displayname':
-                group.comment = _string_value(value).strip()
-                continue
-            if isinstance(value, dict) and 'displayName' in value:
-                group.comment = _string_value(value.get('displayName')).strip()
-                continue
-        if path in ('members', ''):
-            if path == 'members':
-                member_data = {'members': value if isinstance(value, list) else [value]}
-            elif isinstance(value, dict) and 'members' in value:
-                member_data = {'members': value.get('members')}
+
+        member_filter = _MEMBER_FILTER_PATTERN.fullmatch(path)
+        if member_filter:
+            if op != 'remove' or value is not None:
+                return _scim_error(
+                    400,
+                    'Filtered members paths are supported only for remove without a value',
+                    'invalidPath',
+                )
+            filtered_members, error = _member_values({'members': [member_filter.group(1)]})
+            if error:
+                return error
+            members = [member for member in members if member not in filtered_members]
+            continue
+
+        if path_lower == 'displayname':
+            if op == 'remove':
+                return _scim_error(400, 'Group displayName is required', 'mutability')
+            elif not isinstance(value, str):
+                return _scim_error(400, 'displayName must be a string', 'invalidValue')
             else:
-                return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath')
-            members, error = _member_values(member_data)
+                comment = '' if value.strip().lower() == group.email else value.strip()
+            continue
+
+        if path_lower == 'members':
+            if op == 'remove' and value is None:
+                members = []
+                continue
+            member_data = {'members': value if isinstance(value, list) else [value]}
+            patch_members, error = _member_values(member_data)
             if error:
                 return error
             if op == 'remove':
-                group.destination = [member for member in group.destination if member not in members]
+                members = [member for member in members if member not in patch_members]
             elif op == 'add':
-                group.destination = group.destination + [member for member in members if member not in group.destination]
+                members = members + [member for member in patch_members if member not in members]
             else:
-                group.destination = members
+                members = patch_members
             continue
+
+        if not path:
+            if op not in ('add', 'replace') or not isinstance(value, dict):
+                return _scim_error(400, 'Pathless Group PATCH values must be objects', 'invalidPath')
+            handled = False
+            if 'displayName' in value:
+                if not isinstance(value['displayName'], str):
+                    return _scim_error(400, 'displayName must be a string', 'invalidValue')
+                display_name = value['displayName'].strip()
+                comment = '' if display_name.lower() == group.email else display_name
+                handled = True
+            if 'members' in value:
+                patch_members, error = _member_values({'members': value['members']})
+                if error:
+                    return error
+                if op == 'add':
+                    members = members + [member for member in patch_members if member not in members]
+                else:
+                    members = patch_members
+                handled = True
+            if not handled:
+                return _scim_error(400, 'Pathless Group PATCH has no supported attributes', 'invalidPath')
+            continue
+
         return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath')
+    group.comment = comment
+    group.destination = members
     return None
 
 
-def _validate_user_domain(email):
+def _validate_user_domain(email, *, for_update=False):
     if not validators.email(email):
         return None, _scim_error(400, f'{email!r} is not a valid email address', 'invalidValue')
     localpart, domain_name = email.rsplit('@', 1)
-    domain = models.db.session.get(models.Domain, domain_name)
+    if for_update:
+        domain, error = _locked_resource(models.Domain, domain_name)
+        if error:
+            return None, error
+    else:
+        domain = models.db.session.get(models.Domain, domain_name)
     if not domain:
         return None, _scim_error(404, f'Domain {domain_name} does not exist')
     if domain.max_users != -1 and len(domain.users) >= domain.max_users:
@@ -320,30 +847,58 @@ def _validate_user_domain(email):
     return (localpart, domain), None
 
 
-def _apply_user_data(user, data, *, replacing=False):
+def _user_data_changes(data, *, replacing=False):
+    changes = []
     if replacing:
         if 'active' in data:
             active, error = _active_value(data['active'])
             if error:
-                return error
-            user.enabled = active
+                return None, error
+            changes.append(('active', active))
         else:
-            user.enabled = True
+            changes.append(('active', True))
     elif 'active' in data:
         active, error = _active_value(data['active'])
         if error:
-            return error
-        user.enabled = active
+            return None, error
+        changes.append(('active', active))
 
-    display_name = _display_name(data)
+    display_name, error = _display_name(data)
+    if error:
+        return None, error
     if display_name:
-        user.displayed_name = display_name
+        changes.append(('displayName', display_name))
+    elif replacing:
+        changes.append(('displayName', ''))
     password, error = _password_value(data.get('password'))
     if error:
-        return error
+        return None, error
     if password:
-        user.set_password(password)
-    return None
+        changes.append(('password', password))
+    return changes, None
+
+
+def _apply_user_changes(user, changes):
+    password_changed = False
+    deactivated = False
+    for attribute, value in changes:
+        if attribute == 'active':
+            user.enabled = value
+            deactivated = deactivated or not value
+        elif attribute == 'displayName':
+            user.displayed_name = value
+        elif attribute == 'password':
+            user.set_password(value, keep_sessions=True)
+            password_changed = True
+    return password_changed, deactivated
+
+
+def _apply_user_data(user, data, *, replacing=False):
+    changes, error = _user_data_changes(data, replacing=replacing)
+    if error:
+        return error, False, False
+    password_changed, deactivated = _apply_user_changes(user, changes)
+    return None, password_changed, deactivated
 
 
 def _patch_user(user, data):
@@ -352,64 +907,89 @@ def _patch_user(user, data):
     else:
         operations = data.get('operations')
     if not isinstance(operations, list):
-        return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
+        return _scim_error(400, 'Operations must be a list', 'invalidSyntax'), False
     if not operations:
-        return _scim_error(400, 'Operations must not be empty', 'invalidValue')
+        return _scim_error(400, 'Operations must not be empty', 'invalidValue'), False
+    changes = []
     for operation in operations:
         if not isinstance(operation, dict):
-            return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax')
-        op = _string_value(operation.get('op') or 'replace').lower()
-        path = _string_value(operation.get('path')).lower()
+            return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax'), False
+        op_value = operation.get('op')
+        path_value = operation.get('path')
+        if not isinstance(op_value, str) or not op_value:
+            return _scim_error(400, 'Patch op must be a non-empty string', 'invalidSyntax'), False
+        if path_value is not None and not isinstance(path_value, str):
+            return _scim_error(400, 'Patch path must be a string', 'invalidPath'), False
+        op = op_value.lower()
+        path = _schema_path(path_value or '', SCIM_USER_SCHEMA).lower()
         value = operation.get('value')
-        if op not in ('add', 'replace'):
-            return _scim_error(400, f'Patch operation {op!r} is not supported', 'mutability')
+        if op not in ('add', 'replace', 'remove'):
+            return _scim_error(400, f'Patch operation {op!r} is not supported', 'mutability'), False
+        if path == 'password' or (
+            not path
+            and isinstance(value, dict)
+            and 'password' in value
+        ):
+            return _scim_error(
+                400,
+                'Changing an existing password through SCIM is not supported',
+                'mutability',
+            ), False
+        if op == 'remove':
+            if path in ('displayname', 'name', 'name.formatted'):
+                changes.append(('displayName', ''))
+                continue
+            if path == 'active':
+                changes.append(('active', True))
+                continue
+            return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath'), False
 
         handled = False
         if path in ('active', '') and (path or isinstance(value, dict)):
             if path == 'active':
                 active, error = _active_value(value)
                 if error:
-                    return error
-                user.enabled = active
+                    return error, False
+                changes.append(('active', active))
                 handled = True
             elif isinstance(value, dict) and 'active' in value:
                 active, error = _active_value(value['active'])
                 if error:
-                    return error
-                user.enabled = active
+                    return error, False
+                changes.append(('active', active))
                 handled = True
         if path in ('displayname', '') and (path or isinstance(value, dict)):
             if path == 'displayname' and value is not None:
-                user.displayed_name = _string_value(value)
+                if not isinstance(value, str):
+                    return _scim_error(400, 'displayName must be a string', 'invalidValue'), False
+                changes.append(('displayName', value))
                 handled = True
             elif isinstance(value, dict):
-                display_name = _display_name(value)
+                display_name, error = _display_name(value)
+                if error:
+                    return error, False
                 if display_name:
-                    user.displayed_name = display_name
+                    changes.append(('displayName', display_name))
                     handled = True
         if path in ('name.formatted', 'name', '') and value:
             if path == 'name.formatted':
-                user.displayed_name = _string_value(value)
+                if not isinstance(value, str):
+                    return _scim_error(400, 'name.formatted must be a string', 'invalidValue'), False
+                changes.append(('displayName', value))
                 handled = True
-            elif path == 'name' and isinstance(value, dict) and value.get('formatted'):
-                user.displayed_name = _string_value(value['formatted'])
-                handled = True
-        if path in ('password', ''):
-            if path == 'password' and value:
-                password, error = _password_value(value)
+            elif path == 'name':
+                if not isinstance(value, dict):
+                    return _scim_error(400, 'name must be an object', 'invalidValue'), False
+                display_name, error = _display_name({'name': value})
                 if error:
-                    return error
-                user.set_password(password)
-                handled = True
-            elif isinstance(value, dict) and value.get('password'):
-                password, error = _password_value(value['password'])
-                if error:
-                    return error
-                user.set_password(password)
-                handled = True
+                    return error, False
+                if display_name:
+                    changes.append(('displayName', display_name))
+                    handled = True
         if not handled:
-            return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath')
-    return None
+            return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath'), False
+    password_changed, deactivated = _apply_user_changes(user, changes)
+    return None, password_changed or deactivated
 
 @blueprint.before_request
 def authorize():
@@ -423,14 +1003,26 @@ def authorize():
     return _authorized()
 
 
+@blueprint.before_request
+def validate_projection():
+    _, _, error = _projection_parameters()
+    if error:
+        return _scim_error(400, error, 'invalidValue')
+    return None
+
+
 @blueprint.route('/ServiceProviderConfig', methods=['GET'])
 def service_provider_config():
     return _scim_response({
         'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'],
         'patch': {'supported': True},
-        'bulk': {'supported': True, 'maxOperations': 100, 'maxPayloadSize': 1048576},
-        'filter': {'supported': True, 'maxResults': 200},
-        'changePassword': {'supported': True},
+        'bulk': {
+            'supported': True,
+            'maxOperations': SCIM_MAX_BULK_OPERATIONS,
+            'maxPayloadSize': SCIM_MAX_BULK_PAYLOAD_SIZE,
+        },
+        'filter': {'supported': False, 'maxResults': 200},
+        'changePassword': {'supported': False},
         'sort': {'supported': False},
         'etag': {'supported': True},
         'authenticationSchemes': [{
@@ -443,9 +1035,8 @@ def service_provider_config():
     })
 
 
-@blueprint.route('/ResourceTypes', methods=['GET'])
-def resource_types():
-    resources = [
+def _resource_type_resources():
+    return [
         {
             'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
             'id': 'User',
@@ -463,6 +1054,11 @@ def resource_types():
             'meta': {'resourceType': 'ResourceType', 'location': _resource_location('ResourceTypes', 'Group')},
         },
     ]
+
+
+@blueprint.route('/ResourceTypes', methods=['GET'])
+def resource_types():
+    resources = _resource_type_resources()
     return _scim_response({
         'schemas': [SCIM_LIST_SCHEMA],
         'totalResults': len(resources),
@@ -470,26 +1066,179 @@ def resource_types():
         'itemsPerPage': len(resources),
         'Resources': resources,
     })
+
+
+@blueprint.route('/ResourceTypes/<resource_type>', methods=['GET'])
+def resource_type(resource_type):
+    for resource in _resource_type_resources():
+        if resource['id'] == resource_type:
+            return _scim_response(resource)
+    return _scim_error(404, f'ResourceType {resource_type} cannot be found')
+
+
+def _schema_resources():
+    return [
+        {
+            'schemas': [SCIM_SCHEMA_SCHEMA],
+            'id': SCIM_USER_SCHEMA,
+            'name': 'User',
+            'description': 'Mailu SCIM user schema subset',
+            'attributes': [
+                {
+                    'name': 'userName',
+                    'type': 'string',
+                    'multiValued': False,
+                    'required': True,
+                    'caseExact': False,
+                    'mutability': 'immutable',
+                    'returned': 'default',
+                    'uniqueness': 'server',
+                },
+                {
+                    'name': 'name',
+                    'type': 'complex',
+                    'multiValued': False,
+                    'required': False,
+                    'mutability': 'readWrite',
+                    'returned': 'default',
+                    'subAttributes': [
+                        {
+                            'name': attribute,
+                            'type': 'string',
+                            'multiValued': False,
+                            'required': False,
+                            'caseExact': False,
+                            'mutability': 'readWrite',
+                            'returned': 'default',
+                            'uniqueness': 'none',
+                        }
+                        for attribute in ('formatted',)
+                    ],
+                },
+                {
+                    'name': 'displayName',
+                    'type': 'string',
+                    'multiValued': False,
+                    'required': False,
+                    'caseExact': False,
+                    'mutability': 'readWrite',
+                    'returned': 'default',
+                    'uniqueness': 'none',
+                },
+                {
+                    'name': 'active',
+                    'type': 'boolean',
+                    'multiValued': False,
+                    'required': False,
+                    'mutability': 'readWrite',
+                    'returned': 'default',
+                },
+                {
+                    'name': 'password',
+                    'type': 'string',
+                    'multiValued': False,
+                    'required': False,
+                    'caseExact': True,
+                    'mutability': 'immutable',
+                    'returned': 'never',
+                    'uniqueness': 'none',
+                },
+                {
+                    'name': 'emails',
+                    'type': 'complex',
+                    'multiValued': True,
+                    'required': False,
+                    'mutability': 'immutable',
+                    'returned': 'default',
+                    'subAttributes': [
+                        {
+                            'name': 'value',
+                            'type': 'string',
+                            'multiValued': False,
+                            'required': True,
+                            'caseExact': False,
+                            'mutability': 'immutable',
+                            'returned': 'default',
+                            'uniqueness': 'none',
+                        },
+                        {
+                            'name': 'type',
+                            'type': 'string',
+                            'multiValued': False,
+                            'required': False,
+                            'caseExact': False,
+                            'mutability': 'immutable',
+                            'returned': 'default',
+                            'uniqueness': 'none',
+                        },
+                        {
+                            'name': 'primary',
+                            'type': 'boolean',
+                            'multiValued': False,
+                            'required': False,
+                            'mutability': 'immutable',
+                            'returned': 'default',
+                        },
+                    ],
+                },
+            ],
+            'meta': {'resourceType': 'Schema', 'location': _resource_location('Schemas', SCIM_USER_SCHEMA)},
+        },
+        {
+            'schemas': [SCIM_SCHEMA_SCHEMA],
+            'id': SCIM_GROUP_SCHEMA,
+            'name': 'Group',
+            'description': 'Mailu SCIM group schema subset backed by aliases',
+            'attributes': [
+                {
+                    'name': 'displayName',
+                    'type': 'string',
+                    'multiValued': False,
+                    'required': True,
+                    'caseExact': False,
+                    'mutability': 'readWrite',
+                    'returned': 'default',
+                    'uniqueness': 'none',
+                },
+                {
+                    'name': 'members',
+                    'type': 'complex',
+                    'multiValued': True,
+                    'required': False,
+                    'mutability': 'readWrite',
+                    'returned': 'default',
+                    'subAttributes': [
+                        {
+                            'name': 'value',
+                            'type': 'string',
+                            'multiValued': False,
+                            'required': True,
+                            'caseExact': False,
+                            'mutability': 'immutable',
+                            'returned': 'default',
+                            'uniqueness': 'none',
+                        },
+                        {
+                            'name': 'display',
+                            'type': 'string',
+                            'multiValued': False,
+                            'required': False,
+                            'caseExact': False,
+                            'mutability': 'readOnly',
+                            'returned': 'default',
+                            'uniqueness': 'none',
+                        },
+                    ],
+                },
+            ],
+            'meta': {'resourceType': 'Schema', 'location': _resource_location('Schemas', SCIM_GROUP_SCHEMA)},
+        },
+    ]
 
 
 @blueprint.route('/Schemas', methods=['GET'])
 def schemas():
-    resources = [
-        {
-            'id': SCIM_USER_SCHEMA,
-            'name': 'User',
-            'description': 'Mailu SCIM user schema subset',
-            'attributes': [],
-            'meta': {'resourceType': 'Schema', 'location': _resource_location('Schemas', SCIM_USER_SCHEMA)},
-        },
-        {
-            'id': SCIM_GROUP_SCHEMA,
-            'name': 'Group',
-            'description': 'Mailu SCIM group schema subset backed by aliases',
-            'attributes': [],
-            'meta': {'resourceType': 'Schema', 'location': _resource_location('Schemas', SCIM_GROUP_SCHEMA)},
-        },
-    ]
+    resources = _schema_resources()
     return _scim_response({
         'schemas': [SCIM_LIST_SCHEMA],
         'totalResults': len(resources),
@@ -497,6 +1246,14 @@ def schemas():
         'itemsPerPage': len(resources),
         'Resources': resources,
     })
+
+
+@blueprint.route('/Schemas/<path:schema_id>', methods=['GET'])
+def schema(schema_id):
+    for resource in _schema_resources():
+        if resource['id'] == schema_id:
+            return _scim_response(resource)
+    return _scim_error(404, f'Schema {schema_id} cannot be found')
 
 
 def _list_groups_response():
@@ -508,11 +1265,17 @@ def _list_groups_response():
 
     filter_value = flask.request.args.get('filter')
     if filter_value:
-        prefix = 'displayName eq '
-        if not filter_value.startswith(prefix):
-            return _scim_error(400, 'Only displayName eq filters are supported', 'invalidFilter')
-        email = filter_value[len(prefix):].strip().strip('"').lower()
-        query = query.filter_by(email=email)
+        display_name, error = _equality_filter(filter_value, 'displayName')
+        if error:
+            return error
+        normalized = display_name.lower()
+        predicates = [sqlalchemy.func.lower(models.Alias.comment) == normalized]
+        if validators.email(display_name):
+            predicates.append(sqlalchemy.and_(
+                sqlalchemy.or_(models.Alias.comment.is_(None), models.Alias.comment == ''),
+                models.Alias._email == normalized,
+            ))
+        query = query.filter(sqlalchemy.or_(*predicates))
 
     total = query.count()
     groups = query.offset(start_index - 1).limit(count).all() if count else []
@@ -526,68 +1289,167 @@ def _list_groups_response():
 
 
 def _create_group_response(data):
+    error = _schema_error(data, SCIM_GROUP_SCHEMA)
+    if error:
+        return error
     email, error = _group_email(data)
     if error:
         return error
     if not email:
         return _scim_error(400, 'displayName is required', 'invalidValue')
-    if _get_group(email):
-        return _scim_error(409, f'Group {email} already exists', 'uniqueness')
-    domain_data, error = _validate_alias_domain(email)
+    domain_data, error = _validate_alias_domain(email, for_update=True)
     if error:
+        models.db.session.rollback()
         return error
+    if _get_group(email) or _get_user(email):
+        models.db.session.rollback()
+        return _scim_error(409, f'Address {email} already exists', 'uniqueness')
     localpart, domain = domain_data
     group = models.Alias(localpart=localpart, domain=domain, destination=[])
     error = _apply_group_data(group, data, replacing=True)
     if error:
+        models.db.session.rollback()
         return error
     models.db.session.add(group)
-    models.db.session.commit()
+    try:
+        models.db.session.commit()
+    except IntegrityError:
+        models.db.session.rollback()
+        return _scim_error(409, f'Address {email} already exists', 'uniqueness')
+    except SQLAlchemyError:
+        models.db.session.rollback()
+        flask.current_app.logger.exception('SCIM Group creation failed')
+        return _scim_error(500, 'The SCIM Group could not be created')
     return _scim_response(_make_group_resource(group), 201)
 
 
 def _get_group_response(group_id):
+    group_id, error = _resource_id(group_id, 'Group')
+    if error:
+        return error
     group = _get_group(group_id)
     if not group:
         return _scim_error(404, f'Group {group_id} cannot be found')
+    conditional = _conditional_read_response(group)
+    if conditional:
+        return conditional
     return _scim_response(_make_group_resource(group))
 
 
-def _replace_group_response(group_id, data):
-    group = _get_group(group_id)
-    if not group:
-        return _scim_error(404, f'Group {group_id} cannot be found')
-    new_email, error = _group_email(data)
+def _replace_group_response(
+    group_id,
+    data,
+    if_match=_IF_MATCH_FROM_REQUEST,
+    if_none_match=_IF_MATCH_FROM_REQUEST,
+):
+    error = _schema_error(data, SCIM_GROUP_SCHEMA)
     if error:
         return error
+    group_id, error = _resource_id(group_id, 'Group')
+    if error:
+        return error
+    group, error = _locked_resource(models.Alias, group_id)
+    if error:
+        return error
+    error = _if_match_error(group, if_match)
+    if error:
+        models.db.session.rollback()
+        return error
+    error = _if_none_match_error(group, if_none_match)
+    if error:
+        models.db.session.rollback()
+        return error
+    if not group:
+        models.db.session.rollback()
+        return _scim_error(404, f'Group {group_id} cannot be found')
+    if not isinstance(data.get('displayName'), str) or not data['displayName'].strip():
+        models.db.session.rollback()
+        return _scim_error(400, 'displayName is required', 'invalidValue')
+    supplied_id = data.get('id')
+    if supplied_id is not None:
+        new_email, error = _resource_id(supplied_id, 'Group')
+        if error:
+            models.db.session.rollback()
+            return error
+    else:
+        new_email = None
     if new_email and new_email != group.email:
-        return _scim_error(400, 'Changing group id/displayName is not supported', 'mutability')
+        models.db.session.rollback()
+        return _scim_error(400, 'Changing group id is not supported', 'mutability')
     error = _apply_group_data(group, data, replacing=True)
     if error:
+        models.db.session.rollback()
         return error
     models.db.session.add(group)
-    models.db.session.commit()
+    error = _commit_error()
+    if error:
+        return error
     return _scim_response(_make_group_resource(group))
 
 
-def _patch_group_response(group_id, data):
-    group = _get_group(group_id)
+def _patch_group_response(
+    group_id,
+    data,
+    if_match=_IF_MATCH_FROM_REQUEST,
+    if_none_match=_IF_MATCH_FROM_REQUEST,
+):
+    error = _schema_error(data, SCIM_PATCH_SCHEMA)
+    if error:
+        return error
+    group_id, error = _resource_id(group_id, 'Group')
+    if error:
+        return error
+    group, error = _locked_resource(models.Alias, group_id)
+    if error:
+        return error
+    error = _if_match_error(group, if_match)
+    if error:
+        models.db.session.rollback()
+        return error
+    error = _if_none_match_error(group, if_none_match)
+    if error:
+        models.db.session.rollback()
+        return error
     if not group:
+        models.db.session.rollback()
         return _scim_error(404, f'Group {group_id} cannot be found')
     error = _patch_group(group, data)
     if error:
+        models.db.session.rollback()
         return error
     models.db.session.add(group)
-    models.db.session.commit()
+    error = _commit_error()
+    if error:
+        return error
     return _scim_response(_make_group_resource(group))
 
 
-def _delete_group_response(group_id):
-    group = _get_group(group_id)
+def _delete_group_response(
+    group_id,
+    if_match=_IF_MATCH_FROM_REQUEST,
+    if_none_match=_IF_MATCH_FROM_REQUEST,
+):
+    group_id, error = _resource_id(group_id, 'Group')
+    if error:
+        return error
+    group, error = _locked_resource(models.Alias, group_id)
+    if error:
+        return error
+    error = _if_match_error(group, if_match)
+    if error:
+        models.db.session.rollback()
+        return error
+    error = _if_none_match_error(group, if_none_match)
+    if error:
+        models.db.session.rollback()
+        return error
     if not group:
-        return '', 204
+        models.db.session.rollback()
+        return _scim_error(404, f'Group {group_id} cannot be found')
     models.db.session.delete(group)
-    models.db.session.commit()
+    error = _commit_error()
+    if error:
+        return error
     return '', 204
 
 
@@ -640,10 +1502,12 @@ def list_users():
 
     filter_value = flask.request.args.get('filter')
     if filter_value:
-        prefix = 'userName eq '
-        if not filter_value.startswith(prefix):
-            return _scim_error(400, 'Only userName eq filters are supported', 'invalidFilter')
-        email = filter_value[len(prefix):].strip().strip('"').lower()
+        email, error = _equality_filter(filter_value, 'userName')
+        if error:
+            return error
+        if not validators.email(email):
+            return _scim_error(400, 'userName filter value must be a valid email address', 'invalidFilter')
+        email = email.lower()
         query = query.filter_by(email=email)
 
     total = query.count()
@@ -658,74 +1522,177 @@ def list_users():
 
 
 def _create_user_response(data):
-    email, error = _user_email(data)
+    error = _schema_error(data, SCIM_USER_SCHEMA)
+    if error:
+        return error
+    email, error = _user_email(data, require_user_name=True)
     if error:
         return error
     if not email:
         return _scim_error(400, 'userName or emails[0].value is required', 'invalidValue')
-    if _get_user(email):
-        return _scim_error(409, f'User {email} already exists', 'uniqueness')
-    domain_data, error = _validate_user_domain(email)
+    domain_data, error = _validate_user_domain(email, for_update=True)
     if error:
+        models.db.session.rollback()
         return error
+    if _get_user(email) or _get_group(email):
+        models.db.session.rollback()
+        return _scim_error(409, f'Address {email} already exists', 'uniqueness')
     localpart, domain = domain_data
-    password, error = _password_value(data.get('password'))
-    if error:
-        return error
     user = models.User(localpart=localpart, domain=domain)
-    user.set_password(password or secrets.token_urlsafe())
-    error = _apply_user_data(user, data, replacing=True)
+    error, password_changed, _ = _apply_user_data(user, data, replacing=True)
     if error:
+        models.db.session.rollback()
         return error
+    if not password_changed:
+        user.set_password(secrets.token_urlsafe(), keep_sessions=True)
     models.db.session.add(user)
-    models.db.session.commit()
+    try:
+        models.db.session.commit()
+    except IntegrityError:
+        models.db.session.rollback()
+        return _scim_error(409, f'Address {email} already exists', 'uniqueness')
+    except SQLAlchemyError:
+        models.db.session.rollback()
+        flask.current_app.logger.exception('SCIM User creation failed')
+        return _scim_error(500, 'The SCIM User could not be created')
     return _scim_response(_make_user_resource(user), 201)
 
 
 @blueprint.route('/Users/<path:user_id>', methods=['GET'])
 def get_user(user_id):
+    user_id, error = _resource_id(user_id, 'User')
+    if error:
+        return error
     user = _get_user(user_id)
     if not user:
         return _scim_error(404, f'User {user_id} cannot be found')
+    conditional = _conditional_read_response(user)
+    if conditional:
+        return conditional
     return _scim_response(_make_user_resource(user))
 
 
-def _replace_user_response(user_id, data):
-    user = _get_user(user_id)
-    if not user:
-        return _scim_error(404, f'User {user_id} cannot be found')
-    new_email, error = _user_email(data)
+def _replace_user_response(
+    user_id,
+    data,
+    if_match=_IF_MATCH_FROM_REQUEST,
+    if_none_match=_IF_MATCH_FROM_REQUEST,
+):
+    error = _schema_error(data, SCIM_USER_SCHEMA)
     if error:
         return error
-    if new_email and new_email != user.email:
+    user_id, error = _resource_id(user_id, 'User')
+    if error:
+        return error
+    user, error = _locked_resource(models.User, user_id)
+    if error:
+        return error
+    error = _if_match_error(user, if_match)
+    if error:
+        models.db.session.rollback()
+        return error
+    error = _if_none_match_error(user, if_none_match)
+    if error:
+        models.db.session.rollback()
+        return error
+    if not user:
+        models.db.session.rollback()
+        return _scim_error(404, f'User {user_id} cannot be found')
+    new_email, error = _user_email(
+        data,
+        require_user_name=True,
+        conflict_scim_type='mutability',
+    )
+    if error:
+        models.db.session.rollback()
+        return error
+    if not new_email:
+        models.db.session.rollback()
+        return _scim_error(400, 'userName or emails[0].value is required', 'invalidValue')
+    if new_email != user.email:
+        models.db.session.rollback()
         return _scim_error(400, 'Changing userName/email is not supported', 'mutability')
-    error = _apply_user_data(user, data, replacing=True)
+    if 'password' in data:
+        models.db.session.rollback()
+        return _scim_error(400, 'Changing an existing password through SCIM is not supported', 'mutability')
+    error, password_changed, deactivated = _apply_user_data(user, data, replacing=True)
     if error:
+        models.db.session.rollback()
         return error
     models.db.session.add(user)
-    models.db.session.commit()
+    error = _commit_user_change(
+        user,
+        prune_sessions=password_changed or deactivated,
+    )
+    if error:
+        return error
     return _scim_response(_make_user_resource(user))
 
 
-def _patch_user_response(user_id, data):
-    user = _get_user(user_id)
+def _patch_user_response(
+    user_id,
+    data,
+    if_match=_IF_MATCH_FROM_REQUEST,
+    if_none_match=_IF_MATCH_FROM_REQUEST,
+):
+    error = _schema_error(data, SCIM_PATCH_SCHEMA)
+    if error:
+        return error
+    user_id, error = _resource_id(user_id, 'User')
+    if error:
+        return error
+    user, error = _locked_resource(models.User, user_id)
+    if error:
+        return error
+    error = _if_match_error(user, if_match)
+    if error:
+        models.db.session.rollback()
+        return error
+    error = _if_none_match_error(user, if_none_match)
+    if error:
+        models.db.session.rollback()
+        return error
     if not user:
+        models.db.session.rollback()
         return _scim_error(404, f'User {user_id} cannot be found')
-    error = _patch_user(user, data)
+    error, prune_sessions = _patch_user(user, data)
     if error:
+        models.db.session.rollback()
         return error
     models.db.session.add(user)
-    models.db.session.commit()
+    error = _commit_user_change(user, prune_sessions=prune_sessions)
+    if error:
+        return error
     return _scim_response(_make_user_resource(user))
 
 
-def _delete_user_response(user_id):
-    user = _get_user(user_id)
+def _delete_user_response(
+    user_id,
+    if_match=_IF_MATCH_FROM_REQUEST,
+    if_none_match=_IF_MATCH_FROM_REQUEST,
+):
+    user_id, error = _resource_id(user_id, 'User')
+    if error:
+        return error
+    user, error = _locked_resource(models.User, user_id)
+    if error:
+        return error
+    error = _if_match_error(user, if_match)
+    if error:
+        models.db.session.rollback()
+        return error
+    error = _if_none_match_error(user, if_none_match)
+    if error:
+        models.db.session.rollback()
+        return error
     if not user:
-        return '', 204
+        models.db.session.rollback()
+        return _scim_error(404, f'User {user_id} cannot be found')
     user.enabled = False
     models.db.session.add(user)
-    models.db.session.commit()
+    error = _commit_user_change(user, prune_sessions=True)
+    if error:
+        return error
     return '', 204
 
 @blueprint.route('/Users', methods=['POST'])
@@ -757,46 +1724,207 @@ def delete_user(user_id):
     return _delete_user_response(user_id)
 
 
+def _resolve_bulk_ids(value, bulk_ids):
+    if isinstance(value, str) and value.startswith('bulkId:'):
+        return bulk_ids.get(value[7:], value)
+    if isinstance(value, list):
+        return [_resolve_bulk_ids(item, bulk_ids) for item in value]
+    if isinstance(value, dict):
+        return {key: _resolve_bulk_ids(item, bulk_ids) for key, item in value.items()}
+    return value
+
+
+def _bulk_id_references(value):
+    if isinstance(value, str):
+        return {value[7:]} if value.startswith('bulkId:') else set()
+    if isinstance(value, list):
+        references = set()
+        for item in value:
+            references.update(_bulk_id_references(item))
+        return references
+    if isinstance(value, dict):
+        references = set()
+        for item in value.values():
+            references.update(_bulk_id_references(item))
+        return references
+    return set()
+
+
+def _operation_bulk_references(operation):
+    references = _bulk_id_references(operation.get('data'))
+    path = operation.get('path')
+    if isinstance(path, str):
+        parts = path.lstrip('/').split('/', 1)
+        if len(parts) == 2 and parts[1].startswith('bulkId:'):
+            references.add(parts[1][7:])
+    return references
+
+
+def _parse_bulk_path(path, bulk_ids):
+    if not isinstance(path, str) or not path:
+        return None, None, None, 'Bulk operations require method and path', 'invalidValue'
+    try:
+        parsed = urllib.parse.urlsplit(path)
+    except ValueError:
+        return None, None, None, f'Unsupported bulk path {path!r}', 'invalidPath'
+    if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment:
+        return None, None, None, f'Unsupported bulk path {path!r}', 'invalidPath'
+    normalized_path = parsed.path.lstrip('/')
+    parts = normalized_path.split('/')
+    if (
+        not normalized_path
+        or len(parts) > 2
+        or parts[0] not in ('Users', 'Groups')
+        or (len(parts) == 2 and not parts[1])
+    ):
+        return None, None, None, f'Unsupported bulk path {path!r}', 'invalidPath'
+    collection = parts[0]
+    resource_id = parts[1] if len(parts) == 2 else None
+    if resource_id is None:
+        return collection, None, None, None, None
+    if resource_id.startswith('bulkId:'):
+        resource_id = bulk_ids.get(resource_id[7:], resource_id)
+        if resource_id.startswith('bulkId:'):
+            return (
+                None,
+                None,
+                None,
+                'Bulk operation path references an unknown bulkId',
+                'invalidValue',
+            )
+    else:
+        if _INVALID_PERCENT_ESCAPE.search(resource_id):
+            return None, None, None, f'Unsupported bulk path {path!r}', 'invalidPath'
+        try:
+            resource_id = urllib.parse.unquote(resource_id, errors='strict')
+        except UnicodeDecodeError:
+            return None, None, None, f'Unsupported bulk path {path!r}', 'invalidPath'
+    if '/' in resource_id:
+        return None, None, None, f'Unsupported bulk path {path!r}', 'invalidPath'
+    return (
+        collection,
+        resource_id,
+        _resource_location(collection, resource_id),
+        None,
+        None,
+    )
+
+
+def _bulk_operation_location(operation, bulk_ids):
+    path = operation.get('path')
+    _, _, location, _, _ = _parse_bulk_path(path, bulk_ids)
+    return location
+
+
+def _bulk_error(operation, method, status, detail, scim_type, *, location=None):
+    item = {
+        'method': method,
+        'status': str(status),
+        'response': _response_payload(_scim_error(status, detail, scim_type)),
+    }
+    if operation.get('bulkId'):
+        item['bulkId'] = operation['bulkId']
+    if location:
+        item['location'] = location
+    models.db.session.rollback()
+    return item, None
+
+
 def _bulk_response(operation, bulk_ids):
     method = _string_value(operation.get('method')).upper()
-    path = _string_value(operation.get('path')).lstrip('/')
-    data = operation.get('data') or {}
-    if not method or not path:
-        return {'status': '400', 'response': _response_payload(_scim_error(400, 'Bulk operations require method and path', 'invalidValue'))}, None
+    path = operation.get('path')
+    data = operation.get('data')
+    if data is None:
+        data = {}
+    version = operation.get('version')
+    if not method or not isinstance(path, str) or not path:
+        return _bulk_error(
+            operation,
+            method,
+            400,
+            'Bulk operations require method and path',
+            'invalidValue',
+        )
+    collection, resource_id, request_location, path_error, path_scim_type = (
+        _parse_bulk_path(path, bulk_ids)
+    )
+    if path_error:
+        return _bulk_error(
+            operation,
+            method,
+            400,
+            path_error,
+            path_scim_type,
+            location=request_location,
+        )
     if not isinstance(data, dict):
-        return {'status': '400', 'response': _response_payload(_scim_error(400, 'Bulk operation data must be an object', 'invalidSyntax'))}, None
+        return _bulk_error(
+            operation,
+            method,
+            400,
+            'Bulk operation data must be an object',
+            'invalidSyntax',
+            location=request_location,
+        )
+    data = _resolve_bulk_ids(data, bulk_ids)
+    if _bulk_id_references(data):
+        return _bulk_error(
+            operation,
+            method,
+            400,
+            'Bulk operation references an unknown bulkId',
+            'invalidValue',
+            location=request_location,
+        )
 
-    for key, value in list(data.items()):
-        if isinstance(value, str) and value.startswith('bulkId:'):
-            data[key] = bulk_ids.get(value[7:], value)
-
-    parts = path.split('/', 1)
-    collection = parts[0]
-    resource_id = parts[1] if len(parts) > 1 else None
     if collection == 'Users':
         if method == 'POST' and resource_id is None:
             response = _create_user_response(data)
-        elif method == 'GET' and resource_id:
-            response = get_user(resource_id)
         elif method == 'PUT' and resource_id:
-            response = _replace_user_response(resource_id, data)
+            response = _replace_user_response(
+                resource_id,
+                data,
+                if_match=version,
+                if_none_match=None,
+            )
         elif method == 'PATCH' and resource_id:
-            response = _patch_user_response(resource_id, data)
+            response = _patch_user_response(
+                resource_id,
+                data,
+                if_match=version,
+                if_none_match=None,
+            )
         elif method == 'DELETE' and resource_id:
-            response = _delete_user_response(resource_id)
+            response = _delete_user_response(
+                resource_id,
+                if_match=version,
+                if_none_match=None,
+            )
         else:
             response = _scim_error(400, f'Unsupported bulk path {path!r}', 'invalidPath')
     elif collection == 'Groups':
         if method == 'POST' and resource_id is None:
             response = _create_group_response(data)
-        elif method == 'GET' and resource_id:
-            response = _get_group_response(resource_id)
         elif method == 'PUT' and resource_id:
-            response = _replace_group_response(resource_id, data)
+            response = _replace_group_response(
+                resource_id,
+                data,
+                if_match=version,
+                if_none_match=None,
+            )
         elif method == 'PATCH' and resource_id:
-            response = _patch_group_response(resource_id, data)
+            response = _patch_group_response(
+                resource_id,
+                data,
+                if_match=version,
+                if_none_match=None,
+            )
         elif method == 'DELETE' and resource_id:
-            response = _delete_group_response(resource_id)
+            response = _delete_group_response(
+                resource_id,
+                if_match=version,
+                if_none_match=None,
+            )
         else:
             response = _scim_error(400, f'Unsupported bulk path {path!r}', 'invalidPath')
     else:
@@ -806,49 +1934,136 @@ def _bulk_response(operation, bulk_ids):
         status = response[1]
         payload = None
         location = None
+        response_version = None
     else:
         status = response.status_code
         payload = _response_payload(response)
         location = payload.get('meta', {}).get('location') if isinstance(payload, dict) else None
-    item = {'status': str(status)}
+        response_version = response.headers.get('ETag')
+    location = location or request_location
+    item = {'method': method, 'status': str(status)}
     if operation.get('bulkId'):
         item['bulkId'] = operation['bulkId']
     if location:
         item['location'] = location
+    if response_version:
+        item['version'] = response_version
     if payload is not None:
         item['response'] = payload
     resource_id = payload.get('id') if isinstance(payload, dict) else None
+    if int(status) >= 400:
+        models.db.session.rollback()
     return item, resource_id
 
 
 @blueprint.route('/Bulk', methods=['POST'])
 def bulk():
+    if (
+        flask.request.content_length is not None
+        and flask.request.content_length > SCIM_MAX_BULK_PAYLOAD_SIZE
+    ):
+        return _scim_error(413, 'Bulk request exceeds maxPayloadSize')
+    if len(flask.request.get_data(cache=True)) > SCIM_MAX_BULK_PAYLOAD_SIZE:
+        return _scim_error(413, 'Bulk request exceeds maxPayloadSize')
     data, error = _payload()
+    if error:
+        return error
+    error = _schema_error(data, SCIM_BULK_REQUEST_SCHEMA)
     if error:
         return error
     operations = data.get('Operations') or data.get('operations')
     if not isinstance(operations, list):
         return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
-    if len(operations) > 100:
+    if not operations:
+        return _scim_error(400, 'Operations must not be empty', 'invalidValue')
+    if len(operations) > SCIM_MAX_BULK_OPERATIONS:
         return _scim_error(413, 'Too many bulk operations', 'tooMany')
-    fail_on_errors = _parse_positive_int(data.get('failOnErrors', len(operations)), len(operations), minimum=0)
-    responses = []
-    errors = 0
-    bulk_ids = {}
+    raw_fail_on_errors = data.get('failOnErrors', len(operations))
+    try:
+        fail_on_errors = int(raw_fail_on_errors)
+    except (TypeError, ValueError):
+        fail_on_errors = None
+    if isinstance(raw_fail_on_errors, bool) or fail_on_errors is None or fail_on_errors < 0:
+        return _scim_error(400, 'failOnErrors must be a non-negative integer', 'invalidValue')
+    bulk_id_values = []
     for operation in operations:
         if not isinstance(operation, dict):
-            responses.append({'status': '400', 'response': _response_payload(_scim_error(400, 'Bulk operations must be objects', 'invalidSyntax'))})
-            errors += 1
-        else:
-            response, resource_id = _bulk_response(operation, bulk_ids)
-            responses.append(response)
-            if operation.get('bulkId') and resource_id:
+            continue
+        bulk_id = operation.get('bulkId')
+        method = _string_value(operation.get('method')).upper()
+        if method == 'POST' and (not isinstance(bulk_id, str) or not bulk_id):
+            return _scim_error(400, 'POST bulk operations require a non-empty bulkId', 'invalidValue')
+        if bulk_id is not None and (not isinstance(bulk_id, str) or not bulk_id):
+            return _scim_error(400, 'bulkId must be a non-empty string', 'invalidValue')
+        if bulk_id in bulk_id_values:
+            return _scim_error(400, f'Duplicate bulkId {bulk_id!r}', 'invalidValue')
+        if bulk_id is not None:
+            bulk_id_values.append(bulk_id)
+    responses = {}
+    errors = 0
+    bulk_ids = {}
+    declared_bulk_ids = set(bulk_id_values)
+    pending = list(enumerate(operations))
+    stopped = False
+    while pending and not stopped:
+        deferred = []
+        progressed = False
+        for index, operation in pending:
+            if not isinstance(operation, dict):
+                response = {
+                    'status': '400',
+                    'response': _response_payload(
+                        _scim_error(400, 'Bulk operations must be objects', 'invalidSyntax')
+                    ),
+                }
+                resource_id = None
+            else:
+                references = _operation_bulk_references(operation)
+                unknown = references - declared_bulk_ids
+                unresolved = references - bulk_ids.keys()
+                if unknown:
+                    response, resource_id = _bulk_error(
+                        operation,
+                        _string_value(operation.get('method')).upper(),
+                        400,
+                        f'Bulk operation references unknown bulkId {sorted(unknown)[0]!r}',
+                        'invalidValue',
+                        location=_bulk_operation_location(operation, bulk_ids),
+                    )
+                elif unresolved:
+                    deferred.append((index, operation))
+                    continue
+                else:
+                    response, resource_id = _bulk_response(operation, bulk_ids)
+            responses[index] = response
+            progressed = True
+            if isinstance(operation, dict) and operation.get('bulkId') and resource_id:
                 bulk_ids[operation['bulkId']] = resource_id
             if int(response['status']) >= 400:
                 errors += 1
-        if fail_on_errors and errors >= fail_on_errors:
+            if fail_on_errors and errors >= fail_on_errors:
+                stopped = True
+                break
+        if stopped or not deferred:
             break
+        if progressed:
+            pending = deferred
+            continue
+        for index, operation in deferred:
+            response, _ = _bulk_error(
+                operation,
+                _string_value(operation.get('method')).upper(),
+                409,
+                'Bulk operation has a circular or failed bulkId dependency',
+                None,
+                location=_bulk_operation_location(operation, bulk_ids),
+            )
+            responses[index] = response
+            errors += 1
+            if fail_on_errors and errors >= fail_on_errors:
+                break
+        break
     return _scim_response({
         'schemas': [SCIM_BULK_RESPONSE_SCHEMA],
-        'Operations': responses,
+        'Operations': [responses[index] for index in sorted(responses)],
     })

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -1,0 +1,331 @@
+import secrets
+
+import flask
+import validators
+
+from . import common
+from .. import models
+
+
+SCIM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User'
+SCIM_GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group'
+SCIM_LIST_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:ListResponse'
+SCIM_PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'
+SCIM_ERROR_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:Error'
+
+blueprint = flask.Blueprint('scim', __name__)
+
+
+def _base_url():
+    web_api_root = flask.current_app.config.get('WEB_API') or '/api'
+    return flask.request.url_root.rstrip('/') + web_api_root.rstrip('/') + '/scim/v2'
+
+
+def _resource_location(resource, resource_id):
+    return f'{_base_url()}/{resource}/{resource_id}'
+
+
+def _scim_response(payload, status=200):
+    response = flask.jsonify(payload)
+    response.status_code = status
+    response.headers['Content-Type'] = 'application/scim+json'
+    return response
+
+
+def _scim_error(status, detail, scim_type=None):
+    payload = {
+        'schemas': [SCIM_ERROR_SCHEMA],
+        'status': str(status),
+        'detail': detail,
+    }
+    if scim_type:
+        payload['scimType'] = scim_type
+    return _scim_response(payload, status)
+
+
+def _payload():
+    data = flask.request.get_json(silent=True)
+    if data is None:
+        return {}
+    return data
+
+
+def _user_email(data):
+    user_name = (data.get('userName') or '').strip().lower()
+    if user_name:
+        return user_name
+    for email in data.get('emails') or []:
+        value = (email.get('value') or '').strip().lower()
+        if value:
+            return value
+    return ''
+
+
+def _display_name(data):
+    if data.get('displayName'):
+        return data['displayName']
+    name = data.get('name') or {}
+    if name.get('formatted'):
+        return name['formatted']
+    parts = [name.get('givenName'), name.get('familyName')]
+    return ' '.join(part for part in parts if part)
+
+
+def _get_user(user_id):
+    return models.db.session.get(models.User, user_id.lower())
+
+
+def _make_user_resource(user):
+    email = user.email
+    payload = {
+        'schemas': [SCIM_USER_SCHEMA],
+        'id': email,
+        'externalId': email,
+        'userName': email,
+        'active': user.enabled,
+        'displayName': user.displayed_name or email,
+        'name': {
+            'formatted': user.displayed_name or email,
+        },
+        'emails': [{
+            'value': email,
+            'primary': True,
+            'type': 'work',
+        }],
+        'meta': {
+            'resourceType': 'User',
+            'location': _resource_location('Users', email),
+        },
+    }
+    return payload
+
+
+def _validate_user_domain(email):
+    if not validators.email(email):
+        return None, _scim_error(400, f'{email!r} is not a valid email address', 'invalidValue')
+    localpart, domain_name = email.rsplit('@', 1)
+    domain = models.db.session.get(models.Domain, domain_name)
+    if not domain:
+        return None, _scim_error(404, f'Domain {domain_name} does not exist')
+    if domain.max_users != -1 and len(domain.users) >= domain.max_users:
+        return None, _scim_error(409, f'Too many users for domain {domain_name}', 'uniqueness')
+    return (localpart, domain), None
+
+
+def _apply_user_data(user, data, *, replacing=False):
+    if replacing:
+        user.enabled = bool(data.get('active', True))
+    elif 'active' in data:
+        user.enabled = bool(data['active'])
+
+    display_name = _display_name(data)
+    if display_name:
+        user.displayed_name = display_name
+    if data.get('password'):
+        user.set_password(data['password'])
+
+
+def _patch_user(user, data):
+    operations = data.get('Operations') or data.get('operations') or []
+    for operation in operations:
+        op = (operation.get('op') or 'replace').lower()
+        path = (operation.get('path') or '').lower()
+        value = operation.get('value')
+        if op not in ('add', 'replace'):
+            continue
+        if path in ('active', '') and (path or isinstance(value, dict)):
+            if path == 'active':
+                user.enabled = bool(value)
+            elif isinstance(value, dict) and 'active' in value:
+                user.enabled = bool(value['active'])
+        if path in ('displayname', '') and (path or isinstance(value, dict)):
+            if path == 'displayname' and value is not None:
+                user.displayed_name = str(value)
+            elif isinstance(value, dict):
+                display_name = _display_name(value)
+                if display_name:
+                    user.displayed_name = display_name
+        if path in ('name.formatted', 'name', '') and value:
+            if path == 'name.formatted':
+                user.displayed_name = str(value)
+            elif path == 'name' and isinstance(value, dict) and value.get('formatted'):
+                user.displayed_name = value['formatted']
+        if path in ('password', ''):
+            if path == 'password' and value:
+                user.set_password(str(value))
+            elif isinstance(value, dict) and value.get('password'):
+                user.set_password(value['password'])
+
+
+@blueprint.before_request
+def authorize():
+    if flask.request.method == 'OPTIONS':
+        return None
+
+    @common.api_token_authorization
+    def _authorized():
+        return None
+
+    return _authorized()
+
+
+@blueprint.route('/ServiceProviderConfig', methods=['GET'])
+def service_provider_config():
+    return _scim_response({
+        'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ServiceProviderConfig'],
+        'patch': {'supported': True},
+        'bulk': {'supported': False, 'maxOperations': 0, 'maxPayloadSize': 0},
+        'filter': {'supported': True, 'maxResults': 200},
+        'changePassword': {'supported': True},
+        'sort': {'supported': False},
+        'etag': {'supported': False},
+        'authenticationSchemes': [{
+            'type': 'oauthbearertoken',
+            'name': 'Bearer',
+            'description': 'Mailu API_TOKEN bearer authentication',
+            'primary': True,
+        }],
+        'meta': {'resourceType': 'ServiceProviderConfig'},
+    })
+
+
+@blueprint.route('/ResourceTypes', methods=['GET'])
+def resource_types():
+    return _scim_response({
+        'schemas': [SCIM_LIST_SCHEMA],
+        'totalResults': 1,
+        'startIndex': 1,
+        'itemsPerPage': 1,
+        'Resources': [{
+            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:ResourceType'],
+            'id': 'User',
+            'name': 'User',
+            'endpoint': '/Users',
+            'schema': SCIM_USER_SCHEMA,
+            'meta': {'resourceType': 'ResourceType', 'location': _resource_location('ResourceTypes', 'User')},
+        }],
+    })
+
+
+@blueprint.route('/Schemas', methods=['GET'])
+def schemas():
+    return _scim_response({
+        'schemas': [SCIM_LIST_SCHEMA],
+        'totalResults': 1,
+        'startIndex': 1,
+        'itemsPerPage': 1,
+        'Resources': [{
+            'id': SCIM_USER_SCHEMA,
+            'name': 'User',
+            'description': 'Mailu SCIM user schema subset',
+            'attributes': [],
+            'meta': {'resourceType': 'Schema', 'location': _resource_location('Schemas', SCIM_USER_SCHEMA)},
+        }],
+    })
+
+
+@blueprint.route('/Groups', methods=['GET'])
+def list_groups():
+    return _scim_response({
+        'schemas': [SCIM_LIST_SCHEMA],
+        'totalResults': 0,
+        'startIndex': 1,
+        'itemsPerPage': 0,
+        'Resources': [],
+    })
+
+
+@blueprint.route('/Groups', methods=['POST'])
+@blueprint.route('/Groups/<path:group_id>', methods=['GET', 'PUT', 'PATCH', 'DELETE'])
+def unsupported_groups(group_id=None):
+    return _scim_error(501, 'Mailu SCIM currently provisions users only; groups are not supported')
+
+
+@blueprint.route('/Users', methods=['GET'])
+def list_users():
+    start_index = max(int(flask.request.args.get('startIndex', 1)), 1)
+    count = max(int(flask.request.args.get('count', 100)), 0)
+    query = models.User.query.order_by(models.User._email)
+
+    filter_value = flask.request.args.get('filter')
+    if filter_value:
+        prefix = 'userName eq '
+        if not filter_value.startswith(prefix):
+            return _scim_error(400, 'Only userName eq filters are supported', 'invalidFilter')
+        email = filter_value[len(prefix):].strip().strip('"').lower()
+        query = query.filter_by(email=email)
+
+    total = query.count()
+    users = query.offset(start_index - 1).limit(count).all() if count else []
+    return _scim_response({
+        'schemas': [SCIM_LIST_SCHEMA],
+        'totalResults': total,
+        'startIndex': start_index,
+        'itemsPerPage': len(users),
+        'Resources': [_make_user_resource(user) for user in users],
+    })
+
+
+@blueprint.route('/Users', methods=['POST'])
+def create_user():
+    data = _payload()
+    email = _user_email(data)
+    if not email:
+        return _scim_error(400, 'userName or emails[0].value is required', 'invalidValue')
+    if _get_user(email):
+        return _scim_error(409, f'User {email} already exists', 'uniqueness')
+    domain_data, error = _validate_user_domain(email)
+    if error:
+        return error
+    localpart, domain = domain_data
+    user = models.User(localpart=localpart, domain=domain)
+    user.set_password(data.get('password') or secrets.token_urlsafe())
+    _apply_user_data(user, data, replacing=True)
+    models.db.session.add(user)
+    models.db.session.commit()
+    return _scim_response(_make_user_resource(user), 201)
+
+
+@blueprint.route('/Users/<path:user_id>', methods=['GET'])
+def get_user(user_id):
+    user = _get_user(user_id)
+    if not user:
+        return _scim_error(404, f'User {user_id} cannot be found')
+    return _scim_response(_make_user_resource(user))
+
+
+@blueprint.route('/Users/<path:user_id>', methods=['PUT'])
+def replace_user(user_id):
+    user = _get_user(user_id)
+    if not user:
+        return _scim_error(404, f'User {user_id} cannot be found')
+    data = _payload()
+    new_email = _user_email(data)
+    if new_email and new_email != user.email:
+        return _scim_error(400, 'Changing userName/email is not supported', 'mutability')
+    _apply_user_data(user, data, replacing=True)
+    models.db.session.add(user)
+    models.db.session.commit()
+    return _scim_response(_make_user_resource(user))
+
+
+@blueprint.route('/Users/<path:user_id>', methods=['PATCH'])
+def patch_user(user_id):
+    user = _get_user(user_id)
+    if not user:
+        return _scim_error(404, f'User {user_id} cannot be found')
+    _patch_user(user, _payload())
+    models.db.session.add(user)
+    models.db.session.commit()
+    return _scim_response(_make_user_resource(user))
+
+
+@blueprint.route('/Users/<path:user_id>', methods=['DELETE'])
+def delete_user(user_id):
+    user = _get_user(user_id)
+    if not user:
+        return '', 204
+    user.enabled = False
+    models.db.session.add(user)
+    models.db.session.commit()
+    return '', 204

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -94,16 +94,29 @@ def _active_value(value):
 
 
 def _user_email(data):
-    user_name = _string_value(data.get('userName')).strip().lower()
-    if user_name:
-        return user_name
-    for email in data.get('emails') or []:
+    user_name = data.get('userName')
+    if user_name not in (None, ''):
+        if not isinstance(user_name, str):
+            return None, _scim_error(400, 'userName must be a string', 'invalidValue')
+        user_name = user_name.strip().lower()
+        if user_name:
+            return user_name, None
+
+    emails = data.get('emails') or []
+    if not isinstance(emails, list):
+        return None, _scim_error(400, 'emails must be a list', 'invalidValue')
+    for email in emails:
         if not isinstance(email, dict):
             continue
-        value = _string_value(email.get('value')).strip().lower()
+        value = email.get('value')
+        if value in (None, ''):
+            continue
+        if not isinstance(value, str):
+            return None, _scim_error(400, 'email values must be strings', 'invalidValue')
+        value = value.strip().lower()
         if value:
-            return value
-    return ''
+            return value, None
+    return '', None
 
 
 def _display_name(data):
@@ -369,7 +382,9 @@ def create_user():
     data, error = _payload()
     if error:
         return error
-    email = _user_email(data)
+    email, error = _user_email(data)
+    if error:
+        return error
     if not email:
         return _scim_error(400, 'userName or emails[0].value is required', 'invalidValue')
     if _get_user(email):
@@ -407,7 +422,9 @@ def replace_user(user_id):
     data, error = _payload()
     if error:
         return error
-    new_email = _user_email(data)
+    new_email, error = _user_email(data)
+    if error:
+        return error
     if new_email and new_email != user.email:
         return _scim_error(400, 'Changing userName/email is not supported', 'mutability')
     error = _apply_user_data(user, data, replacing=True)

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -183,37 +183,48 @@ def _patch_user(user, data):
         path = _string_value(operation.get('path')).lower()
         value = operation.get('value')
         if op not in ('add', 'replace'):
-            continue
+            return _scim_error(400, f'Patch operation {op!r} is not supported', 'mutability')
+
+        handled = False
         if path in ('active', '') and (path or isinstance(value, dict)):
             if path == 'active':
                 active, error = _active_value(value)
                 if error:
                     return error
                 user.enabled = active
+                handled = True
             elif isinstance(value, dict) and 'active' in value:
                 active, error = _active_value(value['active'])
                 if error:
                     return error
                 user.enabled = active
+                handled = True
         if path in ('displayname', '') and (path or isinstance(value, dict)):
             if path == 'displayname' and value is not None:
                 user.displayed_name = _string_value(value)
+                handled = True
             elif isinstance(value, dict):
                 display_name = _display_name(value)
                 if display_name:
                     user.displayed_name = display_name
+                    handled = True
         if path in ('name.formatted', 'name', '') and value:
             if path == 'name.formatted':
                 user.displayed_name = _string_value(value)
+                handled = True
             elif path == 'name' and isinstance(value, dict) and value.get('formatted'):
-                user.displayed_name = value['formatted']
+                user.displayed_name = _string_value(value['formatted'])
+                handled = True
         if path in ('password', ''):
             if path == 'password' and value:
                 user.set_password(_string_value(value))
+                handled = True
             elif isinstance(value, dict) and value.get('password'):
-                user.set_password(value['password'])
+                user.set_password(_string_value(value['password']))
+                handled = True
+        if not handled:
+            return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath')
     return None
-
 
 @blueprint.before_request
 def authorize():

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -18,6 +18,7 @@ from .. import models, utils
 
 SCIM_USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User'
 SCIM_GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group'
+SCIM_GROUP_EXTENSION = 'https://mailu.io/schemas/scim/2.0/Group'
 SCIM_LIST_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:ListResponse'
 SCIM_PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'
 SCIM_ERROR_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:Error'
@@ -27,6 +28,7 @@ SCIM_SCHEMA_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Schema'
 
 blueprint = flask.Blueprint('scim', __name__)
 _IF_MATCH_FROM_REQUEST = object()
+_UNCHANGED = object()
 SCIM_MAX_BULK_OPERATIONS = 100
 SCIM_MAX_BULK_PAYLOAD_SIZE = 1048576
 _FILTER_PATTERN = re.compile(r'^\s*([A-Za-z][A-Za-z0-9.]*)\s+eq\s+"([^"]*)"\s*$', re.IGNORECASE)
@@ -34,18 +36,23 @@ _MEMBER_FILTER_PATTERN = re.compile(
     r'^\s*members\s*\[\s*value\s+eq\s+"([^"]+)"\s*\]\s*$',
     re.IGNORECASE,
 )
-_PROJECTION_SEGMENT_PATTERN = re.compile(r'^[A-Za-z][A-Za-z0-9_-]*$')
+_PROJECTION_SEGMENT_PATTERN = re.compile(
+    r'^(?:[A-Za-z][A-Za-z0-9_-]*|\$ref)$'
+)
 _INVALID_PERCENT_ESCAPE = re.compile(r'%(?![0-9A-Fa-f]{2})')
 _SCIM_KEY_CASES = {
     key.lower(): key
     for key in (
         'Operations',
+        '$ref',
         'active',
+        'aliasAddress',
         'bulkId',
         'data',
         'displayName',
         'emails',
         'externalId',
+        'externalDestinations',
         'failOnErrors',
         'familyName',
         'formatted',
@@ -63,6 +70,7 @@ _SCIM_KEY_CASES = {
         'userName',
         'value',
         'version',
+        SCIM_GROUP_EXTENSION,
     )
 }
 _USER_PROJECTION_PATHS = {
@@ -73,6 +81,7 @@ _USER_PROJECTION_PATHS = {
     ('emails', 'type'),
     ('emails', 'value'),
     ('id',),
+    ('externalid',),
     ('meta',),
     ('meta', 'location'),
     ('meta', 'resourcetype'),
@@ -86,14 +95,20 @@ _USER_PROJECTION_PATHS = {
 _GROUP_PROJECTION_PATHS = {
     ('displayname',),
     ('id',),
+    ('externalid',),
     ('members',),
     ('members', 'display'),
+    ('members', '$ref'),
+    ('members', 'type'),
     ('members', 'value'),
     ('meta',),
     ('meta', 'location'),
     ('meta', 'resourcetype'),
     ('meta', 'version'),
     ('schemas',),
+    (SCIM_GROUP_EXTENSION.casefold(),),
+    (SCIM_GROUP_EXTENSION.casefold(), 'aliasaddress'),
+    (SCIM_GROUP_EXTENSION.casefold(), 'externaldestinations'),
 }
 _USER_PROJECTION_ENDPOINTS = {
     'create_user',
@@ -138,6 +153,29 @@ def _projection_context():
 def _projection_path(value, schema, allowed_paths):
     path = value.strip()
     prefix = f'{schema}:'
+    extension_prefix = f'{SCIM_GROUP_EXTENSION}:'
+    if path.casefold().startswith(extension_prefix.casefold()):
+        path = path[len(extension_prefix):]
+        parts = path.split('.')
+        if (
+            not path
+            or any(
+                not _PROJECTION_SEGMENT_PATTERN.fullmatch(part)
+                for part in parts
+            )
+        ):
+            return None
+        normalized = (
+            SCIM_GROUP_EXTENSION.casefold(),
+            *(
+                _SCIM_KEY_CASES.get(part.casefold(), part).casefold()
+                for part in parts
+            ),
+        )
+        return normalized if normalized in allowed_paths else None
+    if path.casefold() == SCIM_GROUP_EXTENSION.casefold():
+        normalized = (SCIM_GROUP_EXTENSION.casefold(),)
+        return normalized if normalized in allowed_paths else None
     if path.casefold().startswith('urn:'):
         if not path.casefold().startswith(prefix.casefold()):
             return None
@@ -227,7 +265,13 @@ def _project_value(value, tree, *, include):
 
 
 def _always_returned(resource):
-    return {'schemas', 'id'}
+    always = {'schemas', 'id'}
+    schemas = resource.get('schemas', [])
+    if SCIM_USER_SCHEMA in schemas:
+        always.add('username')
+    if SCIM_GROUP_SCHEMA in schemas:
+        always.add('displayname')
+    return always
 
 
 def _project_resource(resource, mode, paths):
@@ -295,12 +339,37 @@ def _not_modified(version):
 
 
 def _resource_version(resource):
-    if isinstance(resource, models.User):
+    if isinstance(resource, models.ScimResource):
+        state = {
+            'externalId': resource.external_id,
+            'id': resource.id,
+            'resourceType': resource.resource_type,
+            'subjectAddress': resource.subject_address,
+        }
+        if resource.resource_type == 'User' and resource.user is not None:
+            state.update({
+                'active': resource.user.enabled,
+                'displayName': resource.user.displayed_name,
+                'userName': resource.user.email,
+            })
+        elif resource.resource_type == 'Group' and resource.alias is not None:
+            state.update({
+                'aliasAddress': resource.alias.email,
+                'displayName': resource.alias.comment or resource.alias.email,
+                'externalDestinations': sorted(
+                    destination.destination
+                    for destination in resource.destinations
+                ),
+                'members': sorted(
+                    edge.member_id
+                    for edge in resource.member_edges
+                ),
+            })
+    elif isinstance(resource, models.User):
         state = {
             'active': resource.enabled,
             'displayName': resource.displayed_name,
             'id': resource.email,
-            'password': resource.password,
         }
     elif isinstance(resource, models.Alias):
         state = {
@@ -494,14 +563,17 @@ def _commit_error():
 
 
 def _commit_user_change(user, *, prune_sessions):
+    error = _commit_error()
+    if error:
+        return error
     if prune_sessions:
         try:
             utils.MailuSessionExtension.prune_sessions(uid=user.email)
         except Exception:
-            models.db.session.rollback()
-            flask.current_app.logger.exception('SCIM session revocation failed')
-            return _scim_error(500, 'Existing sessions could not be revoked')
-    return _commit_error()
+            flask.current_app.logger.exception(
+                'SCIM post-commit session cleanup failed'
+            )
+    return None
 
 
 @blueprint.errorhandler(HTTPException)
@@ -602,19 +674,55 @@ def _equality_filter(value, supported_attribute):
 
 
 def _schema_error(data, expected):
+    return _schema_set_error(data, [expected])
+
+
+def _schema_set_error(data, expected):
     schemas = data.get('schemas')
     if (
         not isinstance(schemas, list)
-        or len(schemas) != 1
-        or not isinstance(schemas[0], str)
-        or schemas[0].casefold() != expected.casefold()
+        or len(schemas) != len(expected)
+        or any(not isinstance(schema, str) for schema in schemas)
+        or len({schema.casefold() for schema in schemas}) != len(schemas)
+        or {schema.casefold() for schema in schemas}
+        != {schema.casefold() for schema in expected}
     ):
+        description = ', '.join(expected)
         return _scim_error(
             400,
-            f'schemas must contain exactly {expected}',
+            f'schemas must contain exactly {description}',
             'invalidValue',
         )
     return None
+
+
+def _external_id_value(data, *, replacing=False):
+    if 'externalId' not in data:
+        return (None if replacing else _UNCHANGED), None
+    value = data['externalId']
+    if value is None:
+        return None, None
+    if not isinstance(value, str):
+        return None, _scim_error(
+            400,
+            'externalId must be a string',
+            'invalidValue',
+        )
+    try:
+        encoded = value.encode('utf-8')
+    except UnicodeEncodeError:
+        return None, _scim_error(
+            400,
+            'externalId must contain valid Unicode',
+            'invalidValue',
+        )
+    if len(encoded) > 1024:
+        return None, _scim_error(
+            400,
+            'externalId must not exceed 1024 UTF-8 bytes',
+            'invalidValue',
+        )
+    return value, None
 
 
 def _string_value(value):
@@ -667,7 +775,9 @@ def _user_email(data, *, require_user_name=False, conflict_scim_type='invalidVal
         if user_name:
             values.append(user_name)
 
-    emails = data.get('emails') or []
+    emails = data.get('emails', [])
+    if emails is None:
+        emails = []
     if not isinstance(emails, list):
         return None, _scim_error(400, 'emails must be a list', 'invalidValue')
     for email in emails:
@@ -688,6 +798,17 @@ def _user_email(data, *, require_user_name=False, conflict_scim_type='invalidVal
             'userName and emails must identify the same mailbox',
             conflict_scim_type,
         )
+    for value in unique_values:
+        if not validators.email(value):
+            return None, _scim_error(
+                400,
+                f'{value!r} is not a valid email address',
+                'invalidValue',
+            )
+    if require_user_name:
+        # RFC 7643 makes userName independently required. An emails entry is
+        # representation data, not an alternate identity input.
+        return user_name, None
     return (unique_values[0] if unique_values else ''), None
 
 
@@ -698,7 +819,9 @@ def _display_name(data):
         display_name = data['displayName'].strip()
         if display_name:
             return display_name, None
-    name = data.get('name') or {}
+    name = data.get('name', {})
+    if name is None:
+        name = {}
     if not isinstance(name, dict):
         return None, _scim_error(400, 'name must be an object', 'invalidValue')
     for attribute in ('formatted', 'givenName', 'familyName'):
@@ -712,27 +835,73 @@ def _display_name(data):
 
 
 def _resource_id(value, resource_type):
-    if not isinstance(value, str) or not validators.email(value):
+    if (
+        not isinstance(value, str)
+        or not value
+        or len(value) > 255
+        or '/' in value
+    ):
         return None, _scim_error(
             400,
-            f'{resource_type} id must be a valid email address',
+            f'{resource_type} id must be a non-empty opaque identifier',
             'invalidValue',
         )
-    return value.lower(), None
+    return value, None
 
 
 def _get_user(user_id):
-    if not isinstance(user_id, str) or not validators.email(user_id):
+    return models.ScimResource.get_exact(
+        user_id,
+        resource_type='User',
+        active_only=True,
+    )
+
+
+def _get_scim_for_update(resource_id, resource_type):
+    """Lock an exact active mapping and its live Mailu resource."""
+    statement = (
+        sqlalchemy.select(models.ScimResource)
+        .where(models.ScimResource.id == resource_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    )
+    resource = models.db.session.execute(statement).scalar_one_or_none()
+    if (
+        resource is None
+        or resource.id != resource_id
+        or resource.resource_type != resource_type
+        or resource.deleted_at is not None
+    ):
         return None
-    user_id = user_id.lower()
-    return models.db.session.get(models.User, user_id)
+    target_model = (
+        models.User
+        if resource_type == 'User'
+        else models.Alias
+    )
+    target_id = (
+        resource.user_email
+        if resource_type == 'User'
+        else resource.alias_email
+    )
+    target = models.db.session.execute(
+        sqlalchemy.select(target_model)
+        .where(target_model._email == target_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if target is None or target.email != target_id:
+        raise models.ScimIdentityError(
+            f'Active SCIM {resource_type} {resource_id!r} has no live target'
+        )
+    return resource
 
 
-def _make_user_resource(user):
+def _make_user_resource(resource):
+    user = resource.user
     email = user.email
     payload = {
         'schemas': [SCIM_USER_SCHEMA],
-        'id': email,
+        'id': resource.id,
         'userName': email,
         'active': user.enabled,
         'displayName': user.displayed_name or email,
@@ -744,21 +913,29 @@ def _make_user_resource(user):
             'primary': True,
             'type': 'work',
         }],
-        'meta': _resource_meta('User', 'Users', email, user),
+        'meta': _resource_meta(
+            'User',
+            'Users',
+            resource.id,
+            resource,
+        ),
     }
+    if resource.external_id is not None:
+        payload['externalId'] = resource.external_id
     return payload
 
 
 def _get_group(group_id):
-    if not isinstance(group_id, str) or not validators.email(group_id):
-        return None
-    group_id = group_id.lower()
-    return models.db.session.get(models.Alias, group_id)
+    return models.ScimResource.get_exact(
+        group_id,
+        resource_type='Group',
+        active_only=True,
+    )
 
 
 def _member_values(data):
     members = data.get('members', [])
-    if members in (None, ''):
+    if members is None:
         return [], None
     if not isinstance(members, list):
         return None, _scim_error(400, 'members must be a list', 'invalidValue')
@@ -772,36 +949,89 @@ def _member_values(data):
             return None, _scim_error(400, 'members must contain strings or objects', 'invalidValue')
         if not isinstance(value, str) or not value.strip():
             return None, _scim_error(400, 'member values must be non-empty strings', 'invalidValue')
-        value = value.strip().lower()
-        if not validators.email(value):
-            return None, _scim_error(400, f'{value!r} is not a valid member email address', 'invalidValue')
+        value = value.strip()
+        if value.startswith('bulkId:'):
+            return None, _scim_error(
+                400,
+                f'Member {value!r} references an unresolved bulkId',
+                'invalidValue',
+            )
         if value not in values:
             values.append(value)
     return values, None
 
 
-def _group_email(data):
-    for key in ('id', 'displayName'):
-        value = data.get(key)
-        if value not in (None, ''):
-            if not isinstance(value, str):
-                return None, _scim_error(400, f'{key} must be a string', 'invalidValue')
-            return value.strip().lower(), None
-    return '', None
+def _external_destinations(value):
+    if value is None:
+        return [], None
+    if not isinstance(value, list):
+        return None, _scim_error(
+            400,
+            'externalDestinations must be a list',
+            'invalidValue',
+        )
+    destinations = []
+    for destination in value:
+        if not isinstance(destination, str) or not destination.strip():
+            return None, _scim_error(
+                400,
+                'externalDestinations must contain non-empty strings',
+                'invalidValue',
+            )
+        try:
+            canonical = models.canonicalize_scim_destination(destination)
+        except (
+            models.ScimExternalDestinationError,
+            models.ScimIdentityError,
+        ) as error:
+            return None, _scim_error(400, str(error), 'invalidValue')
+        if canonical not in destinations:
+            destinations.append(canonical)
+    return destinations, None
 
 
-def _make_group_resource(group):
-    email = group.email
-    return {
-        'schemas': [SCIM_GROUP_SCHEMA],
-        'id': email,
-        'displayName': group.comment or email,
-        'members': [{
-            'value': destination,
-            'display': destination,
-        } for destination in group.destination],
-        'meta': _resource_meta('Group', 'Groups', email, group),
+def _make_group_resource(resource):
+    group = resource.alias
+    members = []
+    for edge in sorted(resource.member_edges, key=lambda item: item.member_id):
+        member = models.ScimResource.get_exact(
+            edge.member_id,
+            active_only=True,
+        )
+        if member is None:
+            # The live foreign key and graph lock should make this impossible.
+            raise models.ScimGraphError(
+                f'Group member {edge.member_id!r} is not active'
+            )
+        collection = 'Users' if member.resource_type == 'User' else 'Groups'
+        members.append({
+            'value': member.id,
+            '$ref': _resource_location(collection, member.id),
+            'display': member.subject_address,
+            'type': member.resource_type,
+        })
+    payload = {
+        'schemas': [SCIM_GROUP_SCHEMA, SCIM_GROUP_EXTENSION],
+        'id': resource.id,
+        'displayName': group.comment or group.email,
+        'members': members,
+        SCIM_GROUP_EXTENSION: {
+            'aliasAddress': group.email,
+            'externalDestinations': sorted(
+                destination.destination
+                for destination in resource.destinations
+            ),
+        },
+        'meta': _resource_meta(
+            'Group',
+            'Groups',
+            resource.id,
+            resource,
+        ),
     }
+    if resource.external_id is not None:
+        payload['externalId'] = resource.external_id
+    return payload
 
 
 def _validate_alias_domain(email, *, for_update=False):
@@ -821,29 +1051,83 @@ def _validate_alias_domain(email, *, for_update=False):
     return (localpart, domain), None
 
 
-def _apply_group_data(group, data, *, replacing=False):
-    if 'displayName' in data:
-        if not isinstance(data['displayName'], str):
-            return _scim_error(400, 'displayName must be a string', 'invalidValue')
-        group.comment = '' if data['displayName'].strip().lower() == group.email else data['displayName'].strip()
-    elif replacing:
-        group.comment = ''
-    if replacing or 'members' in data:
-        members, error = _member_values(data)
-        if error:
-            return error
-        group.destination = members
-    return None
+def _group_replacement(data, *, current=None):
+    error = _schema_set_error(
+        data,
+        [SCIM_GROUP_SCHEMA, SCIM_GROUP_EXTENSION],
+    )
+    if error:
+        return None, error
+    display_name = data.get('displayName')
+    if not isinstance(display_name, str) or not display_name.strip():
+        return None, _scim_error(
+            400,
+            'displayName is required',
+            'invalidValue',
+        )
+    extension = data.get(SCIM_GROUP_EXTENSION)
+    if not isinstance(extension, dict):
+        return None, _scim_error(
+            400,
+            f'{SCIM_GROUP_EXTENSION} is required',
+            'invalidValue',
+        )
+    alias_address = extension.get('aliasAddress')
+    if not isinstance(alias_address, str) or not alias_address.strip():
+        return None, _scim_error(
+            400,
+            'aliasAddress is required',
+            'invalidValue',
+        )
+    alias_address = alias_address.strip().lower()
+    if not validators.email(alias_address):
+        return None, _scim_error(
+            400,
+            f'{alias_address!r} is not a valid aliasAddress',
+            'invalidValue',
+        )
+    if current is not None and alias_address != current.alias.email:
+        return None, _scim_error(
+            400,
+            'aliasAddress is immutable',
+            'mutability',
+        )
+    members, error = _member_values(data)
+    if error:
+        return None, error
+    destinations, error = _external_destinations(
+        extension.get('externalDestinations', [])
+    )
+    if error:
+        return None, error
+    external_id, error = _external_id_value(data, replacing=True)
+    if error:
+        return None, error
+    return {
+        'aliasAddress': alias_address,
+        'displayName': display_name.strip(),
+        'externalId': external_id,
+        'members': members,
+        'externalDestinations': destinations,
+    }, None
 
 
-def _patch_group(group, data):
+def _patch_group(resource, data):
     operations = data['Operations'] if 'Operations' in data else data.get('operations')
     if not isinstance(operations, list):
         return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
     if not operations:
         return _scim_error(400, 'Operations must not be empty', 'invalidValue')
-    comment = group.comment or ''
-    members = list(group.destination)
+    display_name = resource.alias.comment or resource.alias.email
+    external_id = resource.external_id
+    members = [
+        edge.member_id
+        for edge in resource.member_edges
+    ]
+    external_destinations = [
+        destination.destination
+        for destination in resource.destinations
+    ]
     for operation in operations:
         if not isinstance(operation, dict):
             return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax')
@@ -851,14 +1135,22 @@ def _patch_group(group, data):
         if not isinstance(op_value, str) or not op_value:
             return _scim_error(400, 'Patch op must be a non-empty string', 'invalidSyntax')
         op = op_value.lower()
+        path_present = 'path' in operation
         path_value = operation.get('path')
-        if path_value is not None and not isinstance(path_value, str):
+        if path_present and (
+            not isinstance(path_value, str)
+            or not path_value.strip()
+        ):
             return _scim_error(400, 'Patch path must be a string', 'invalidPath')
         path = _schema_path((path_value or '').strip(), SCIM_GROUP_SCHEMA)
         path_lower = path.lower()
         value = operation.get('value')
         if op not in ('add', 'replace', 'remove'):
             return _scim_error(400, f'Patch operation {op!r} is not supported', 'mutability')
+        if op in ('add', 'replace') and 'value' not in operation:
+            return _scim_error(400, 'Patch value is required', 'invalidValue')
+        if op == 'remove' and not path_present:
+            return _scim_error(400, 'Pathless remove has no target', 'noTarget')
 
         member_filter = _MEMBER_FILTER_PATTERN.fullmatch(path)
         if member_filter:
@@ -880,7 +1172,18 @@ def _patch_group(group, data):
             elif not isinstance(value, str):
                 return _scim_error(400, 'displayName must be a string', 'invalidValue')
             else:
-                comment = '' if value.strip().lower() == group.email else value.strip()
+                display_name = value.strip()
+            continue
+
+        if path_lower == 'externalid':
+            if op == 'remove':
+                external_id = None
+            else:
+                external_id, error = _external_id_value(
+                    {'externalId': value},
+                )
+                if error:
+                    return error
             continue
 
         if path_lower == 'members':
@@ -899,7 +1202,42 @@ def _patch_group(group, data):
                 members = patch_members
             continue
 
-        if not path:
+        extension_path = _schema_path(
+            (path_value or '').strip(),
+            SCIM_GROUP_EXTENSION,
+        )
+        if extension_path.casefold() == 'aliasaddress':
+            return _scim_error(
+                400,
+                'aliasAddress is immutable',
+                'mutability',
+            )
+        if extension_path.casefold() == 'externaldestinations':
+            if op == 'remove' and value is None:
+                external_destinations = []
+                continue
+            patch_destinations, error = _external_destinations(
+                value if isinstance(value, list) else [value]
+            )
+            if error:
+                return error
+            if op == 'remove':
+                external_destinations = [
+                    item
+                    for item in external_destinations
+                    if item not in patch_destinations
+                ]
+            elif op == 'add':
+                external_destinations += [
+                    item
+                    for item in patch_destinations
+                    if item not in external_destinations
+                ]
+            else:
+                external_destinations = patch_destinations
+            continue
+
+        if not path_present:
             if op not in ('add', 'replace') or not isinstance(value, dict):
                 return _scim_error(400, 'Pathless Group PATCH values must be objects', 'invalidPath')
             handled = False
@@ -907,7 +1245,11 @@ def _patch_group(group, data):
                 if not isinstance(value['displayName'], str):
                     return _scim_error(400, 'displayName must be a string', 'invalidValue')
                 display_name = value['displayName'].strip()
-                comment = '' if display_name.lower() == group.email else display_name
+                handled = True
+            if 'externalId' in value:
+                external_id, error = _external_id_value(value)
+                if error:
+                    return error
                 handled = True
             if 'members' in value:
                 patch_members, error = _member_values({'members': value['members']})
@@ -918,14 +1260,53 @@ def _patch_group(group, data):
                 else:
                     members = patch_members
                 handled = True
+            if SCIM_GROUP_EXTENSION in value:
+                extension = value[SCIM_GROUP_EXTENSION]
+                if not isinstance(extension, dict):
+                    return _scim_error(
+                        400,
+                        f'{SCIM_GROUP_EXTENSION} must be an object',
+                        'invalidValue',
+                    )
+                if 'aliasAddress' in extension:
+                    alias_address = extension['aliasAddress']
+                    if (
+                        not isinstance(alias_address, str)
+                        or alias_address.strip().lower()
+                        != resource.alias.email
+                    ):
+                        return _scim_error(
+                            400,
+                            'aliasAddress is immutable',
+                            'mutability',
+                        )
+                    handled = True
+                if 'externalDestinations' in extension:
+                    patch_destinations, error = _external_destinations(
+                        extension['externalDestinations']
+                    )
+                    if error:
+                        return error
+                    if op == 'add':
+                        external_destinations += [
+                            item
+                            for item in patch_destinations
+                            if item not in external_destinations
+                        ]
+                    else:
+                        external_destinations = patch_destinations
+                    handled = True
             if not handled:
                 return _scim_error(400, 'Pathless Group PATCH has no supported attributes', 'invalidPath')
             continue
 
         return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath')
-    group.comment = comment
-    group.destination = members
-    return None
+    return {
+        'displayName': display_name,
+        'externalId': external_id,
+        'members': members,
+        'externalDestinations': external_destinations,
+    }
 
 
 def _validate_user_domain(email, *, for_update=False):
@@ -977,12 +1358,15 @@ def _user_data_changes(data, *, replacing=False):
 
 
 def _apply_user_changes(user, changes):
+    final_changes = {}
+    for attribute, value in changes:
+        final_changes[attribute] = value
     password_changed = False
     deactivated = False
-    for attribute, value in changes:
+    for attribute, value in final_changes.items():
         if attribute == 'active':
+            deactivated = user.enabled and not value
             user.enabled = value
-            deactivated = deactivated or not value
         elif attribute == 'displayName':
             user.displayed_name = value
         elif attribute == 'password':
@@ -999,7 +1383,8 @@ def _apply_user_data(user, data, *, replacing=False):
     return None, password_changed, deactivated
 
 
-def _patch_user(user, data):
+def _patch_user(resource, data):
+    user = resource.user
     if 'Operations' in data:
         operations = data['Operations']
     else:
@@ -1009,20 +1394,29 @@ def _patch_user(user, data):
     if not operations:
         return _scim_error(400, 'Operations must not be empty', 'invalidValue'), False
     changes = []
+    external_id = resource.external_id
     for operation in operations:
         if not isinstance(operation, dict):
             return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax'), False
         op_value = operation.get('op')
+        path_present = 'path' in operation
         path_value = operation.get('path')
         if not isinstance(op_value, str) or not op_value:
             return _scim_error(400, 'Patch op must be a non-empty string', 'invalidSyntax'), False
-        if path_value is not None and not isinstance(path_value, str):
+        if path_present and (
+            not isinstance(path_value, str)
+            or not path_value.strip()
+        ):
             return _scim_error(400, 'Patch path must be a string', 'invalidPath'), False
         op = op_value.lower()
         path = _schema_path(path_value or '', SCIM_USER_SCHEMA).lower()
         value = operation.get('value')
         if op not in ('add', 'replace', 'remove'):
             return _scim_error(400, f'Patch operation {op!r} is not supported', 'mutability'), False
+        if op in ('add', 'replace') and 'value' not in operation:
+            return _scim_error(400, 'Patch value is required', 'invalidValue'), False
+        if op == 'remove' and not path_present:
+            return _scim_error(400, 'Pathless remove has no target', 'noTarget'), False
         if path == 'password' or (
             not path
             and isinstance(value, dict)
@@ -1034,6 +1428,9 @@ def _patch_user(user, data):
                 'mutability',
             ), False
         if op == 'remove':
+            if path == 'externalid':
+                external_id = None
+                continue
             if path in ('displayname', 'name', 'name.formatted'):
                 changes.append(('displayName', ''))
                 continue
@@ -1043,6 +1440,18 @@ def _patch_user(user, data):
             return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath'), False
 
         handled = False
+        if path == 'externalid':
+            external_id, error = _external_id_value(
+                {'externalId': value},
+            )
+            if error:
+                return error, False
+            handled = True
+        elif not path_present and isinstance(value, dict) and 'externalId' in value:
+            external_id, error = _external_id_value(value)
+            if error:
+                return error, False
+            handled = True
         if path in ('active', '') and (path or isinstance(value, dict)):
             if path == 'active':
                 active, error = _active_value(value)
@@ -1050,7 +1459,7 @@ def _patch_user(user, data):
                     return error, False
                 changes.append(('active', active))
                 handled = True
-            elif isinstance(value, dict) and 'active' in value:
+            elif not path_present and isinstance(value, dict) and 'active' in value:
                 active, error = _active_value(value['active'])
                 if error:
                     return error, False
@@ -1062,13 +1471,14 @@ def _patch_user(user, data):
                     return _scim_error(400, 'displayName must be a string', 'invalidValue'), False
                 changes.append(('displayName', value))
                 handled = True
-            elif isinstance(value, dict):
+            elif not path_present and isinstance(value, dict) and (
+                'displayName' in value or 'name' in value
+            ):
                 display_name, error = _display_name(value)
                 if error:
                     return error, False
-                if display_name:
-                    changes.append(('displayName', display_name))
-                    handled = True
+                changes.append(('displayName', display_name))
+                handled = True
         if path in ('name.formatted', 'name', '') and value:
             if path == 'name.formatted':
                 if not isinstance(value, str):
@@ -1084,8 +1494,22 @@ def _patch_user(user, data):
                 if display_name:
                     changes.append(('displayName', display_name))
                     handled = True
+        if not path_present and isinstance(value, dict) and (
+            'userName' in value or 'emails' in value
+        ):
+            email, error = _user_email(value)
+            if error:
+                return error, False
+            if email and email != user.email:
+                return _scim_error(
+                    400,
+                    'userName and emails are immutable',
+                    'mutability',
+                ), False
+            handled = True
         if not handled:
             return _scim_error(400, f'Patch path {path!r} is not supported', 'invalidPath'), False
+    resource.external_id = external_id
     password_changed, deactivated = _apply_user_changes(user, changes)
     return None, password_changed or deactivated
 
@@ -1119,6 +1543,9 @@ def service_provider_config():
             'maxOperations': SCIM_MAX_BULK_OPERATIONS,
             'maxPayloadSize': SCIM_MAX_BULK_PAYLOAD_SIZE,
         },
+        # Mailu implements only two exact-equality convenience filters per
+        # resource. That is not RFC 7644 filter support and must not be
+        # advertised as such.
         'filter': {'supported': False, 'maxResults': 200},
         'changePassword': {'supported': False},
         'sort': {'supported': False},
@@ -1149,6 +1576,10 @@ def _resource_type_resources():
             'name': 'Group',
             'endpoint': '/Groups',
             'schema': SCIM_GROUP_SCHEMA,
+            'schemaExtensions': [{
+                'schema': SCIM_GROUP_EXTENSION,
+                'required': True,
+            }],
             'meta': {'resourceType': 'ResourceType', 'location': _resource_location('ResourceTypes', 'Group')},
         },
     ]
@@ -1183,13 +1614,23 @@ def _schema_resources():
             'description': 'Mailu SCIM user schema subset',
             'attributes': [
                 {
+                    'name': 'externalId',
+                    'type': 'string',
+                    'multiValued': False,
+                    'required': False,
+                    'caseExact': True,
+                    'mutability': 'readWrite',
+                    'returned': 'default',
+                    'uniqueness': 'none',
+                },
+                {
                     'name': 'userName',
                     'type': 'string',
                     'multiValued': False,
                     'required': True,
                     'caseExact': False,
                     'mutability': 'immutable',
-                    'returned': 'default',
+                    'returned': 'always',
                     'uniqueness': 'server',
                 },
                 {
@@ -1289,13 +1730,23 @@ def _schema_resources():
             'description': 'Mailu SCIM group schema subset backed by aliases',
             'attributes': [
                 {
+                    'name': 'externalId',
+                    'type': 'string',
+                    'multiValued': False,
+                    'required': False,
+                    'caseExact': True,
+                    'mutability': 'readWrite',
+                    'returned': 'default',
+                    'uniqueness': 'none',
+                },
+                {
                     'name': 'displayName',
                     'type': 'string',
                     'multiValued': False,
                     'required': True,
                     'caseExact': False,
                     'mutability': 'readWrite',
-                    'returned': 'default',
+                    'returned': 'always',
                     'uniqueness': 'none',
                 },
                 {
@@ -1326,10 +1777,67 @@ def _schema_resources():
                             'returned': 'default',
                             'uniqueness': 'none',
                         },
+                        {
+                            'name': '$ref',
+                            'type': 'reference',
+                            'multiValued': False,
+                            'required': False,
+                            'caseExact': True,
+                            'mutability': 'readOnly',
+                            'returned': 'default',
+                            'referenceTypes': ['User', 'Group'],
+                        },
+                        {
+                            'name': 'type',
+                            'type': 'string',
+                            'multiValued': False,
+                            'required': False,
+                            'caseExact': True,
+                            'mutability': 'readOnly',
+                            'returned': 'default',
+                            'uniqueness': 'none',
+                        },
                     ],
                 },
             ],
             'meta': {'resourceType': 'Schema', 'location': _resource_location('Schemas', SCIM_GROUP_SCHEMA)},
+        },
+        {
+            'schemas': [SCIM_SCHEMA_SCHEMA],
+            'id': SCIM_GROUP_EXTENSION,
+            'name': 'MailuGroup',
+            'description': (
+                'Mailu alias routing attributes for SCIM Groups'
+            ),
+            'attributes': [
+                {
+                    'name': 'aliasAddress',
+                    'type': 'string',
+                    'multiValued': False,
+                    'required': True,
+                    'caseExact': False,
+                    'mutability': 'immutable',
+                    'returned': 'default',
+                    'uniqueness': 'server',
+                },
+                {
+                    'name': 'externalDestinations',
+                    'type': 'string',
+                    'multiValued': True,
+                    'required': False,
+                    'caseExact': False,
+                    'mutability': 'readWrite',
+                    'returned': 'default',
+                    'uniqueness': 'none',
+                },
+            ],
+            'meta': {
+                'resourceType': 'Schema',
+                'location': _resource_location(
+                    'Schemas',
+                    SCIM_GROUP_EXTENSION,
+                ),
+            },
         },
     ]
 
@@ -1359,21 +1867,56 @@ def _list_groups_response():
     count = _parse_positive_int(flask.request.args.get('count', 100), 100, minimum=0, maximum=200)
     if start_index is None or count is None:
         return _scim_error(400, 'startIndex and count must be integers', 'invalidValue')
-    query = models.Alias.query.order_by(models.Alias._email)
+    query = (
+        models.ScimResource.query
+        .filter(
+            models.ScimResource.resource_type == 'Group',
+            models.ScimResource.deleted_at.is_(None),
+            models.ScimResource.alias_email.is_not(None),
+        )
+        .join(
+            models.Alias,
+            models.ScimResource.alias_email == models.Alias._email,
+        )
+        .order_by(models.ScimResource.id)
+    )
 
     filter_value = flask.request.args.get('filter')
     if filter_value:
-        display_name, error = _equality_filter(filter_value, 'displayName')
-        if error:
-            return error
-        normalized = display_name.lower()
-        predicates = [sqlalchemy.func.lower(models.Alias.comment) == normalized]
-        if validators.email(display_name):
-            predicates.append(sqlalchemy.and_(
-                sqlalchemy.or_(models.Alias.comment.is_(None), models.Alias.comment == ''),
-                models.Alias._email == normalized,
+        match = _FILTER_PATTERN.fullmatch(filter_value)
+        if not match:
+            return _scim_error(
+                400,
+                'Only displayName or externalId eq filters are supported',
+                'invalidFilter',
+            )
+        attribute, value = match.groups()
+        if attribute.casefold() == 'displayname':
+            normalized = value.lower()
+            query = query.filter(sqlalchemy.or_(
+                sqlalchemy.func.lower(models.Alias.comment) == normalized,
+                sqlalchemy.and_(
+                    sqlalchemy.or_(
+                        models.Alias.comment.is_(None),
+                        models.Alias.comment == '',
+                    ),
+                    sqlalchemy.func.lower(models.Alias._email) == normalized,
+                ),
             ))
-        query = query.filter(sqlalchemy.or_(*predicates))
+        elif attribute.casefold() == 'externalid':
+            try:
+                encoded = value.encode('utf-8')
+            except UnicodeEncodeError:
+                encoded = None
+            query = query.filter(
+                models.ScimResource.external_id_bytes == encoded
+            )
+        else:
+            return _scim_error(
+                400,
+                'Only displayName or externalId eq filters are supported',
+                'invalidFilter',
+            )
 
     total = query.count()
     groups = query.offset(start_index - 1).limit(count).all() if count else []
@@ -1387,51 +1930,79 @@ def _list_groups_response():
 
 
 def _create_group_response(data):
-    error = _schema_error(data, SCIM_GROUP_SCHEMA)
+    replacement, error = _group_replacement(data)
     if error:
         return error
-    email, error = _group_email(data)
-    if error:
-        return error
-    if not email:
-        return _scim_error(400, 'displayName is required', 'invalidValue')
-    domain_data, error = _validate_alias_domain(email, for_update=True)
-    if error:
-        models.db.session.rollback()
-        return error
-    if _get_group(email) or _get_user(email):
-        models.db.session.rollback()
-        return _scim_error(409, f'Address {email} already exists', 'uniqueness')
-    localpart, domain = domain_data
-    group = models.Alias(localpart=localpart, domain=domain, destination=[])
-    error = _apply_group_data(group, data, replacing=True)
-    if error:
-        models.db.session.rollback()
-        return error
-    models.db.session.add(group)
+    email = replacement['aliasAddress']
     try:
+        models.lock_scim_graph()
+        domain_data, error = _validate_alias_domain(email)
+        if error:
+            models.db.session.rollback()
+            return error
+        if models.db.session.get(models.MailAddress, email):
+            models.db.session.rollback()
+            return _scim_error(
+                409,
+                f'Address {email} already exists',
+                'uniqueness',
+            )
+        localpart, domain = domain_data
+        group = models.Alias(
+            localpart=localpart,
+            domain=domain,
+            destination=[],
+            comment=replacement['displayName'],
+            disabled=False,
+            wildcard=False,
+            owner=None,
+        )
+        models.db.session.add(group)
+        models.db.session.flush()
+        resource = models.create_scim_group_mapping(
+            group,
+            resource_id=models.new_scim_id(),
+            external_id=replacement['externalId'],
+        )
+        models.replace_scim_group_graph(
+            resource,
+            member_ids=replacement['members'],
+            external_destinations=replacement['externalDestinations'],
+        )
         models.db.session.commit()
-    except IntegrityError:
+    except (IntegrityError, models.AddressConflict):
         models.db.session.rollback()
         return _scim_error(409, f'Address {email} already exists', 'uniqueness')
+    except (
+        models.ScimExternalDestinationError,
+        models.ScimGraphError,
+    ) as identity_error:
+        models.db.session.rollback()
+        return _scim_error(400, str(identity_error), 'invalidValue')
+    except models.ScimIdentityError:
+        models.db.session.rollback()
+        flask.current_app.logger.exception(
+            'SCIM Group identity invariant failed during creation'
+        )
+        return _scim_error(500, 'The SCIM Group identity is inconsistent')
     except SQLAlchemyError:
         models.db.session.rollback()
         flask.current_app.logger.exception('SCIM Group creation failed')
         return _scim_error(500, 'The SCIM Group could not be created')
-    return _scim_response(_make_group_resource(group), 201)
+    return _scim_response(_make_group_resource(resource), 201)
 
 
 def _get_group_response(group_id):
     group_id, error = _resource_id(group_id, 'Group')
     if error:
         return error
-    group = _get_group(group_id)
-    if not group:
+    resource = _get_group(group_id)
+    if not resource:
         return _scim_error(404, f'Group {group_id} cannot be found')
-    conditional = _conditional_read_response(group)
+    conditional = _conditional_read_response(resource)
     if conditional:
         return conditional
-    return _scim_response(_make_group_resource(group))
+    return _scim_response(_make_group_resource(resource))
 
 
 def _replace_group_response(
@@ -1440,49 +2011,53 @@ def _replace_group_response(
     if_match=_IF_MATCH_FROM_REQUEST,
     if_none_match=_IF_MATCH_FROM_REQUEST,
 ):
-    error = _schema_error(data, SCIM_GROUP_SCHEMA)
-    if error:
-        return error
     group_id, error = _resource_id(group_id, 'Group')
     if error:
         return error
-    group, error = _locked_resource(models.Alias, group_id)
-    if error:
-        return error
-    error = _if_match_error(group, if_match)
-    if error:
-        models.db.session.rollback()
-        return error
-    error = _if_none_match_error(group, if_none_match)
-    if error:
-        models.db.session.rollback()
-        return error
-    if not group:
-        models.db.session.rollback()
-        return _scim_error(404, f'Group {group_id} cannot be found')
-    if not isinstance(data.get('displayName'), str) or not data['displayName'].strip():
-        models.db.session.rollback()
-        return _scim_error(400, 'displayName is required', 'invalidValue')
-    supplied_id = data.get('id')
-    if supplied_id is not None:
-        new_email, error = _resource_id(supplied_id, 'Group')
+    try:
+        models.lock_scim_graph()
+        resource = _get_scim_for_update(group_id, 'Group')
+        error = _if_match_error(resource, if_match)
         if error:
             models.db.session.rollback()
             return error
-    else:
-        new_email = None
-    if new_email and new_email != group.email:
+        error = _if_none_match_error(resource, if_none_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        if not resource:
+            models.db.session.rollback()
+            return _scim_error(404, f'Group {group_id} cannot be found')
+        replacement, error = _group_replacement(data, current=resource)
+        if error:
+            models.db.session.rollback()
+            return error
+        models.permit_scim_managed_alias_edit(resource.alias)
+        resource.alias.comment = replacement['displayName']
+        resource.external_id = replacement['externalId']
+        models.replace_scim_group_graph(
+            resource,
+            member_ids=replacement['members'],
+            external_destinations=replacement['externalDestinations'],
+        )
+        models.db.session.commit()
+    except (
+        models.ScimExternalDestinationError,
+        models.ScimGraphError,
+    ) as identity_error:
         models.db.session.rollback()
-        return _scim_error(400, 'Changing group id is not supported', 'mutability')
-    error = _apply_group_data(group, data, replacing=True)
-    if error:
+        return _scim_error(400, str(identity_error), 'invalidValue')
+    except models.ScimIdentityError:
         models.db.session.rollback()
-        return error
-    models.db.session.add(group)
-    error = _commit_error()
-    if error:
-        return error
-    return _scim_response(_make_group_resource(group))
+        flask.current_app.logger.exception(
+            'SCIM Group identity invariant failed during replacement'
+        )
+        return _scim_error(500, 'The SCIM Group identity is inconsistent')
+    except SQLAlchemyError:
+        models.db.session.rollback()
+        flask.current_app.logger.exception('SCIM Group replacement failed')
+        return _scim_error(500, 'The SCIM Group could not be replaced')
+    return _scim_response(_make_group_resource(resource))
 
 
 def _patch_group_response(
@@ -1497,29 +2072,57 @@ def _patch_group_response(
     group_id, error = _resource_id(group_id, 'Group')
     if error:
         return error
-    group, error = _locked_resource(models.Alias, group_id)
-    if error:
-        return error
-    error = _if_match_error(group, if_match)
-    if error:
+    try:
+        models.lock_scim_graph()
+        resource = _get_scim_for_update(group_id, 'Group')
+        error = _if_match_error(resource, if_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        error = _if_none_match_error(resource, if_none_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        if not resource:
+            models.db.session.rollback()
+            return _scim_error(404, f'Group {group_id} cannot be found')
+        replacement = _patch_group(resource, data)
+        if not isinstance(replacement, dict):
+            models.db.session.rollback()
+            return replacement
+        if not replacement['displayName']:
+            models.db.session.rollback()
+            return _scim_error(
+                400,
+                'Group displayName is required',
+                'mutability',
+            )
+        models.permit_scim_managed_alias_edit(resource.alias)
+        resource.alias.comment = replacement['displayName']
+        resource.external_id = replacement['externalId']
+        models.replace_scim_group_graph(
+            resource,
+            member_ids=replacement['members'],
+            external_destinations=replacement['externalDestinations'],
+        )
+        models.db.session.commit()
+    except (
+        models.ScimExternalDestinationError,
+        models.ScimGraphError,
+    ) as identity_error:
         models.db.session.rollback()
-        return error
-    error = _if_none_match_error(group, if_none_match)
-    if error:
+        return _scim_error(400, str(identity_error), 'invalidValue')
+    except models.ScimIdentityError:
         models.db.session.rollback()
-        return error
-    if not group:
+        flask.current_app.logger.exception(
+            'SCIM Group identity invariant failed during patch'
+        )
+        return _scim_error(500, 'The SCIM Group identity is inconsistent')
+    except SQLAlchemyError:
         models.db.session.rollback()
-        return _scim_error(404, f'Group {group_id} cannot be found')
-    error = _patch_group(group, data)
-    if error:
-        models.db.session.rollback()
-        return error
-    models.db.session.add(group)
-    error = _commit_error()
-    if error:
-        return error
-    return _scim_response(_make_group_resource(group))
+        flask.current_app.logger.exception('SCIM Group patch failed')
+        return _scim_error(500, 'The SCIM Group could not be patched')
+    return _scim_response(_make_group_resource(resource))
 
 
 def _delete_group_response(
@@ -1530,24 +2133,41 @@ def _delete_group_response(
     group_id, error = _resource_id(group_id, 'Group')
     if error:
         return error
-    group, error = _locked_resource(models.Alias, group_id)
-    if error:
-        return error
-    error = _if_match_error(group, if_match)
-    if error:
+    try:
+        models.lock_scim_graph()
+        resource = _get_scim_for_update(group_id, 'Group')
+        error = _if_match_error(resource, if_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        error = _if_none_match_error(resource, if_none_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        if not resource:
+            models.db.session.rollback()
+            return _scim_error(404, f'Group {group_id} cannot be found')
+        alias = resource.alias
+        models.tombstone_scim_resource(resource)
+        # Persist the detached tombstone before deleting the Alias. Otherwise
+        # the generic before_flush lifecycle hook still sees the database's
+        # pre-tombstone live FK and attempts to tombstone it a second time.
+        models.db.session.flush()
+        models.db.session.delete(alias)
+        models.db.session.commit()
+    except models.ScimGraphError as identity_error:
         models.db.session.rollback()
-        return error
-    error = _if_none_match_error(group, if_none_match)
-    if error:
+        return _scim_error(400, str(identity_error), 'invalidValue')
+    except models.ScimIdentityError:
         models.db.session.rollback()
-        return error
-    if not group:
+        flask.current_app.logger.exception(
+            'SCIM Group identity invariant failed during deletion'
+        )
+        return _scim_error(500, 'The SCIM Group identity is inconsistent')
+    except SQLAlchemyError:
         models.db.session.rollback()
-        return _scim_error(404, f'Group {group_id} cannot be found')
-    models.db.session.delete(group)
-    error = _commit_error()
-    if error:
-        return error
+        flask.current_app.logger.exception('SCIM Group deletion failed')
+        return _scim_error(500, 'The SCIM Group could not be deleted')
     return '', 204
 
 
@@ -1596,17 +2216,52 @@ def list_users():
     count = _parse_positive_int(flask.request.args.get('count', 100), 100, minimum=0, maximum=200)
     if start_index is None or count is None:
         return _scim_error(400, 'startIndex and count must be integers', 'invalidValue')
-    query = models.User.query.order_by(models.User._email)
+    query = (
+        models.ScimResource.query
+        .filter(
+            models.ScimResource.resource_type == 'User',
+            models.ScimResource.deleted_at.is_(None),
+            models.ScimResource.user_email.is_not(None),
+        )
+        .join(
+            models.User,
+            models.ScimResource.user_email == models.User._email,
+        )
+        .order_by(models.ScimResource.id)
+    )
 
     filter_value = flask.request.args.get('filter')
     if filter_value:
-        email, error = _equality_filter(filter_value, 'userName')
-        if error:
-            return error
-        if not validators.email(email):
-            return _scim_error(400, 'userName filter value must be a valid email address', 'invalidFilter')
-        email = email.lower()
-        query = query.filter_by(email=email)
+        match = _FILTER_PATTERN.fullmatch(filter_value)
+        if not match:
+            return _scim_error(
+                400,
+                'Only userName or externalId eq filters are supported',
+                'invalidFilter',
+            )
+        attribute, value = match.groups()
+        if attribute.casefold() == 'username':
+            if not validators.email(value):
+                return _scim_error(
+                    400,
+                    'userName filter value must be a valid email address',
+                    'invalidFilter',
+                )
+            query = query.filter(models.User._email == value.lower())
+        elif attribute.casefold() == 'externalid':
+            try:
+                encoded = value.encode('utf-8')
+            except UnicodeEncodeError:
+                encoded = None
+            query = query.filter(
+                models.ScimResource.external_id_bytes == encoded
+            )
+        else:
+            return _scim_error(
+                400,
+                'Only userName or externalId eq filters are supported',
+                'invalidFilter',
+            )
 
     total = query.count()
     users = query.offset(start_index - 1).limit(count).all() if count else []
@@ -1627,33 +2282,67 @@ def _create_user_response(data):
     if error:
         return error
     if not email:
-        return _scim_error(400, 'userName or emails[0].value is required', 'invalidValue')
-    domain_data, error = _validate_user_domain(email, for_update=True)
+        return _scim_error(400, 'userName is required', 'invalidValue')
+    external_id, error = _external_id_value(data, replacing=True)
     if error:
-        models.db.session.rollback()
         return error
-    if _get_user(email) or _get_group(email):
-        models.db.session.rollback()
-        return _scim_error(409, f'Address {email} already exists', 'uniqueness')
-    localpart, domain = domain_data
-    user = models.User(localpart=localpart, domain=domain)
-    error, password_changed, _ = _apply_user_data(user, data, replacing=True)
-    if error:
-        models.db.session.rollback()
-        return error
-    if not password_changed:
-        user.set_password(secrets.token_urlsafe(), keep_sessions=True)
-    models.db.session.add(user)
     try:
+        models.lock_scim_graph()
+        domain_name = email.rsplit('@', 1)[1]
+        domain = models.db.session.get(models.Domain, domain_name)
+        if not domain:
+            models.db.session.rollback()
+            return _scim_error(404, f'Domain {domain_name} does not exist')
+        address = models.db.session.get(models.MailAddress, email)
+        user = models.db.session.get(models.User, email)
+        if address is not None or user is not None:
+            models.db.session.rollback()
+            return _scim_error(
+                409,
+                f'Address {email} already exists',
+                'uniqueness',
+            )
+        if (
+            domain.max_users != -1
+            and len(domain.users) >= domain.max_users
+        ):
+            models.db.session.rollback()
+            return _scim_error(
+                409,
+                f'Too many users for domain {domain_name}',
+                'uniqueness',
+            )
+        localpart = email.rsplit('@', 1)[0]
+        user = models.User(localpart=localpart, domain=domain)
+        models.db.session.add(user)
+        error, password_changed, _ = _apply_user_data(
+            user,
+            data,
+            replacing=True,
+        )
+        if error:
+            models.db.session.rollback()
+            return error
+        if not password_changed:
+            user.set_password(secrets.token_urlsafe(), keep_sessions=True)
+        models.db.session.add(user)
+        models.db.session.flush()
+        resource = models.create_scim_user_mapping(
+            user,
+            external_id=external_id,
+        )
         models.db.session.commit()
-    except IntegrityError:
+    except (IntegrityError, models.AddressConflict):
         models.db.session.rollback()
         return _scim_error(409, f'Address {email} already exists', 'uniqueness')
+    except models.ScimIdentityError as identity_error:
+        models.db.session.rollback()
+        return _scim_error(409, str(identity_error), 'uniqueness')
     except SQLAlchemyError:
         models.db.session.rollback()
         flask.current_app.logger.exception('SCIM User creation failed')
         return _scim_error(500, 'The SCIM User could not be created')
-    return _scim_response(_make_user_resource(user), 201)
+    return _scim_response(_make_user_resource(resource), 201)
 
 
 @blueprint.route('/Users/<path:user_id>', methods=['GET'])
@@ -1661,13 +2350,13 @@ def get_user(user_id):
     user_id, error = _resource_id(user_id, 'User')
     if error:
         return error
-    user = _get_user(user_id)
-    if not user:
+    resource = _get_user(user_id)
+    if not resource:
         return _scim_error(404, f'User {user_id} cannot be found')
-    conditional = _conditional_read_response(user)
+    conditional = _conditional_read_response(resource)
     if conditional:
         return conditional
-    return _scim_response(_make_user_resource(user))
+    return _scim_response(_make_user_resource(resource))
 
 
 def _replace_user_response(
@@ -1682,49 +2371,82 @@ def _replace_user_response(
     user_id, error = _resource_id(user_id, 'User')
     if error:
         return error
-    user, error = _locked_resource(models.User, user_id)
-    if error:
-        return error
-    error = _if_match_error(user, if_match)
-    if error:
+    try:
+        models.lock_scim_graph()
+        resource = _get_scim_for_update(user_id, 'User')
+        error = _if_match_error(resource, if_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        error = _if_none_match_error(resource, if_none_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        if not resource:
+            models.db.session.rollback()
+            return _scim_error(404, f'User {user_id} cannot be found')
+        user = resource.user
+        new_email, error = _user_email(
+            data,
+            require_user_name=True,
+            conflict_scim_type='mutability',
+        )
+        if error:
+            models.db.session.rollback()
+            return error
+        if not new_email:
+            models.db.session.rollback()
+            return _scim_error(
+                400,
+                'userName is required',
+                'invalidValue',
+            )
+        if new_email != user.email:
+            models.db.session.rollback()
+            return _scim_error(
+                400,
+                'Changing userName/email is not supported',
+                'mutability',
+            )
+        if 'password' in data:
+            models.db.session.rollback()
+            return _scim_error(
+                400,
+                'Changing an existing password through SCIM is not supported',
+                'mutability',
+            )
+        external_id, error = _external_id_value(data, replacing=True)
+        if error:
+            models.db.session.rollback()
+            return error
+        resource.external_id = external_id
+        error, password_changed, deactivated = _apply_user_data(
+            user,
+            data,
+            replacing=True,
+        )
+        if error:
+            models.db.session.rollback()
+            return error
+        models.db.session.add(resource)
+        models.db.session.add(user)
+        error = _commit_user_change(
+            user,
+            prune_sessions=password_changed or deactivated,
+        )
+        if error:
+            return error
+    except models.ScimIdentityError:
         models.db.session.rollback()
-        return error
-    error = _if_none_match_error(user, if_none_match)
-    if error:
+        flask.current_app.logger.exception(
+            'SCIM User identity invariant failed during replacement'
+        )
+        return _scim_error(500, 'The SCIM User identity is inconsistent')
+    except SQLAlchemyError:
         models.db.session.rollback()
-        return error
-    if not user:
-        models.db.session.rollback()
-        return _scim_error(404, f'User {user_id} cannot be found')
-    new_email, error = _user_email(
-        data,
-        require_user_name=True,
-        conflict_scim_type='mutability',
-    )
-    if error:
-        models.db.session.rollback()
-        return error
-    if not new_email:
-        models.db.session.rollback()
-        return _scim_error(400, 'userName or emails[0].value is required', 'invalidValue')
-    if new_email != user.email:
-        models.db.session.rollback()
-        return _scim_error(400, 'Changing userName/email is not supported', 'mutability')
-    if 'password' in data:
-        models.db.session.rollback()
-        return _scim_error(400, 'Changing an existing password through SCIM is not supported', 'mutability')
-    error, password_changed, deactivated = _apply_user_data(user, data, replacing=True)
-    if error:
-        models.db.session.rollback()
-        return error
-    models.db.session.add(user)
-    error = _commit_user_change(
-        user,
-        prune_sessions=password_changed or deactivated,
-    )
-    if error:
-        return error
-    return _scim_response(_make_user_resource(user))
+        flask.current_app.logger.exception('SCIM User replacement failed')
+        return _scim_error(500, 'The SCIM User could not be replaced')
+    return _scim_response(_make_user_resource(resource))
 
 
 def _patch_user_response(
@@ -1739,29 +2461,43 @@ def _patch_user_response(
     user_id, error = _resource_id(user_id, 'User')
     if error:
         return error
-    user, error = _locked_resource(models.User, user_id)
-    if error:
-        return error
-    error = _if_match_error(user, if_match)
-    if error:
+    try:
+        models.lock_scim_graph()
+        resource = _get_scim_for_update(user_id, 'User')
+        error = _if_match_error(resource, if_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        error = _if_none_match_error(resource, if_none_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        if not resource:
+            models.db.session.rollback()
+            return _scim_error(404, f'User {user_id} cannot be found')
+        error, prune_sessions = _patch_user(resource, data)
+        if error:
+            models.db.session.rollback()
+            return error
+        models.db.session.add(resource)
+        models.db.session.add(resource.user)
+        error = _commit_user_change(
+            resource.user,
+            prune_sessions=prune_sessions,
+        )
+        if error:
+            return error
+    except models.ScimIdentityError:
         models.db.session.rollback()
-        return error
-    error = _if_none_match_error(user, if_none_match)
-    if error:
+        flask.current_app.logger.exception(
+            'SCIM User identity invariant failed during patch'
+        )
+        return _scim_error(500, 'The SCIM User identity is inconsistent')
+    except SQLAlchemyError:
         models.db.session.rollback()
-        return error
-    if not user:
-        models.db.session.rollback()
-        return _scim_error(404, f'User {user_id} cannot be found')
-    error, prune_sessions = _patch_user(user, data)
-    if error:
-        models.db.session.rollback()
-        return error
-    models.db.session.add(user)
-    error = _commit_user_change(user, prune_sessions=prune_sessions)
-    if error:
-        return error
-    return _scim_response(_make_user_resource(user))
+        flask.current_app.logger.exception('SCIM User patch failed')
+        return _scim_error(500, 'The SCIM User could not be patched')
+    return _scim_response(_make_user_resource(resource))
 
 
 def _delete_user_response(
@@ -1772,25 +2508,45 @@ def _delete_user_response(
     user_id, error = _resource_id(user_id, 'User')
     if error:
         return error
-    user, error = _locked_resource(models.User, user_id)
-    if error:
-        return error
-    error = _if_match_error(user, if_match)
-    if error:
+    try:
+        models.lock_scim_graph()
+        resource = _get_scim_for_update(user_id, 'User')
+        error = _if_match_error(resource, if_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        error = _if_none_match_error(resource, if_none_match)
+        if error:
+            models.db.session.rollback()
+            return error
+        if not resource:
+            models.db.session.rollback()
+            return _scim_error(404, f'User {user_id} cannot be found')
+        email = resource.user.email
+        models.tombstone_scim_resource(
+            resource,
+            scrub_user_authority=True,
+        )
+        models.db.session.commit()
+    except models.ScimGraphError as identity_error:
         models.db.session.rollback()
-        return error
-    error = _if_none_match_error(user, if_none_match)
-    if error:
+        return _scim_error(400, str(identity_error), 'invalidValue')
+    except models.ScimIdentityError:
         models.db.session.rollback()
-        return error
-    if not user:
+        flask.current_app.logger.exception(
+            'SCIM User identity invariant failed during deletion'
+        )
+        return _scim_error(500, 'The SCIM User identity is inconsistent')
+    except SQLAlchemyError:
         models.db.session.rollback()
-        return _scim_error(404, f'User {user_id} cannot be found')
-    user.enabled = False
-    models.db.session.add(user)
-    error = _commit_user_change(user, prune_sessions=True)
-    if error:
-        return error
+        flask.current_app.logger.exception('SCIM User deletion failed')
+        return _scim_error(500, 'The SCIM User could not be deleted')
+    try:
+        utils.MailuSessionExtension.prune_sessions(uid=email)
+    except Exception:
+        flask.current_app.logger.exception(
+            'SCIM post-commit session cleanup failed'
+        )
     return '', 204
 
 @blueprint.route('/Users', methods=['POST'])
@@ -1823,38 +2579,117 @@ def delete_user(user_id):
 
 
 def _resolve_bulk_ids(value, bulk_ids):
-    if isinstance(value, str) and value.startswith('bulkId:'):
-        return bulk_ids.get(value[7:], value)
-    if isinstance(value, list):
-        return [_resolve_bulk_ids(item, bulk_ids) for item in value]
-    if isinstance(value, dict):
-        return {key: _resolve_bulk_ids(item, bulk_ids) for key, item in value.items()}
-    return value
+    """Resolve Bulk references only in Group member reference slots."""
+    if not isinstance(value, dict):
+        return value
+    resolved = dict(value)
+    if 'members' in resolved:
+        members = resolved['members']
+        if isinstance(members, list):
+            resolved_members = []
+            for member in members:
+                if (
+                    isinstance(member, str)
+                    and member.startswith('bulkId:')
+                ):
+                    member = bulk_ids.get(member[7:], member)
+                elif isinstance(member, dict):
+                    member = dict(member)
+                    reference = member.get('value')
+                    if (
+                        isinstance(reference, str)
+                        and reference.startswith('bulkId:')
+                    ):
+                        member['value'] = bulk_ids.get(
+                            reference[7:],
+                            reference,
+                        )
+                resolved_members.append(member)
+            resolved['members'] = resolved_members
+    operations = resolved.get('Operations')
+    if isinstance(operations, list):
+        resolved_operations = []
+        for operation in operations:
+            if not isinstance(operation, dict):
+                resolved_operations.append(operation)
+                continue
+            operation = dict(operation)
+            path = operation.get('path')
+            if not path and isinstance(operation.get('value'), dict):
+                operation['value'] = _resolve_bulk_ids(
+                    operation['value'],
+                    bulk_ids,
+                )
+            elif isinstance(path, str):
+                core_path = _schema_path(path.strip(), SCIM_GROUP_SCHEMA)
+                if core_path.casefold() == 'members':
+                    wrapped = {
+                        'members': (
+                            operation.get('value')
+                            if isinstance(operation.get('value'), list)
+                            else [operation.get('value')]
+                        )
+                    }
+                    operation['value'] = _resolve_bulk_ids(
+                        wrapped,
+                        bulk_ids,
+                    )['members']
+            resolved_operations.append(operation)
+        resolved['Operations'] = resolved_operations
+    return resolved
+
+
+def _member_bulk_references(value):
+    references = set()
+    if not isinstance(value, dict):
+        return references
+    members = value.get('members')
+    if isinstance(members, list):
+        for member in members:
+            reference = (
+                member.get('value')
+                if isinstance(member, dict)
+                else member
+            )
+            if isinstance(reference, str) and reference.startswith('bulkId:'):
+                references.add(reference[7:])
+    operations = value.get('Operations')
+    if isinstance(operations, list):
+        for operation in operations:
+            if not isinstance(operation, dict):
+                continue
+            path = operation.get('path')
+            if not path and isinstance(operation.get('value'), dict):
+                references.update(
+                    _member_bulk_references(operation['value'])
+                )
+            elif isinstance(path, str):
+                core_path = _schema_path(path.strip(), SCIM_GROUP_SCHEMA)
+                if core_path.casefold() == 'members':
+                    item = operation.get('value')
+                    references.update(_member_bulk_references({
+                        'members': item if isinstance(item, list) else [item],
+                    }))
+    return references
 
 
 def _bulk_id_references(value):
-    if isinstance(value, str):
-        return {value[7:]} if value.startswith('bulkId:') else set()
-    if isinstance(value, list):
-        references = set()
-        for item in value:
-            references.update(_bulk_id_references(item))
-        return references
-    if isinstance(value, dict):
-        references = set()
-        for item in value.values():
-            references.update(_bulk_id_references(item))
-        return references
+    return _member_bulk_references(value)
+
+
+def _path_bulk_reference(operation):
+    path = operation.get('path')
+    if not isinstance(path, str):
+        return set()
+    parts = path.lstrip('/').split('/', 1)
+    if len(parts) == 2 and parts[1].startswith('bulkId:'):
+        return {parts[1][7:]}
     return set()
 
 
 def _operation_bulk_references(operation):
-    references = _bulk_id_references(operation.get('data'))
-    path = operation.get('path')
-    if isinstance(path, str):
-        parts = path.lstrip('/').split('/', 1)
-        if len(parts) == 2 and parts[1].startswith('bulkId:'):
-            references.add(parts[1][7:])
+    references = _member_bulk_references(operation.get('data'))
+    references.update(_path_bulk_reference(operation))
     return references
 
 
@@ -2076,21 +2911,28 @@ def bulk():
         return _scim_error(400, 'Operations must not be empty', 'invalidValue')
     if len(operations) > SCIM_MAX_BULK_OPERATIONS:
         return _scim_error(413, 'Too many bulk operations', 'tooMany')
-    raw_fail_on_errors = data.get('failOnErrors', len(operations))
-    try:
-        fail_on_errors = int(raw_fail_on_errors)
-    except (TypeError, ValueError):
-        fail_on_errors = None
-    if isinstance(raw_fail_on_errors, bool) or fail_on_errors is None or fail_on_errors < 0:
+    fail_on_errors = data.get('failOnErrors', len(operations))
+    if (
+        isinstance(fail_on_errors, bool)
+        or not isinstance(fail_on_errors, int)
+        or fail_on_errors < 0
+    ):
         return _scim_error(400, 'failOnErrors must be a non-negative integer', 'invalidValue')
     bulk_id_values = []
     for operation in operations:
         if not isinstance(operation, dict):
             continue
         bulk_id = operation.get('bulkId')
-        method = _string_value(operation.get('method')).upper()
+        method_value = operation.get('method')
+        if not isinstance(method_value, str):
+            return _scim_error(400, 'Bulk operation method must be a string', 'invalidValue')
+        method = method_value.upper()
+        if method not in ('POST', 'PUT', 'PATCH', 'DELETE'):
+            return _scim_error(400, f'Unsupported bulk method {method!r}', 'invalidValue')
         if method == 'POST' and (not isinstance(bulk_id, str) or not bulk_id):
             return _scim_error(400, 'POST bulk operations require a non-empty bulkId', 'invalidValue')
+        if method != 'POST' and bulk_id is not None:
+            return _scim_error(400, 'bulkId is permitted only for POST operations', 'invalidValue')
         if bulk_id is not None and (not isinstance(bulk_id, str) or not bulk_id):
             return _scim_error(400, 'bulkId must be a non-empty string', 'invalidValue')
         if bulk_id in bulk_id_values:

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -8,8 +8,9 @@ import flask
 import sqlalchemy
 import validators
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from werkzeug.datastructures import ETags
 from werkzeug.exceptions import HTTPException
-from werkzeug.http import parse_etags, unquote_etag
+from werkzeug.http import unquote_etag
 
 from . import common
 from .. import models, utils
@@ -349,16 +350,87 @@ def _locked_resource(model, resource_id):
         return None, _scim_error(500, 'The SCIM resource could not be locked')
 
 
+def _parse_entity_tags(value, field_name):
+    if not isinstance(value, str):
+        return None, _scim_error(
+            400,
+            f'{field_name} must be an entity-tag string',
+            'invalidValue',
+        )
+
+    def invalid():
+        return None, _scim_error(
+            400,
+            f'{field_name} must contain valid HTTP entity-tags',
+            'invalidValue',
+        )
+
+    length = len(value)
+    start = 0
+    while start < length and value[start] in ' \t':
+        start += 1
+    end = length
+    while end > start and value[end - 1] in ' \t':
+        end -= 1
+    if end - start == 1 and value[start] == '*':
+        return ETags(star_tag=True), None
+
+    strong = []
+    weak = []
+    position = 0
+    while True:
+        while position < length and value[position] in ' \t':
+            position += 1
+        if position == length:
+            return ETags(strong, weak), None
+        if value[position] == ',':
+            position += 1
+            continue
+
+        is_weak = value.startswith('W/', position)
+        if is_weak:
+            position += 2
+        if position == length or value[position] != '"':
+            return invalid()
+        position += 1
+        tag_start = position
+        while position < length and value[position] != '"':
+            codepoint = ord(value[position])
+            if not (
+                codepoint == 0x21
+                or 0x23 <= codepoint <= 0x7e
+                or 0x80 <= codepoint <= 0xff
+            ):
+                return invalid()
+            position += 1
+        if position == length:
+            return invalid()
+        tag = value[tag_start:position]
+        position += 1
+        (weak if is_weak else strong).append(tag)
+
+        while position < length and value[position] in ' \t':
+            position += 1
+        if position == length:
+            return ETags(strong, weak), None
+        if value[position] != ',':
+            return invalid()
+        position += 1
+
+
 def _if_match_error(resource, value=_IF_MATCH_FROM_REQUEST):
     if value is _IF_MATCH_FROM_REQUEST:
         value = flask.request.headers.get('If-Match')
+        field_name = 'If-Match'
+    else:
+        field_name = 'version'
     if value is None:
         return None
-    if not isinstance(value, str):
-        return _scim_error(400, 'version must be an entity-tag string', 'invalidValue')
+    candidates, error = _parse_entity_tags(value, field_name)
+    if error:
+        return error
     if resource is None:
         return _scim_error(412, 'If-Match does not match the current resource version')
-    candidates = parse_etags(value)
     current = _resource_version(resource)
     current_opaque, current_is_weak = unquote_etag(current)
     if candidates.star_tag or (not current_is_weak and candidates.contains(current_opaque)):
@@ -373,7 +445,9 @@ def _conditional_read_response(resource):
     value = flask.request.headers.get('If-None-Match')
     if value is None:
         return None
-    candidates = parse_etags(value)
+    candidates, error = _parse_entity_tags(value, 'If-None-Match')
+    if error:
+        return error
     current = _resource_version(resource)
     current_opaque, _ = unquote_etag(current)
     if candidates.star_tag or candidates.contains_weak(current_opaque):
@@ -384,9 +458,13 @@ def _conditional_read_response(resource):
 def _if_none_match_error(resource, value=_IF_MATCH_FROM_REQUEST):
     if value is _IF_MATCH_FROM_REQUEST:
         value = flask.request.headers.get('If-None-Match')
-    if value is None or resource is None:
+    if value is None:
         return None
-    candidates = parse_etags(value)
+    candidates, error = _parse_entity_tags(value, 'If-None-Match')
+    if error:
+        return error
+    if resource is None:
+        return None
     current = _resource_version(resource)
     current_opaque, _ = unquote_etag(current)
     if candidates.star_tag or candidates.contains_weak(current_opaque):
@@ -439,12 +517,32 @@ def _database_error(_error):
     return _scim_error(500, 'The SCIM database operation failed')
 
 
+def _reject_duplicate_json_names(pairs):
+    value = {}
+    for key, item in pairs:
+        if key in value:
+            raise _AmbiguousScimKeys(f'Duplicate JSON member name {key!r}')
+        value[key] = item
+    return value
+
+
 def _payload():
-    data = flask.request.get_json(silent=True)
-    if data is None:
-        if flask.request.get_data(cache=True).strip():
-            return None, _scim_error(400, 'Request body must be valid JSON', 'invalidSyntax')
+    raw_data = flask.request.get_data(cache=True)
+    if not raw_data.strip():
         return {}, None
+    if not flask.request.is_json:
+        return None, _scim_error(400, 'Request body must be valid JSON', 'invalidSyntax')
+    try:
+        data = flask.current_app.json.loads(
+            raw_data,
+            object_pairs_hook=_reject_duplicate_json_names,
+        )
+    except _AmbiguousScimKeys as error:
+        return None, _scim_error(400, str(error), 'invalidSyntax')
+    except (TypeError, ValueError):
+        return None, _scim_error(400, 'Request body must be valid JSON', 'invalidSyntax')
+    if data is None:
+        return None, _scim_error(400, 'Request body must be valid JSON', 'invalidSyntax')
     if not isinstance(data, dict):
         return None, _scim_error(400, 'Request body must be a JSON object', 'invalidSyntax')
     try:
@@ -1971,7 +2069,7 @@ def bulk():
     error = _schema_error(data, SCIM_BULK_REQUEST_SCHEMA)
     if error:
         return error
-    operations = data.get('Operations') or data.get('operations')
+    operations = data['Operations'] if 'Operations' in data else data.get('operations')
     if not isinstance(operations, list):
         return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
     if not operations:

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -60,6 +60,14 @@ def _parse_positive_int(value, default, *, minimum=0):
     return max(parsed, minimum)
 
 
+def _string_value(value):
+    if value is None:
+        return ''
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
 def _active_value(value):
     if isinstance(value, bool):
         return value, None
@@ -73,25 +81,30 @@ def _active_value(value):
 
 
 def _user_email(data):
-    user_name = (data.get('userName') or '').strip().lower()
+    user_name = _string_value(data.get('userName')).strip().lower()
     if user_name:
         return user_name
     for email in data.get('emails') or []:
         if not isinstance(email, dict):
             continue
-        value = (email.get('value') or '').strip().lower()
+        value = _string_value(email.get('value')).strip().lower()
         if value:
             return value
     return ''
 
 
 def _display_name(data):
-    if data.get('displayName'):
-        return data['displayName']
+    if data.get('displayName') is not None:
+        display_name = _string_value(data.get('displayName')).strip()
+        if display_name:
+            return display_name
     name = data.get('name') or {}
-    if name.get('formatted'):
-        return name['formatted']
-    parts = [name.get('givenName'), name.get('familyName')]
+    if not isinstance(name, dict):
+        return ''
+    formatted = _string_value(name.get('formatted')).strip()
+    if formatted:
+        return formatted
+    parts = [_string_value(name.get('givenName')).strip(), _string_value(name.get('familyName')).strip()]
     return ' '.join(part for part in parts if part)
 
 
@@ -166,8 +179,8 @@ def _patch_user(user, data):
     for operation in operations:
         if not isinstance(operation, dict):
             return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax')
-        op = (operation.get('op') or 'replace').lower()
-        path = (operation.get('path') or '').lower()
+        op = _string_value(operation.get('op') or 'replace').lower()
+        path = _string_value(operation.get('path')).lower()
         value = operation.get('value')
         if op not in ('add', 'replace'):
             continue
@@ -184,19 +197,19 @@ def _patch_user(user, data):
                 user.enabled = active
         if path in ('displayname', '') and (path or isinstance(value, dict)):
             if path == 'displayname' and value is not None:
-                user.displayed_name = str(value)
+                user.displayed_name = _string_value(value)
             elif isinstance(value, dict):
                 display_name = _display_name(value)
                 if display_name:
                     user.displayed_name = display_name
         if path in ('name.formatted', 'name', '') and value:
             if path == 'name.formatted':
-                user.displayed_name = str(value)
+                user.displayed_name = _string_value(value)
             elif path == 'name' and isinstance(value, dict) and value.get('formatted'):
                 user.displayed_name = value['formatted']
         if path in ('password', ''):
             if path == 'password' and value:
-                user.set_password(str(value))
+                user.set_password(_string_value(value))
             elif isinstance(value, dict) and value.get('password'):
                 user.set_password(value['password'])
     return None

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -46,8 +46,30 @@ def _scim_error(status, detail, scim_type=None):
 def _payload():
     data = flask.request.get_json(silent=True)
     if data is None:
-        return {}
-    return data
+        return {}, None
+    if not isinstance(data, dict):
+        return None, _scim_error(400, 'Request body must be a JSON object', 'invalidSyntax')
+    return data, None
+
+
+def _parse_positive_int(value, default, *, minimum=0):
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return max(parsed, minimum)
+
+
+def _active_value(value):
+    if isinstance(value, bool):
+        return value, None
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered == 'true':
+            return True, None
+        if lowered == 'false':
+            return False, None
+    return None, _scim_error(400, 'active must be a boolean', 'invalidValue')
 
 
 def _user_email(data):
@@ -55,6 +77,8 @@ def _user_email(data):
     if user_name:
         return user_name
     for email in data.get('emails') or []:
+        if not isinstance(email, dict):
+            continue
         value = (email.get('value') or '').strip().lower()
         if value:
             return value
@@ -114,20 +138,34 @@ def _validate_user_domain(email):
 
 def _apply_user_data(user, data, *, replacing=False):
     if replacing:
-        user.enabled = bool(data.get('active', True))
+        if 'active' in data:
+            active, error = _active_value(data['active'])
+            if error:
+                return error
+            user.enabled = active
+        else:
+            user.enabled = True
     elif 'active' in data:
-        user.enabled = bool(data['active'])
+        active, error = _active_value(data['active'])
+        if error:
+            return error
+        user.enabled = active
 
     display_name = _display_name(data)
     if display_name:
         user.displayed_name = display_name
     if data.get('password'):
         user.set_password(data['password'])
+    return None
 
 
 def _patch_user(user, data):
     operations = data.get('Operations') or data.get('operations') or []
+    if not isinstance(operations, list):
+        return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
     for operation in operations:
+        if not isinstance(operation, dict):
+            return _scim_error(400, 'Patch operations must be objects', 'invalidSyntax')
         op = (operation.get('op') or 'replace').lower()
         path = (operation.get('path') or '').lower()
         value = operation.get('value')
@@ -135,9 +173,15 @@ def _patch_user(user, data):
             continue
         if path in ('active', '') and (path or isinstance(value, dict)):
             if path == 'active':
-                user.enabled = bool(value)
+                active, error = _active_value(value)
+                if error:
+                    return error
+                user.enabled = active
             elif isinstance(value, dict) and 'active' in value:
-                user.enabled = bool(value['active'])
+                active, error = _active_value(value['active'])
+                if error:
+                    return error
+                user.enabled = active
         if path in ('displayname', '') and (path or isinstance(value, dict)):
             if path == 'displayname' and value is not None:
                 user.displayed_name = str(value)
@@ -155,6 +199,7 @@ def _patch_user(user, data):
                 user.set_password(str(value))
             elif isinstance(value, dict) and value.get('password'):
                 user.set_password(value['password'])
+    return None
 
 
 @blueprint.before_request
@@ -243,8 +288,10 @@ def unsupported_groups(group_id=None):
 
 @blueprint.route('/Users', methods=['GET'])
 def list_users():
-    start_index = max(int(flask.request.args.get('startIndex', 1)), 1)
-    count = max(int(flask.request.args.get('count', 100)), 0)
+    start_index = _parse_positive_int(flask.request.args.get('startIndex', 1), 1, minimum=1)
+    count = _parse_positive_int(flask.request.args.get('count', 100), 100, minimum=0)
+    if start_index is None or count is None:
+        return _scim_error(400, 'startIndex and count must be integers', 'invalidValue')
     query = models.User.query.order_by(models.User._email)
 
     filter_value = flask.request.args.get('filter')
@@ -268,7 +315,9 @@ def list_users():
 
 @blueprint.route('/Users', methods=['POST'])
 def create_user():
-    data = _payload()
+    data, error = _payload()
+    if error:
+        return error
     email = _user_email(data)
     if not email:
         return _scim_error(400, 'userName or emails[0].value is required', 'invalidValue')
@@ -280,7 +329,9 @@ def create_user():
     localpart, domain = domain_data
     user = models.User(localpart=localpart, domain=domain)
     user.set_password(data.get('password') or secrets.token_urlsafe())
-    _apply_user_data(user, data, replacing=True)
+    error = _apply_user_data(user, data, replacing=True)
+    if error:
+        return error
     models.db.session.add(user)
     models.db.session.commit()
     return _scim_response(_make_user_resource(user), 201)
@@ -299,11 +350,15 @@ def replace_user(user_id):
     user = _get_user(user_id)
     if not user:
         return _scim_error(404, f'User {user_id} cannot be found')
-    data = _payload()
+    data, error = _payload()
+    if error:
+        return error
     new_email = _user_email(data)
     if new_email and new_email != user.email:
         return _scim_error(400, 'Changing userName/email is not supported', 'mutability')
-    _apply_user_data(user, data, replacing=True)
+    error = _apply_user_data(user, data, replacing=True)
+    if error:
+        return error
     models.db.session.add(user)
     models.db.session.commit()
     return _scim_response(_make_user_resource(user))
@@ -314,7 +369,12 @@ def patch_user(user_id):
     user = _get_user(user_id)
     if not user:
         return _scim_error(404, f'User {user_id} cannot be found')
-    _patch_user(user, _payload())
+    data, error = _payload()
+    if error:
+        return error
+    error = _patch_user(user, data)
+    if error:
+        return error
     models.db.session.add(user)
     models.db.session.commit()
     return _scim_response(_make_user_resource(user))

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -46,6 +46,8 @@ def _scim_error(status, detail, scim_type=None):
 def _payload():
     data = flask.request.get_json(silent=True)
     if data is None:
+        if flask.request.get_data(cache=True).strip():
+            return None, _scim_error(400, 'Request body must be valid JSON', 'invalidSyntax')
         return {}, None
     if not isinstance(data, dict):
         return None, _scim_error(400, 'Request body must be a JSON object', 'invalidSyntax')

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -187,7 +187,10 @@ def _apply_user_data(user, data, *, replacing=False):
 
 
 def _patch_user(user, data):
-    operations = data.get('Operations') or data.get('operations')
+    if 'Operations' in data:
+        operations = data['Operations']
+    else:
+        operations = data.get('operations')
     if not isinstance(operations, list):
         return _scim_error(400, 'Operations must be a list', 'invalidSyntax')
     if not operations:

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -8,6 +8,7 @@ import flask
 import sqlalchemy
 import validators
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
+from sqlalchemy.orm import contains_eager, joinedload, selectinload
 from werkzeug.datastructures import ETags
 from werkzeug.exceptions import HTTPException
 from werkzeug.http import unquote_etag
@@ -40,6 +41,12 @@ _PROJECTION_SEGMENT_PATTERN = re.compile(
     r'^(?:[A-Za-z][A-Za-z0-9_-]*|\$ref)$'
 )
 _INVALID_PERCENT_ESCAPE = re.compile(r'%(?![0-9A-Fa-f]{2})')
+_GROUP_READ_OPTIONS = (
+    selectinload(models.ScimResource.member_edges).joinedload(
+        models.ScimGroupMember.member
+    ),
+    selectinload(models.ScimResource.destinations),
+)
 _SCIM_KEY_CASES = {
     key.lower(): key
     for key in (
@@ -850,11 +857,19 @@ def _resource_id(value, resource_type):
 
 
 def _get_user(user_id):
-    return models.ScimResource.get_exact(
-        user_id,
-        resource_type='User',
-        active_only=True,
+    resource = (
+        models.ScimResource.query
+        .filter(
+            models.ScimResource.id == user_id,
+            models.ScimResource.resource_type == 'User',
+            models.ScimResource.deleted_at.is_(None),
+        )
+        .options(joinedload(models.ScimResource.user))
+        .one_or_none()
     )
+    if resource is None or resource.id != user_id:
+        return None
+    return resource
 
 
 def _get_scim_for_update(resource_id, resource_type):
@@ -926,11 +941,22 @@ def _make_user_resource(resource):
 
 
 def _get_group(group_id):
-    return models.ScimResource.get_exact(
-        group_id,
-        resource_type='Group',
-        active_only=True,
+    resource = (
+        models.ScimResource.query
+        .filter(
+            models.ScimResource.id == group_id,
+            models.ScimResource.resource_type == 'Group',
+            models.ScimResource.deleted_at.is_(None),
+        )
+        .options(
+            joinedload(models.ScimResource.alias),
+            *_GROUP_READ_OPTIONS,
+        )
+        .one_or_none()
     )
+    if resource is None or resource.id != group_id:
+        return None
+    return resource
 
 
 def _member_values(data):
@@ -1878,6 +1904,10 @@ def _list_groups_response():
             models.Alias,
             models.ScimResource.alias_email == models.Alias._email,
         )
+        .options(
+            contains_eager(models.ScimResource.alias),
+            *_GROUP_READ_OPTIONS,
+        )
         .order_by(models.ScimResource.id)
     )
 
@@ -2227,6 +2257,7 @@ def list_users():
             models.User,
             models.ScimResource.user_email == models.User._email,
         )
+        .options(contains_eager(models.ScimResource.user))
         .order_by(models.ScimResource.id)
     )
 

--- a/core/admin/mailu/api/scim.py
+++ b/core/admin/mailu/api/scim.py
@@ -959,6 +959,30 @@ def _get_group(group_id):
     return resource
 
 
+def _reload_committed_group(group_id):
+    resource = _get_group(group_id)
+    if resource is None:
+        raise models.ScimIdentityError(
+            f'Committed SCIM Group {group_id!r} cannot be reloaded'
+        )
+    return resource
+
+
+def _committed_group_response(group_id, status=200):
+    try:
+        resource = _reload_committed_group(group_id)
+    except (models.ScimIdentityError, SQLAlchemyError):
+        models.db.session.rollback()
+        flask.current_app.logger.exception(
+            'Committed SCIM Group reload failed'
+        )
+        return _scim_error(
+            500,
+            'The committed SCIM Group could not be reloaded',
+        )
+    return _scim_response(_make_group_resource(resource), status)
+
+
 def _member_values(data):
     members = data.get('members', [])
     if members is None:
@@ -1999,6 +2023,7 @@ def _create_group_response(data):
             member_ids=replacement['members'],
             external_destinations=replacement['externalDestinations'],
         )
+        resource_id = resource.id
         models.db.session.commit()
     except (IntegrityError, models.AddressConflict):
         models.db.session.rollback()
@@ -2019,7 +2044,7 @@ def _create_group_response(data):
         models.db.session.rollback()
         flask.current_app.logger.exception('SCIM Group creation failed')
         return _scim_error(500, 'The SCIM Group could not be created')
-    return _scim_response(_make_group_resource(resource), 201)
+    return _committed_group_response(resource_id, 201)
 
 
 def _get_group_response(group_id):
@@ -2070,6 +2095,7 @@ def _replace_group_response(
             member_ids=replacement['members'],
             external_destinations=replacement['externalDestinations'],
         )
+        resource_id = resource.id
         models.db.session.commit()
     except (
         models.ScimExternalDestinationError,
@@ -2087,7 +2113,7 @@ def _replace_group_response(
         models.db.session.rollback()
         flask.current_app.logger.exception('SCIM Group replacement failed')
         return _scim_error(500, 'The SCIM Group could not be replaced')
-    return _scim_response(_make_group_resource(resource))
+    return _committed_group_response(resource_id)
 
 
 def _patch_group_response(
@@ -2135,6 +2161,7 @@ def _patch_group_response(
             member_ids=replacement['members'],
             external_destinations=replacement['externalDestinations'],
         )
+        resource_id = resource.id
         models.db.session.commit()
     except (
         models.ScimExternalDestinationError,
@@ -2152,7 +2179,7 @@ def _patch_group_response(
         models.db.session.rollback()
         flask.current_app.logger.exception('SCIM Group patch failed')
         return _scim_error(500, 'The SCIM Group could not be patched')
-    return _scim_response(_make_group_resource(resource))
+    return _committed_group_response(resource_id)
 
 
 def _delete_group_response(

--- a/core/admin/mailu/api/v1/alias.py
+++ b/core/admin/mailu/api/v1/alias.py
@@ -69,6 +69,9 @@ class Aliases(Resource):
         alias_found = models.Alias.query.filter_by(email = data['email']).first()
         if alias_found:
           return { 'code': 409, 'message': f'Duplicate alias {data["email"]}'}, 409
+        user_found = models.User.query.filter_by(email=data['email']).first()
+        if user_found:
+          return { 'code': 409, 'message': f'Email address {data["email"]} is already used'}, 409
 
         alias_model = models.Alias(email=data["email"],destination=data['destination'])
         if 'comment' in data:
@@ -76,7 +79,11 @@ class Aliases(Resource):
         if 'wildcard' in data:
           alias_model.wildcard = data['wildcard']
         db.session.add(alias_model)
-        db.session.commit()
+        try:
+          db.session.commit()
+        except models.AddressConflict:
+          db.session.rollback()
+          return { 'code': 409, 'message': f'Email address {data["email"]} is already used'}, 409
 
         return {'code': 200, 'message': f'Alias {data["email"]} to destination(s) {data["destination"]} has been created'}, 200
 

--- a/core/admin/mailu/api/v1/alias.py
+++ b/core/admin/mailu/api/v1/alias.py
@@ -112,6 +112,7 @@ class Alias(Resource):
     @alias.doc(responses={401: 'Authorization header missing', 403: 'Invalid authorization header'})
     @alias.response(404, 'Alias not found', response_fields)
     @alias.response(400, 'Input validation exception', response_fields)
+    @alias.response(409, 'Alias is managed by SCIM', response_fields)
     @alias.doc(security='Bearer')
     @common.api_token_authorization
     def patch(self, alias):
@@ -123,19 +124,24 @@ class Alias(Resource):
       alias_found = models.Alias.query.filter_by(email = alias).first()
       if alias_found is None:
         return { 'code': 404, 'message': f'Alias {alias} cannot be found'}, 404
-      if 'comment' in data:
-        alias_found.comment = data['comment']
       if 'destination' in data:
-        alias_found.destination = data['destination']
         for dest in data['destination']:
             if not validators.email(dest):
                 return { 'code': 400, 'message': f'Provided destination email address {dest} is not a valid email address'}, 400
             elif models.User.query.filter_by(email=dest).first() is None:
                 return { 'code': 404, 'message': f'Provided destination email address {dest} does not exist'}, 404
+      if 'comment' in data:
+        alias_found.comment = data['comment']
+      if 'destination' in data:
+        alias_found.destination = data['destination']
       if 'wildcard' in data:
         alias_found.wildcard = data['wildcard']
       db.session.add(alias_found)
-      db.session.commit()
+      try:
+        db.session.commit()
+      except models.ScimManagedAliasError as exc:
+        db.session.rollback()
+        return {'code': 409, 'message': str(exc)}, 409
       return {'code': 200, 'message': f'Alias {alias} has been updated'}
 
     @alias.doc('delete_alias')
@@ -143,6 +149,7 @@ class Alias(Resource):
     @alias.response(400, 'Input validation exception', response_fields)
     @alias.doc(responses={401: 'Authorization header missing', 403: 'Invalid authorization header'})
     @alias.response(404, 'Alias not found', response_fields)
+    @alias.response(409, 'Alias is managed by SCIM', response_fields)
     @alias.doc(security='Bearer')
     @common.api_token_authorization
     def delete(self, alias):
@@ -152,8 +159,12 @@ class Alias(Resource):
       alias_found = models.Alias.query.filter_by(email = alias).first()
       if alias_found is None:
         return { 'code': 404, 'message': f'Alias {alias} cannot be found'}, 404
-      db.session.delete(alias_found)
-      db.session.commit()
+      try:
+        db.session.delete(alias_found)
+        db.session.commit()
+      except models.ScimManagedAliasError as exc:
+        db.session.rollback()
+        return {'code': 409, 'message': str(exc)}, 409
       return {'code': 200, 'message': f'Alias {alias} has been deleted'}, 200
 
 @alias.route('/destination/<string:domain>')

--- a/core/admin/mailu/api/v1/domain.py
+++ b/core/admin/mailu/api/v1/domain.py
@@ -200,6 +200,7 @@ class Domain(Resource):
     @dom.response(400, 'Input validation exception', response_fields)
     @dom.doc(responses={401: 'Authorization header missing', 403: 'Invalid authorization header'})
     @dom.response(404, 'Domain not found', response_fields)
+    @dom.response(409, 'Domain contains a SCIM-managed Alias', response_fields)
     @dom.doc(security='Bearer')
     @common.api_token_authorization
     def delete(self, domain):
@@ -209,8 +210,12 @@ class Domain(Resource):
         domain_found = models.Domain.query.get(domain)
         if not domain_found:
             return { 'code': 404, 'message': f'Domain {domain} does not exist'}, 404
-        db.session.delete(domain_found)
-        db.session.commit()
+        try:
+            db.session.delete(domain_found)
+            db.session.commit()
+        except models.ScimManagedAliasError as exc:
+            db.session.rollback()
+            return {'code': 409, 'message': str(exc)}, 409
         return {'code': 200, 'message': f'Domain {domain} has been deleted'}, 200
 
 @dom.route('/<domain>/dkim')

--- a/core/admin/mailu/api/v1/user.py
+++ b/core/admin/mailu/api/v1/user.py
@@ -131,6 +131,9 @@ class Users(Resource):
         email_found = models.User.query.filter_by(email=data['email']).first()
         if email_found:
             return { 'code': 409, 'message': f'User {data["email"]} already exists'}, 409
+        alias_found = models.Alias.query.filter_by(email=data['email']).first()
+        if alias_found:
+            return { 'code': 409, 'message': f'Email address {data["email"]} is already used'}, 409
         if 'forward_enabled' in data and data['forward_enabled'] is True:
             if ('forward_destination' in data and len(data['forward_destination']) == 0) or 'forward_destination' not in data:
                 return { 'code': 400, 'message': f'forward_destination is mandatory when forward_enabled is true'}, 400
@@ -185,7 +188,11 @@ class Users(Resource):
         if 'spam_threshold' in data:
             user_new.spam_threshold = data['spam_threshold']
         db.session.add(user_new)
-        db.session.commit()
+        try:
+            db.session.commit()
+        except models.AddressConflict:
+            db.session.rollback()
+            return { 'code': 409, 'message': f'Email address {data["email"]} is already used'}, 409
 
         return {'code': 200,'message': f'User {data["email"]} has been created'}, 200
 

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -147,6 +147,19 @@ class ConfigManager:
             template = self.DB_TEMPLATES[self.config['DB_FLAVOR']]
             self.config['SQLALCHEMY_DATABASE_URI'] = template.format(**self.config)
 
+        database_scheme = (
+            self.config['SQLALCHEMY_DATABASE_URI']
+            .partition(':')[0]
+            .partition('+')[0]
+            .lower()
+        )
+        if database_scheme in {'mysql', 'mariadb'}:
+            engine_options = dict(
+                self.config.get('SQLALCHEMY_ENGINE_OPTIONS') or {}
+            )
+            engine_options['isolation_level'] = 'READ COMMITTED'
+            self.config['SQLALCHEMY_ENGINE_OPTIONS'] = engine_options
+
         if not self.config.get('RATELIMIT_STORAGE_URL'):
             self.config['RATELIMIT_STORAGE_URL'] = f'redis://{self.config["REDIS_ADDRESS"]}/2'
 

--- a/core/admin/mailu/configuration.py
+++ b/core/admin/mailu/configuration.py
@@ -27,7 +27,7 @@ DEFAULT_CONFIG = {
     'DB_NAME': 'mailu',
     'DB_APPENDIX': '',
     'SQLITE_DATABASE_FILE': 'data/main.db',
-    'SQLALCHEMY_DATABASE_URI': 'sqlite:////data/main.db',
+    'SQLALCHEMY_DATABASE_URI': 'sqlite:////data/main.db?timeout=30',
     'SQLALCHEMY_DATABASE_URI_ROUNDCUBE': 'sqlite:////data/roundcube.db',
     'SQLALCHEMY_TRACK_MODIFICATIONS': False,
     # Statistics management
@@ -105,7 +105,7 @@ class ConfigManager:
     """
 
     DB_TEMPLATES = {
-        'sqlite': 'sqlite:////{SQLITE_DATABASE_FILE}',
+        'sqlite': 'sqlite:////{SQLITE_DATABASE_FILE}?timeout=30',
         'postgresql': 'postgresql://{DB_USER}:{DB_PW}@{DB_HOST}/{DB_NAME}{DB_APPENDIX}',
         'mysql': 'mysql+mysqlconnector://{DB_USER}:{DB_PW}@{DB_HOST}/{DB_NAME}{DB_APPENDIX}',
     }

--- a/core/admin/mailu/internal/nginx.py
+++ b/core/admin/mailu/internal/nginx.py
@@ -44,7 +44,7 @@ def check_credentials(user, password, ip, protocol=None, auth_port=None, source_
         return False
     # webmails
     if auth_port in WEBMAIL_PORTS and password.startswith('token-'):
-        if utils.verify_temp_token(user.get_id(), password):
+        if utils.verify_temp_token(user, password):
             app.logger.debug(f'Login attempt for: {user}/{protocol}/{auth_port} from: {ip}/{source_port}: success: webmail-token')
             return True
     if utils.is_app_token(password):

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -452,6 +452,60 @@ def alias(localpart, domain_name, destination, wildcard=False):
     db.session.commit()
 
 
+@mailu.command('scim-group-adopt')
+@click.argument('email')
+@click.option(
+    '--external-id',
+    default=None,
+    help='Optional provider externalId to bind to the adopted SCIM Group.',
+)
+@with_appcontext
+def scim_group_adopt(email, external_id=None):
+    """Adopt one eligible existing alias as a provider-managed SCIM Group."""
+    alias = db.session.get(models.Alias, email)
+    if alias is None or alias.email != email:
+        raise click.ClickException(f'alias {email!r} not found')
+
+    original_destinations = list(alias.destination)
+    try:
+        group = models.create_scim_group_mapping(
+            alias,
+            external_id=external_id,
+        )
+        member_ids = []
+        external_destinations = []
+        for value in original_destinations:
+            destination = models.canonicalize_scim_destination(value)
+            local_address = db.session.get(models.MailAddress, destination)
+            if local_address is None:
+                external_destinations.append(destination)
+                continue
+
+            if local_address.address_type == models.User.ADDRESS_TYPE:
+                subject = db.session.get(models.User, local_address.email)
+            else:
+                subject = db.session.get(models.Alias, local_address.email)
+            member = subject.scim_resource if subject is not None else None
+            if member is None or member.deleted_at is not None:
+                raise models.ScimGroupAdoptionError(
+                    f'local destination {destination!r} is not an active '
+                    'SCIM resource'
+                )
+            member_ids.append(member.id)
+
+        models.replace_scim_group_graph(
+            group,
+            member_ids=member_ids,
+            external_destinations=external_destinations,
+        )
+        db.session.commit()
+    except (models.ScimIdentityError, ValueError) as exc:
+        db.session.rollback()
+        raise click.ClickException(str(exc)) from exc
+
+    click.echo(f'adopted {email!r} as SCIM Group {group.id}')
+
+
 @mailu.command()
 @click.argument('domain_name')
 @click.argument('max_users')

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -339,6 +339,28 @@ def config_import(verbose=0, secrets=False, debug=False, quiet=False, color=Fals
     }
 
     schema = MailuSchema(only=MailuSchema.Meta.order, context=context)
+    absent = object()
+    dkim_state = [
+        (
+            domain,
+            domain.__dict__.get('_dkim_key', absent),
+            domain.__dict__.get('_dkim_key_on_disk', absent),
+        )
+        for domain in models.Domain.query.all()
+    ]
+
+    def rollback():
+        """Roll back SQL and unmapped Domain key cache state."""
+        db.session.rollback()
+        for domain, key, on_disk in dkim_state:
+            for name, value in (
+                ('_dkim_key', key),
+                ('_dkim_key_on_disk', on_disk),
+            ):
+                if value is absent:
+                    domain.__dict__.pop(name, None)
+                else:
+                    domain.__dict__[name] = value
 
     try:
         # import source
@@ -350,6 +372,7 @@ def config_import(verbose=0, secrets=False, debug=False, quiet=False, color=Fals
         # check for duplicate domain names
         config.check()
     except Exception as exc:
+        rollback()
         if msg := log.format_exception(exc):
             raise click.ClickException(msg) from exc
         raise
@@ -357,7 +380,7 @@ def config_import(verbose=0, secrets=False, debug=False, quiet=False, color=Fals
     # do not commit when running dry
     if dry_run:
         log.changes('Dry run. Not committing changes.')
-        db.session.rollback()
+        rollback()
     else:
         log.changes('Committing changes.')
         db.session.commit()

--- a/core/admin/mailu/manage.py
+++ b/core/admin/mailu/manage.py
@@ -176,6 +176,14 @@ def user_import(localpart, domain_name, password_hash):
 def config_update(verbose=False, delete_objects=False):
     """ Sync configuration with data from YAML (deprecated)
     """
+    try:
+        _config_update(verbose=verbose, delete_objects=delete_objects)
+    except models.ScimManagedAliasError as exc:
+        db.session.rollback()
+        raise click.ClickException(str(exc)) from exc
+
+
+def _config_update(verbose=False, delete_objects=False):
     new_config = yaml.safe_load(sys.stdin)
     # print new_config
     domains = new_config.get('domains', [])
@@ -273,7 +281,7 @@ def config_update(verbose=False, delete_objects=False):
             alias.wildcard = wildcard
         db.session.add(alias)
 
-    db.session.commit()
+    db.session.flush()
 
     managers = new_config.get('managers', [])
     # tracked_managers=set()
@@ -288,7 +296,7 @@ def config_update(verbose=False, delete_objects=False):
             domain.managers.append(manageruser)
         db.session.add(domain)
 
-    db.session.commit()
+    db.session.flush()
 
     if delete_objects:
         for user in db.session.query(models.User).all():
@@ -447,8 +455,12 @@ def user_delete(email, really=False):
 def alias_delete(email):
     """delete alias"""
     if alias := models.Alias.query.get(email):
-        db.session.delete(alias)
-        db.session.commit()
+        try:
+            db.session.delete(alias)
+            db.session.commit()
+        except models.ScimManagedAliasError as exc:
+            db.session.rollback()
+            raise click.ClickException(str(exc)) from exc
 
 
 @mailu.command()
@@ -489,12 +501,12 @@ def scim_group_adopt(email, external_id=None):
     if alias is None or alias.email != email:
         raise click.ClickException(f'alias {email!r} not found')
 
-    original_destinations = list(alias.destination)
     try:
         group = models.create_scim_group_mapping(
             alias,
             external_id=external_id,
         )
+        original_destinations = list(group.alias.destination)
         member_ids = []
         external_destinations = []
         for value in original_destinations:

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -3,8 +3,11 @@
 
 import os
 import json
+import secrets
+import sqlite3
+import uuid
 
-from datetime import date
+from datetime import date, datetime, timezone
 from email.mime import text
 from itertools import chain
 
@@ -17,10 +20,12 @@ import logging
 import os
 import smtplib
 import idna
+import validators
 import dns.resolver
 import dns.exception
 
 from flask import current_app as app
+from sqlalchemy.dialects import mysql
 from sqlalchemy.ext import declarative
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.inspection import inspect
@@ -36,6 +41,42 @@ logging.getLogger('passlib').setLevel(logging.ERROR)
 
 
 db = flask_sqlalchemy.SQLAlchemy()
+
+
+@sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, 'connect')
+def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record):
+    """Make SQLite enforce the same foreign-key contract as production SQL."""
+    if isinstance(dbapi_connection, sqlite3.Connection):
+        cursor = dbapi_connection.cursor()
+        cursor.execute('PRAGMA foreign_keys=ON')
+        cursor.close()
+
+
+class AddressConflict(sqlalchemy.exc.IntegrityError):
+    """Raised when two concrete resources claim one routing address."""
+
+    def __init__(self, email, original):
+        self.email = email
+        if isinstance(original, sqlalchemy.exc.IntegrityError):
+            statement = original.statement
+            params = original.params
+            cause = original.orig
+            invalidated = original.connection_invalidated
+        else:
+            statement = None
+            params = {'email': email}
+            cause = original
+            invalidated = False
+        super().__init__(
+            statement,
+            params,
+            cause,
+            connection_invalidated=invalidated,
+        )
+
+
+class AddressRenameError(ValueError):
+    """Raised when code attempts to mutate a persisted address primary key."""
 
 
 class IdnaDomain(db.TypeDecorator):
@@ -64,6 +105,8 @@ class IdnaEmail(db.TypeDecorator):
 
     def process_bind_param(self, value, dialect):
         """ encode unicode domain part of email address to punycode """
+        if value is None:
+            return None
         if not '@' in value:
             raise ValueError('invalid email address (no "@")')
         localpart, domain_name = value.lower().rsplit('@', 1)
@@ -73,8 +116,19 @@ class IdnaEmail(db.TypeDecorator):
 
     def process_result_value(self, value, dialect):
         """ decode punycode domain part of email to unicode """
+        if value is None:
+            return None
         localpart, domain_name = value.rsplit('@', 1)
         return f'{localpart}@{idna.decode(domain_name)}'
+
+
+def ExactScimId():
+    """Store provider IDs with byte-exact MySQL/MariaDB comparisons."""
+    return db.String(255).with_variant(
+        mysql.VARCHAR(255, collation='utf8mb4_bin'),
+        'mysql',
+    )
+
 
 class CommaSeparatedList(db.TypeDecorator):
     """ Stores a list as a comma-separated string, compatible with Postfix.
@@ -427,6 +481,32 @@ class Relay(Base):
     smtp = db.Column(db.String(80), nullable=True)
 
 
+class MailAddress(db.Model):
+    """Single active owner of a canonical routing address.
+
+    This table enforces address uniqueness across the otherwise independent
+    User and Alias primary-key namespaces. It is deliberately not a SCIM
+    identity or tombstone table.
+    """
+
+    __tablename__ = 'mail_address'
+
+    email = db.Column(IdnaEmail, primary_key=True, nullable=False)
+    address_type = db.Column(db.String(5), nullable=False)
+
+    __table_args__ = (
+        db.UniqueConstraint(
+            'email',
+            'address_type',
+            name='mail_address_email_type_key',
+        ),
+        db.CheckConstraint(
+            "address_type IN ('user', 'alias')",
+            name='mail_address_type_check',
+        ),
+    )
+
+
 class Email(object):
     """ Abstraction for an email address (localpart and domain).
     """
@@ -574,12 +654,37 @@ class User(Base, Email):
     """
 
     __tablename__ = 'user'
+    ADDRESS_TYPE = 'user'
     _ctx = None
     _credential_cache = {}
+
+    address_type = db.Column(
+        db.String(5),
+        nullable=False,
+        default=ADDRESS_TYPE,
+        server_default=ADDRESS_TYPE,
+    )
+
+    __table_args__ = (
+        db.CheckConstraint(
+            "address_type = 'user'",
+            name='user_address_type_check',
+        ),
+        db.ForeignKeyConstraint(
+            ['email', 'address_type'],
+            ['mail_address.email', 'mail_address.address_type'],
+            name='user_mail_address_fkey',
+        ),
+    )
 
     domain = db.relationship(Domain,
         backref=db.backref('users', cascade='all, delete-orphan'))
     password = db.Column(db.String(255), nullable=False)
+    auth_generation = db.Column(
+        db.String(32),
+        nullable=False,
+        default=lambda: secrets.token_hex(16),
+    )
     quota_bytes = db.Column(db.BigInteger, nullable=False, default=10**9)
     quota_bytes_used = db.Column(db.BigInteger, nullable=False, default=0)
     global_admin = db.Column(db.Boolean, nullable=False, default=False)
@@ -611,8 +716,12 @@ class User(Base, Email):
 
     # Flask-login attributes
     is_authenticated = True
-    is_active = True
     is_anonymous = False
+
+    @property
+    def is_active(self):
+        """Disabled users are not valid Flask-Login principals."""
+        return bool(self.enabled)
 
     def get_id(self):
         """ return users email address """
@@ -692,7 +801,11 @@ class User(Base, Email):
 
         result, new_hash = User.get_password_context().verify_and_update(password, reference)
         if new_hash:
-            self.password = new_hash
+            self._preserve_auth_generation = True
+            try:
+                self.password = new_hash
+            finally:
+                del self._preserve_auth_generation
             db.session.add(self)
             db.session.commit()
 
@@ -709,14 +822,22 @@ in clear-text regardless of the presence of the cache.
         return result
 
     def set_password(self, password, raw=False, keep_sessions=None):
-        """ Set password for user and destroy all web sessions except those in keep_sessions
+        """Set a credential and rotate SQL-backed session authority.
+
             @password: plain text password to encrypt (or, if raw is True: the hash itself)
-            @keep_sessions: True if all the sessions should be preserved, otherwise a
-set() containing the sessions to keep
+            @keep_sessions: retained for caller compatibility; physical session
+              cleanup must run only after the surrounding SQL transaction commits.
         """
-        self.password = password if raw else User.get_password_context().hash(password)
-        if keep_sessions is not True and self.email is not None:
-            utils.MailuSessionExtension.prune_sessions(uid=self.email, keep=keep_sessions)
+        replacement = (
+            password
+            if raw
+            else User.get_password_context().hash(password)
+        )
+        self.password = replacement
+
+    def rotate_auth_generation(self):
+        """Invalidate every previously issued browser/webmail session."""
+        self.auth_generation = secrets.token_hex(16)
 
     def get_managed_domains(self):
         """ return list of domains this user can manage """
@@ -751,11 +872,71 @@ set() containing the sessions to keep
         return user if (user and user.enabled and user.check_password(password)) else None
 
 
+@sqlalchemy.event.listens_for(
+    User.enabled,
+    'set',
+    active_history=True,
+)
+def _rotate_auth_generation_on_enabled_change(
+    target,
+    value,
+    oldvalue,
+    _initiator,
+):
+    """Make enablement changes invalidate sessions at the model boundary."""
+    if (
+        oldvalue is not sqlalchemy.orm.attributes.NO_VALUE
+        and bool(value) != bool(oldvalue)
+    ):
+        target.rotate_auth_generation()
+
+
+@sqlalchemy.event.listens_for(
+    User.password,
+    'set',
+    active_history=True,
+)
+def _rotate_auth_generation_on_password_change(
+    target,
+    value,
+    oldvalue,
+    _initiator,
+):
+    """Catch every ORM credential writer, including Marshmallow imports."""
+    if (
+        oldvalue is not sqlalchemy.orm.attributes.NO_VALUE
+        and oldvalue is not None
+        and value != oldvalue
+        and not getattr(target, '_preserve_auth_generation', False)
+    ):
+        target.rotate_auth_generation()
+
+
 class Alias(Base, Email):
     """ An alias is an email address that redirects to some destination.
     """
 
     __tablename__ = 'alias'
+    ADDRESS_TYPE = 'alias'
+
+    address_type = db.Column(
+        db.String(5),
+        nullable=False,
+        default=ADDRESS_TYPE,
+        server_default=ADDRESS_TYPE,
+    )
+
+    __table_args__ = (
+        db.CheckConstraint(
+            "address_type = 'alias'",
+            name='alias_address_type_check',
+        ),
+        db.ForeignKeyConstraint(
+            ['email', 'address_type'],
+            ['mail_address.email', 'mail_address.address_type'],
+            name='alias_mail_address_fkey',
+        ),
+    )
 
     domain = db.relationship(Domain,
         backref=db.backref('aliases', cascade='all, delete-orphan'))
@@ -830,6 +1011,87 @@ class Alias(Base, Email):
 
 
 # end of Alias class helpers
+
+
+def _address_value(target):
+    """Return and materialize the canonical email before mapper INSERT."""
+    if target.email:
+        return target.email
+    domain_name = target.domain_name
+    if not domain_name and target.domain is not None:
+        domain_name = target.domain.name
+    if not target.localpart or not domain_name:
+        raise ValueError('User and Alias require a complete email address')
+    target.email = f'{target.localpart}@{domain_name}'
+    return target.email
+
+
+def _claim_mail_address(_mapper, connection, target):
+    email = _address_value(target)
+    target.address_type = target.ADDRESS_TYPE
+    graph_lock = globals().get('_lock_scim_graph_connection')
+    destination_model = globals().get('ScimGroupDestination')
+    if graph_lock is not None:
+        graph_lock(connection)
+    if (
+        destination_model is not None
+        and connection.execute(
+            sqlalchemy.select(destination_model.group_id).where(
+                destination_model.destination == email
+            ).limit(1).with_for_update()
+        ).first()
+        is not None
+    ):
+        original = RuntimeError(
+            f'Routing address {email!r} is reserved as an external '
+            'destination'
+        )
+        raise AddressConflict(email, original) from original
+    try:
+        connection.execute(
+            MailAddress.__table__.insert().values(
+                email=email,
+                address_type=target.ADDRESS_TYPE,
+            )
+        )
+    except sqlalchemy.exc.IntegrityError as exc:
+        raise AddressConflict(email, exc) from exc
+
+
+def _reject_mail_address_rename(_mapper, _connection, target):
+    if sqlalchemy.inspect(target).attrs._email.history.has_changes():
+        raise AddressRenameError(
+            f'Persisted email address {target.email} cannot be renamed'
+        )
+
+
+def _release_mail_address(_mapper, connection, target):
+    connection.execute(
+        MailAddress.__table__.delete().where(
+            sqlalchemy.and_(
+                MailAddress.email == target.email,
+                MailAddress.address_type == target.ADDRESS_TYPE,
+            )
+        )
+    )
+
+
+for _address_model in (User, Alias):
+    sqlalchemy.event.listen(
+        _address_model,
+        'before_insert',
+        _claim_mail_address,
+    )
+    sqlalchemy.event.listen(
+        _address_model,
+        'before_update',
+        _reject_mail_address_rename,
+    )
+    sqlalchemy.event.listen(
+        _address_model,
+        'after_delete',
+        _release_mail_address,
+    )
 
 
 class Token(Base):
@@ -945,6 +1207,819 @@ def has_domain_access(domain_name, user=None):
         DomainAccess.user_email == user.email
     )
     return db.session.query(query.exists()).scalar()
+
+
+class ScimIdentityError(RuntimeError):
+    """Base error for persistent SCIM identity invariants."""
+
+
+class ScimGraphError(ScimIdentityError):
+    """Raised when a normalized Group graph would be invalid."""
+
+
+class ScimManagedAliasError(ScimIdentityError):
+    """Raised when an ordinary writer mutates a SCIM-owned Alias."""
+
+
+class ScimGroupAdoptionError(ScimIdentityError):
+    """Raised when an Alias cannot safely enter exclusive SCIM ownership."""
+
+
+class ScimExternalDestinationError(ScimIdentityError):
+    """Raised when a raw destination conflicts with local routing ownership."""
+
+
+class ScimState(db.Model):
+    """Singleton row used to serialize every normalized graph mutation."""
+
+    __tablename__ = 'scim_state'
+
+    id = db.Column(db.Integer, primary_key=True, autoincrement=False)
+    revision = db.Column(db.BigInteger, nullable=False, default=0)
+
+    __table_args__ = (
+        db.CheckConstraint('id = 1', name='scim_state_singleton_check'),
+    )
+
+
+class ScimResource(Base):
+    """Stable provider identity and ownership marker for a SCIM resource."""
+
+    __tablename__ = 'scim_resource'
+
+    id = db.Column(ExactScimId(), primary_key=True, nullable=False)
+    resource_type = db.Column(db.String(5), nullable=False)
+    external_id_bytes = db.Column(db.LargeBinary(1024), nullable=True)
+    user_email = db.Column(
+        IdnaEmail,
+        db.ForeignKey(User.email),
+        nullable=True,
+        unique=True,
+    )
+    alias_email = db.Column(
+        IdnaEmail,
+        db.ForeignKey(Alias.email),
+        nullable=True,
+        unique=True,
+    )
+    subject_address = db.Column(IdnaEmail, nullable=False)
+    deleted_at = db.Column(db.DateTime, nullable=True)
+
+    user = db.relationship(
+        User,
+        foreign_keys=[user_email],
+        backref=db.backref(
+            'scim_resource',
+            uselist=False,
+            passive_deletes=True,
+        ),
+    )
+    alias = db.relationship(
+        Alias,
+        foreign_keys=[alias_email],
+        backref=db.backref(
+            'scim_resource',
+            uselist=False,
+            passive_deletes=True,
+        ),
+    )
+
+    __table_args__ = (
+        db.CheckConstraint(
+            "resource_type IN ('User', 'Group')",
+            name='scim_resource_type_check',
+        ),
+        db.CheckConstraint(
+            '('
+            "deleted_at IS NULL AND resource_type = 'User' "
+            'AND user_email IS NOT NULL AND alias_email IS NULL '
+            'AND subject_address = user_email'
+            ') OR ('
+            "deleted_at IS NULL AND resource_type = 'Group' "
+            'AND user_email IS NULL AND alias_email IS NOT NULL '
+            'AND subject_address = alias_email'
+            ') OR ('
+            'deleted_at IS NOT NULL '
+            'AND user_email IS NULL AND alias_email IS NULL'
+            ')',
+            name='scim_resource_lifecycle_check',
+        ),
+    )
+
+    @property
+    def external_id(self):
+        if self.external_id_bytes is None:
+            return None
+        return self.external_id_bytes.decode('utf-8')
+
+    @external_id.setter
+    def external_id(self, value):
+        if value is None:
+            self.external_id_bytes = None
+            return
+        if not isinstance(value, str):
+            raise TypeError('externalId must be a string or null')
+        encoded = value.encode('utf-8')
+        if len(encoded) > 1024:
+            raise ValueError('externalId must not exceed 1024 UTF-8 bytes')
+        self.external_id_bytes = encoded
+
+    @property
+    def active(self):
+        return self.deleted_at is None
+
+    @classmethod
+    def get_exact(cls, resource_id, *, resource_type=None, active_only=True):
+        """Fetch an opaque ID without trusting a case-insensitive collation."""
+        if not isinstance(resource_id, str):
+            return None
+        resource = db.session.get(cls, resource_id)
+        if resource is None or resource.id != resource_id:
+            return None
+        if resource_type is not None and resource.resource_type != resource_type:
+            return None
+        if active_only and resource.deleted_at is not None:
+            return None
+        return resource
+
+
+class ScimGroupMember(db.Model):
+    """Stable normalized edge from one managed Group to a SCIM resource."""
+
+    __tablename__ = 'scim_group_member'
+
+    group_id = db.Column(
+        ExactScimId(),
+        db.ForeignKey(ScimResource.id),
+        primary_key=True,
+    )
+    member_id = db.Column(
+        ExactScimId(),
+        db.ForeignKey(ScimResource.id),
+        primary_key=True,
+    )
+
+    group = db.relationship(
+        ScimResource,
+        foreign_keys=[group_id],
+        backref=db.backref(
+            'member_edges',
+            cascade='all, delete-orphan',
+        ),
+    )
+    member = db.relationship(
+        ScimResource,
+        foreign_keys=[member_id],
+        backref=db.backref(
+            'membership_edges',
+            cascade='all, delete-orphan',
+        ),
+    )
+
+
+class ScimGroupDestination(db.Model):
+    """Raw, non-local forwarding destination owned by a managed Group."""
+
+    __tablename__ = 'scim_group_destination'
+
+    group_id = db.Column(
+        ExactScimId(),
+        db.ForeignKey(ScimResource.id),
+        primary_key=True,
+    )
+    destination = db.Column(IdnaEmail, primary_key=True)
+
+    __table_args__ = (
+        db.Index(
+            'scim_group_destination_destination_idx',
+            'destination',
+        ),
+    )
+
+    group = db.relationship(
+        ScimResource,
+        foreign_keys=[group_id],
+        backref=db.backref(
+            'destinations',
+            cascade='all, delete-orphan',
+        ),
+    )
+
+
+@sqlalchemy.event.listens_for(ScimState.__table__, 'after_create')
+def _seed_scim_state(_target, connection, **_kwargs):
+    connection.execute(
+        ScimState.__table__.insert().values(id=1, revision=0)
+    )
+
+
+def new_scim_id():
+    """Return the one canonical representation used for new provider IDs."""
+    return str(uuid.uuid4()).lower()
+
+
+def _lock_scim_graph_connection(connection):
+    result = connection.execute(
+        ScimState.__table__.update().where(
+            ScimState.id == 1
+        ).values(
+            revision=ScimState.revision,
+        )
+    )
+    if result.rowcount != 1:
+        raise ScimGraphError('SCIM graph state row is missing')
+
+
+def lock_scim_graph(session=None):
+    """Acquire the portable singleton graph write lock for this transaction."""
+    session = session or db.session
+    result = session.execute(
+        ScimState.__table__.update().where(
+            ScimState.id == 1
+        ).values(
+            revision=ScimState.revision,
+        )
+    )
+    if result.rowcount != 1:
+        raise ScimGraphError('SCIM graph state row is missing')
+
+
+def create_scim_user_mapping(
+    user,
+    *,
+    resource_id=None,
+    external_id=None,
+):
+    """Return or create the active mapping for a persistent User."""
+    if inspect(user).persistent is False:
+        raise ScimIdentityError(
+            'User must be persistent before its SCIM mapping is created'
+        )
+    lock_scim_graph()
+    existing = db.session.execute(
+        sqlalchemy.select(ScimResource)
+        .where(
+            ScimResource.resource_type == 'User',
+            ScimResource.user_email == user.email,
+            ScimResource.deleted_at.is_(None),
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if existing is not None:
+        if existing.deleted_at is not None:
+            raise ScimIdentityError(
+                f'User {user.email} has a deleted SCIM mapping'
+            )
+        if resource_id is not None and resource_id != existing.id:
+            raise ScimIdentityError(
+                f'User {user.email} already has a different SCIM mapping'
+            )
+        if external_id is not None:
+            existing.external_id = external_id
+        return existing
+    reserved = db.session.execute(
+        sqlalchemy.select(ScimResource)
+        .where(
+            ScimResource.resource_type == 'User',
+            ScimResource.subject_address == user.email,
+            ScimResource.deleted_at.is_not(None),
+        )
+        .limit(1)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if reserved is not None:
+        raise ScimIdentityError(
+            f'User address {user.email} is permanently reserved by a '
+            'deleted SCIM identity'
+        )
+    resource = ScimResource(
+        id=resource_id or new_scim_id(),
+        resource_type='User',
+        user=user,
+        subject_address=user.email,
+    )
+    resource.external_id = external_id
+    db.session.add(resource)
+    return resource
+
+
+def validate_scim_group_adoption(alias):
+    """Require a live, exact, unowned Alias before exclusive adoption."""
+    if inspect(alias).persistent is False:
+        raise ScimGroupAdoptionError('Alias must be persistent before adoption')
+    if alias.disabled:
+        raise ScimGroupAdoptionError('Disabled Alias cannot be adopted')
+    if alias.wildcard:
+        raise ScimGroupAdoptionError('Wildcard Alias cannot be adopted')
+    if alias.owner_email is not None:
+        raise ScimGroupAdoptionError('Owned Alias cannot be adopted')
+    if alias.scim_resource is not None:
+        raise ScimGroupAdoptionError('Alias is already SCIM managed')
+    return alias
+
+
+def create_scim_group_mapping(
+    alias,
+    *,
+    resource_id=None,
+    external_id=None,
+):
+    """Adopt an existing Alias; graph initialization remains explicit."""
+    lock_scim_graph()
+    alias = db.session.execute(
+        sqlalchemy.select(Alias)
+        .where(Alias._email == alias.email)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if alias is None:
+        raise ScimGroupAdoptionError('Alias disappeared during adoption')
+    existing_mapping = db.session.execute(
+        sqlalchemy.select(ScimResource.id)
+        .where(
+            ScimResource.alias_email == alias.email,
+            ScimResource.deleted_at.is_(None),
+        )
+        .limit(1)
+        .with_for_update()
+    ).first()
+    if existing_mapping is not None:
+        raise ScimGroupAdoptionError('Alias is already SCIM managed')
+    validate_scim_group_adoption(alias)
+    resource = ScimResource(
+        id=resource_id or alias.email,
+        resource_type='Group',
+        alias=alias,
+        subject_address=alias.email,
+    )
+    resource.external_id = external_id
+    db.session.add(resource)
+    return resource
+
+
+def scrub_scim_user_authority(user):
+    """Remove identity-bound authority before retaining a deleted mailbox."""
+    user.global_admin = False
+    user.allow_spoofing = False
+    user.forward_enabled = False
+    user.forward_destination = []
+    user.forward_keep = True
+    user.reply_enabled = False
+    user.reply_subject = None
+    user.reply_body = None
+    user.reply_startdate = date(1900, 1, 1)
+    user.reply_enddate = date(2999, 12, 31)
+    user.set_password(secrets.token_urlsafe(48))
+    for token in list(user.tokens):
+        db.session.delete(token)
+    for fetch in list(user.fetches):
+        db.session.delete(fetch)
+    for alias in list(user.owned_aliases):
+        db.session.delete(alias)
+    for access in list(user.domain_accesses):
+        db.session.delete(access)
+    db.session.execute(
+        managers.delete().where(managers.c.user_email == user.email)
+    )
+
+
+def canonicalize_scim_destination(value):
+    if not isinstance(value, str):
+        raise ScimExternalDestinationError(
+            'External destinations must be strings'
+        )
+    value = value.strip().lower()
+    if not value or ',' in value or value.count('@') != 1:
+        raise ScimExternalDestinationError(
+            f'Invalid external destination {value!r}'
+        )
+    localpart, domain_name = value.rsplit('@', 1)
+    if not localpart or not domain_name:
+        raise ScimExternalDestinationError(
+            f'Invalid external destination {value!r}'
+        )
+    try:
+        domain_name = idna.decode(idna.encode(domain_name))
+    except idna.IDNAError as exc:
+        raise ScimExternalDestinationError(
+            f'Invalid external destination {value!r}'
+        ) from exc
+    destination = f'{localpart}@{domain_name}'
+    if not validators.email(destination):
+        raise ScimExternalDestinationError(
+            f'Invalid external destination {value!r}'
+        )
+    return destination
+
+
+def _active_scim_resource(resource_id):
+    resource = db.session.execute(
+        sqlalchemy.select(ScimResource)
+        .where(ScimResource.id == resource_id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalar_one_or_none()
+    if (
+        resource is None
+        or resource.id != resource_id
+        or resource.deleted_at is not None
+    ):
+        raise ScimGraphError(
+            f'SCIM member {resource_id!r} is not an active resource'
+        )
+    return resource
+
+
+def _validate_scim_cycle(group, member_ids):
+    adjacency = {}
+    edges = db.session.execute(
+        sqlalchemy.select(
+            ScimGroupMember.group_id,
+            ScimGroupMember.member_id,
+        ).with_for_update()
+    ).all()
+    for group_id, member_id in edges:
+        if group_id == group.id:
+            continue
+        adjacency.setdefault(group_id, set()).add(member_id)
+    adjacency[group.id] = set(member_ids)
+
+    def reaches_group(resource_id, seen):
+        if resource_id == group.id:
+            return True
+        if resource_id in seen:
+            return False
+        seen.add(resource_id)
+        return any(
+            reaches_group(child_id, seen)
+            for child_id in adjacency.get(resource_id, ())
+        )
+
+    if any(reaches_group(member_id, set()) for member_id in member_ids):
+        raise ScimGraphError('SCIM Group membership would create a cycle')
+
+
+def permit_scim_managed_alias_edit(alias):
+    """Permit exactly one pending flush of a managed Alias mutation."""
+    session = inspect(alias).session
+    if session is None:
+        raise ScimManagedAliasError('Managed Alias is detached')
+    session.info.setdefault('_scim_alias_edit_permits', set()).add(id(alias))
+
+
+def materialize_scim_group(group):
+    """Project normalized members and raw destinations into Alias.destination."""
+    if (
+        group.resource_type != 'Group'
+        or group.deleted_at is not None
+        or group.alias is None
+    ):
+        raise ScimGraphError('Only an active Group can be materialized')
+
+    destinations = set(db.session.execute(
+        sqlalchemy.select(ScimResource.subject_address)
+        .join(
+            ScimGroupMember,
+            ScimGroupMember.member_id == ScimResource.id,
+        )
+        .where(
+            ScimGroupMember.group_id == group.id,
+            ScimResource.deleted_at.is_(None),
+        )
+        .with_for_update()
+    ).scalars())
+    destinations.update(db.session.execute(
+        sqlalchemy.select(ScimGroupDestination.destination)
+        .where(ScimGroupDestination.group_id == group.id)
+        .with_for_update()
+    ).scalars()
+    )
+    projection = sorted(destinations)
+    if any(',' in destination for destination in projection):
+        raise ScimGraphError('Group destinations cannot contain commas')
+    if len(','.join(projection)) > 1023:
+        raise ScimGraphError(
+            'Materialized Group destinations exceed 1023 characters'
+        )
+    permit_scim_managed_alias_edit(group.alias)
+    group.alias.destination = projection
+    return projection
+
+
+def replace_scim_group_graph(
+    group,
+    *,
+    member_ids,
+    external_destinations,
+):
+    """Atomically stage and materialize one complete managed Group graph."""
+    if not isinstance(group, ScimResource):
+        raise TypeError('group must be a ScimResource')
+    if (
+        group.resource_type != 'Group'
+        or group.deleted_at is not None
+        or group.alias is None
+    ):
+        raise ScimGraphError('Only an active Group can own graph state')
+    lock_scim_graph()
+
+    member_ids = list(dict.fromkeys(member_ids or ()))
+    members = [_active_scim_resource(member_id) for member_id in member_ids]
+    _validate_scim_cycle(group, member_ids)
+
+    normalized_destinations = sorted({
+        canonicalize_scim_destination(value)
+        for value in (external_destinations or ())
+    })
+    for destination in normalized_destinations:
+        local = db.session.execute(
+            sqlalchemy.select(MailAddress.email)
+            .where(MailAddress.email == destination)
+            .with_for_update()
+        ).scalar_one_or_none()
+        if local is not None:
+            raise ScimExternalDestinationError(
+                f'External destination {destination!r} is locally owned'
+            )
+
+    db.session.execute(
+        sqlalchemy.delete(ScimGroupMember).where(
+            ScimGroupMember.group_id == group.id
+        )
+    )
+    db.session.execute(
+        sqlalchemy.delete(ScimGroupDestination).where(
+            ScimGroupDestination.group_id == group.id
+        )
+    )
+    db.session.add_all(
+        ScimGroupMember(group=group, member=member)
+        for member in members
+    )
+    db.session.add_all(
+        ScimGroupDestination(group=group, destination=destination)
+        for destination in normalized_destinations
+    )
+    materialize_scim_group(group)
+    return group
+
+
+def _remove_scim_resource_edges(resource):
+    membership_edges = db.session.execute(
+        sqlalchemy.select(ScimGroupMember)
+        .where(ScimGroupMember.member_id == resource.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalars().all()
+    member_edges = db.session.execute(
+        sqlalchemy.select(ScimGroupMember)
+        .where(ScimGroupMember.group_id == resource.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalars().all()
+    destinations = db.session.execute(
+        sqlalchemy.select(ScimGroupDestination)
+        .where(ScimGroupDestination.group_id == resource.id)
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalars().all()
+    affected_ids = {
+        edge.group_id
+        for edge in membership_edges
+    }
+    affected_groups = db.session.execute(
+        sqlalchemy.select(ScimResource)
+        .where(
+            ScimResource.id.in_(affected_ids),
+            ScimResource.deleted_at.is_(None),
+        )
+        .with_for_update()
+        .execution_options(populate_existing=True)
+    ).scalars().all() if affected_ids else []
+    db.session.execute(
+        sqlalchemy.delete(ScimGroupMember).where(
+            ScimGroupMember.member_id == resource.id
+        )
+    )
+    db.session.execute(
+        sqlalchemy.delete(ScimGroupMember).where(
+            ScimGroupMember.group_id == resource.id
+        )
+    )
+    db.session.execute(
+        sqlalchemy.delete(ScimGroupDestination).where(
+            ScimGroupDestination.group_id == resource.id
+        )
+    )
+    return affected_groups
+
+
+def tombstone_scim_resource(
+    resource,
+    *,
+    retain_subject=True,
+    scrub_user_authority=False,
+):
+    """Detach one active mapping while retaining its provider ID forever."""
+    if resource.deleted_at is not None:
+        raise ScimIdentityError(f'SCIM resource {resource.id} is already deleted')
+    lock_scim_graph()
+    user = resource.user
+    affected_groups = _remove_scim_resource_edges(resource)
+
+    if user is not None and retain_subject:
+        user.enabled = False
+        if scrub_user_authority:
+            scrub_scim_user_authority(user)
+
+    resource.user = None
+    resource.alias = None
+    resource.user_email = None
+    resource.alias_email = None
+    resource.deleted_at = datetime.now(timezone.utc).replace(tzinfo=None)
+
+    for group in affected_groups:
+        if group not in db.session.deleted and group.deleted_at is None:
+            materialize_scim_group(group)
+    return resource
+
+
+def _create_scim_mapping_after_user_insert(_mapper, connection, target):
+    _lock_scim_graph_connection(connection)
+    connection.execute(
+        ScimResource.__table__.insert().values(
+            id=new_scim_id(),
+            resource_type='User',
+            user_email=target.email,
+            alias_email=None,
+            subject_address=target.email,
+            deleted_at=None,
+            created_at=date.today(),
+            updated_at=None,
+            comment='',
+        )
+    )
+
+
+@sqlalchemy.event.listens_for(ScimResource, 'before_update')
+def _reject_scim_identity_change(_mapper, _connection, target):
+    state = inspect(target)
+    for attribute in ('id', 'resource_type', 'subject_address'):
+        if state.attrs[attribute].history.has_changes():
+            raise ScimIdentityError(
+                f'SCIM resource {attribute} is immutable'
+            )
+    deleted_history = state.attrs.deleted_at.history
+    was_deleted = (
+        deleted_history.deleted[-1]
+        if deleted_history.deleted
+        else target.deleted_at
+    )
+    lifecycle_attributes = (
+        'external_id_bytes',
+        'user_email',
+        'alias_email',
+        'deleted_at',
+    )
+    if was_deleted is not None:
+        if any(
+            state.attrs[attribute].history.has_changes()
+            for attribute in lifecycle_attributes
+        ):
+            raise ScimIdentityError(
+                f'SCIM resource {target.id} tombstone is immutable'
+            )
+        return
+    transitioning_to_tombstone = (
+        target.deleted_at is not None
+        and target.user_email is None
+        and target.alias_email is None
+    )
+    if (
+        any(
+            state.attrs[attribute].history.has_changes()
+            for attribute in ('user_email', 'alias_email', 'deleted_at')
+        )
+        and not transitioning_to_tombstone
+    ):
+        raise ScimIdentityError(
+            f'SCIM resource {target.id} principal binding is immutable'
+        )
+
+
+@sqlalchemy.event.listens_for(ScimResource, 'before_delete')
+def _reject_scim_resource_hard_delete(_mapper, _connection, target):
+    raise ScimIdentityError(
+        f'SCIM resource {target.id} must be retained as a tombstone'
+    )
+
+
+@sqlalchemy.event.listens_for(sqlalchemy.orm.Session, 'before_flush')
+def _maintain_scim_identity_lifecycle(session, _flush_context, _instances):
+    permits = session.info.setdefault('_scim_alias_edit_permits', set())
+    deleted = set(session.deleted)
+
+    dirty_aliases = [
+        value for value in session.dirty
+        if isinstance(value, Alias) and value not in deleted
+    ]
+    address_deletes = [
+        value for value in deleted
+        if isinstance(value, (User, Alias))
+    ]
+    if dirty_aliases or address_deletes:
+        lock_scim_graph(session)
+
+    for alias in dirty_aliases:
+        state = inspect(alias)
+        changed = any(
+            state.attrs[property_.key].history.has_changes()
+            for property_ in state.mapper.column_attrs
+            if property_.key not in ('created_at', 'updated_at')
+        )
+        if not changed:
+            continue
+        managed = session.execute(
+            sqlalchemy.select(ScimResource)
+            .where(
+                ScimResource.alias_email == alias.email,
+                ScimResource.deleted_at.is_(None),
+            )
+            .limit(1)
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        ).scalar_one_or_none()
+        if managed is not None and managed.deleted_at is None:
+            if id(alias) not in permits:
+                raise ScimManagedAliasError(
+                    f'Alias {alias.email} is exclusively SCIM managed'
+                )
+            permits.discard(id(alias))
+
+    mapped_deletes = []
+    with session.no_autoflush:
+        for target in deleted:
+            if isinstance(target, User):
+                resource = session.execute(
+                    sqlalchemy.select(ScimResource).where(
+                        ScimResource.user_email == target.email,
+                        ScimResource.deleted_at.is_(None),
+                    ).with_for_update().execution_options(
+                        populate_existing=True
+                    )
+                ).scalar_one_or_none()
+            elif isinstance(target, Alias):
+                resource = session.execute(
+                    sqlalchemy.select(ScimResource).where(
+                        ScimResource.alias_email == target.email,
+                        ScimResource.deleted_at.is_(None),
+                    ).with_for_update().execution_options(
+                        populate_existing=True
+                    )
+                ).scalar_one_or_none()
+                if resource is not None and resource.deleted_at is None:
+                    raise ScimManagedAliasError(
+                        f'Alias {target.email} is exclusively SCIM managed'
+                    )
+                continue
+            else:
+                continue
+            if resource is not None:
+                mapped_deletes.append(resource)
+
+    for resource in mapped_deletes:
+        tombstone_scim_resource(
+            resource,
+            retain_subject=False,
+            scrub_user_authority=False,
+        )
+
+
+@sqlalchemy.event.listens_for(sqlalchemy.orm.Session, 'after_flush')
+def _clear_scim_alias_edit_permits(session, _flush_context):
+    session.info.pop('_scim_alias_edit_permits', None)
+
+
+@sqlalchemy.event.listens_for(sqlalchemy.orm.Session, 'after_rollback')
+def _clear_scim_alias_edit_permits_after_rollback(session):
+    session.info.pop('_scim_alias_edit_permits', None)
+
+
+@sqlalchemy.event.listens_for(sqlalchemy.orm.Session, 'after_soft_rollback')
+def _clear_scim_alias_edit_permits_after_soft_rollback(
+    session,
+    _previous_transaction,
+):
+    session.info.pop('_scim_alias_edit_permits', None)
+
+
+sqlalchemy.event.listen(
+    User,
+    'after_insert',
+    _create_scim_mapping_after_user_insert,
+)
 
 
 class MailuConfig:

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -43,6 +43,53 @@ logging.getLogger('passlib').setLevel(logging.ERROR)
 db = flask_sqlalchemy.SQLAlchemy()
 
 
+def _sql_variable_enabled(value):
+    if isinstance(value, bytes):
+        value = value.decode('ascii')
+    return str(value).strip().upper() in {'1', 'ON', 'TRUE'}
+
+
+def _reject_mysql_statement_binlog(dbapi_connection, _connection_record):
+    cursor = dbapi_connection.cursor()
+    try:
+        cursor.execute(
+            'SELECT @@GLOBAL.log_bin, @@SESSION.sql_log_bin, '
+            '@@SESSION.binlog_format'
+        )
+        log_bin, sql_log_bin, binlog_format = cursor.fetchone()
+    finally:
+        cursor.close()
+
+    if isinstance(binlog_format, bytes):
+        binlog_format = binlog_format.decode('ascii')
+    if (
+        _sql_variable_enabled(log_bin)
+        and _sql_variable_enabled(sql_log_bin)
+        and str(binlog_format).strip().upper() == 'STATEMENT'
+    ):
+        raise RuntimeError(
+            'Mailu requires MySQL/MariaDB binlog_format=ROW or MIXED '
+            'while binary logging is active because the admin database '
+            'uses READ COMMITTED; binlog_format=STATEMENT is unsupported'
+        )
+
+
+def configure_database_engine(engine):
+    if (
+        engine.dialect.name in {'mysql', 'mariadb'}
+        and not event.contains(
+            engine,
+            'connect',
+            _reject_mysql_statement_binlog,
+        )
+    ):
+        event.listen(
+            engine,
+            'connect',
+            _reject_mysql_statement_binlog,
+        )
+
+
 @sqlalchemy.event.listens_for(sqlalchemy.engine.Engine, 'connect')
 def _enable_sqlite_foreign_keys(dbapi_connection, _connection_record):
     """Make SQLite enforce the same foreign-key contract as production SQL."""

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -2139,13 +2139,16 @@ class MailuConfig:
             return item
 
     def __init__(self):
-
-        # section-name -> attr
-        self._sections = {
-            name: getattr(self, name)
-            for name in dir(self)
-            if isinstance(getattr(self, name), self.MailuCollection)
-        }
+        # The class attributes below are collection templates. Each config
+        # object needs fresh collections: sharing the cached query results
+        # leaks detached ORM instances across app/session lifetimes.
+        self._sections = {}
+        for name in dir(type(self)):
+            template = getattr(type(self), name)
+            if isinstance(template, self.MailuCollection):
+                section = self.MailuCollection(template.model)
+                setattr(self, name, section)
+                self._sections[name] = section
 
         # known models
         self._models = tuple(section.model for section in self._sections.values())

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -1677,8 +1677,6 @@ def canonicalize_scim_destination(value):
 
 
 _SCIM_GRAPH_PROBE_CHUNK_SIZE = 500
-# Cap indexed SQL round trips before one full-scan fallback.
-_SCIM_CYCLE_PROBE_QUERY_BUDGET = 64
 
 
 def _active_scim_resources(resource_ids):
@@ -1742,66 +1740,30 @@ def _validate_scim_cycle(group, member_ids):
     if target_id in proposed_ids:
         raise ScimGraphError('SCIM Group membership would create a cycle')
 
+    reverse_adjacency = {}
+    edges = db.session.execute(
+        sqlalchemy.select(
+            ScimGroupMember.group_id,
+            ScimGroupMember.member_id,
+        ).with_for_update()
+    ).all()
+    for group_id, member_id in edges:
+        if group_id == target_id:
+            continue
+        reverse_adjacency.setdefault(member_id, set()).add(group_id)
+
     visited = {target_id}
     frontier = [target_id]
-    probe_queries = 0
     while frontier:
-        next_frontier = []
-        for start in range(
-            0,
-            len(frontier),
-            _SCIM_GRAPH_PROBE_CHUNK_SIZE,
-        ):
-            if probe_queries == _SCIM_CYCLE_PROBE_QUERY_BUDGET:
-                reverse_adjacency = {}
-                edges = db.session.execute(
-                    sqlalchemy.select(
-                        ScimGroupMember.group_id,
-                        ScimGroupMember.member_id,
-                    ).with_for_update()
-                ).all()
-                for group_id, member_id in edges:
-                    if group_id == target_id:
-                        continue
-                    reverse_adjacency.setdefault(member_id, set()).add(
-                        group_id
-                    )
-
-                fallback_visited = {target_id}
-                fallback_frontier = [target_id]
-                while fallback_frontier:
-                    member_id = fallback_frontier.pop()
-                    for group_id in reverse_adjacency.get(member_id, ()):
-                        if group_id in proposed_ids:
-                            raise ScimGraphError(
-                                'SCIM Group membership would create a cycle'
-                            )
-                        if group_id not in fallback_visited:
-                            fallback_visited.add(group_id)
-                            fallback_frontier.append(group_id)
-                return
-
-            chunk = frontier[
-                start:start + _SCIM_GRAPH_PROBE_CHUNK_SIZE
-            ]
-            group_ids = db.session.execute(
-                sqlalchemy.select(ScimGroupMember.group_id)
-                .where(
-                    ScimGroupMember.member_id.in_(chunk),
-                    ScimGroupMember.group_id != target_id,
+        member_id = frontier.pop()
+        for group_id in reverse_adjacency.get(member_id, ()):
+            if group_id in proposed_ids:
+                raise ScimGraphError(
+                    'SCIM Group membership would create a cycle'
                 )
-                .with_for_update()
-            ).scalars()
-            probe_queries += 1
-            for group_id in group_ids:
-                if group_id in proposed_ids:
-                    raise ScimGraphError(
-                        'SCIM Group membership would create a cycle'
-                    )
-                if group_id not in visited:
-                    visited.add(group_id)
-                    next_frontier.append(group_id)
-        frontier = next_frontier
+            if group_id not in visited:
+                visited.add(group_id)
+                frontier.append(group_id)
 
 
 def permit_scim_managed_alias_edit(alias):

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -172,8 +172,13 @@ class IdnaEmail(db.TypeDecorator):
 def ExactScimId():
     """Store provider IDs with byte-exact MySQL/MariaDB comparisons."""
     return db.String(255).with_variant(
-        mysql.VARCHAR(255, collation='utf8mb4_bin'),
+        mysql.VARCHAR(
+            255,
+            charset='utf8mb4',
+            collation='utf8mb4_bin',
+        ),
         'mysql',
+        'mariadb',
     )
 
 
@@ -1189,7 +1194,10 @@ class Fetch(Base):
         nullable=False)
     user = db.relationship(User,
         backref=db.backref('fetches', cascade='all, delete-orphan'))
-    protocol = db.Column(db.Enum('imap', 'pop3'), nullable=False)
+    protocol = db.Column(
+        db.Enum('imap', 'pop3', name='enum_protocol'),
+        nullable=False,
+    )
     host = db.Column(db.String(255), nullable=False)
     port = db.Column(db.Integer, nullable=False)
     tls = db.Column(db.Boolean, nullable=False, default=False)
@@ -1406,6 +1414,13 @@ class ScimGroupMember(db.Model):
         primary_key=True,
     )
 
+    __table_args__ = (
+        db.Index(
+            'scim_group_member_member_id_idx',
+            'member_id',
+        ),
+    )
+
     group = db.relationship(
         ScimResource,
         foreign_keys=[group_id],
@@ -1596,7 +1611,7 @@ def create_scim_group_mapping(
         raise ScimGroupAdoptionError('Alias is already SCIM managed')
     validate_scim_group_adoption(alias)
     resource = ScimResource(
-        id=resource_id or alias.email,
+        id=resource_id or new_scim_id(),
         resource_type='Group',
         alias=alias,
         subject_address=alias.email,

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -1677,6 +1677,8 @@ def canonicalize_scim_destination(value):
 
 
 _SCIM_GRAPH_PROBE_CHUNK_SIZE = 500
+# Cap indexed SQL round trips before one full-scan fallback.
+_SCIM_CYCLE_PROBE_QUERY_BUDGET = 64
 
 
 def _active_scim_resources(resource_ids):
@@ -1733,32 +1735,73 @@ def _reject_local_scim_destinations(destinations):
 
 
 def _validate_scim_cycle(group, member_ids):
-    adjacency = {}
-    edges = db.session.execute(
-        sqlalchemy.select(
-            ScimGroupMember.group_id,
-            ScimGroupMember.member_id,
-        ).with_for_update()
-    ).all()
-    for group_id, member_id in edges:
-        if group_id == group.id:
-            continue
-        adjacency.setdefault(group_id, set()).add(member_id)
-    adjacency[group.id] = set(member_ids)
-
-    def reaches_group(resource_id, seen):
-        if resource_id == group.id:
-            return True
-        if resource_id in seen:
-            return False
-        seen.add(resource_id)
-        return any(
-            reaches_group(child_id, seen)
-            for child_id in adjacency.get(resource_id, ())
-        )
-
-    if any(reaches_group(member_id, set()) for member_id in member_ids):
+    target_id = group.id
+    proposed_ids = set(member_ids)
+    if not proposed_ids:
+        return
+    if target_id in proposed_ids:
         raise ScimGraphError('SCIM Group membership would create a cycle')
+
+    visited = {target_id}
+    frontier = [target_id]
+    probe_queries = 0
+    while frontier:
+        next_frontier = []
+        for start in range(
+            0,
+            len(frontier),
+            _SCIM_GRAPH_PROBE_CHUNK_SIZE,
+        ):
+            if probe_queries == _SCIM_CYCLE_PROBE_QUERY_BUDGET:
+                reverse_adjacency = {}
+                edges = db.session.execute(
+                    sqlalchemy.select(
+                        ScimGroupMember.group_id,
+                        ScimGroupMember.member_id,
+                    ).with_for_update()
+                ).all()
+                for group_id, member_id in edges:
+                    if group_id == target_id:
+                        continue
+                    reverse_adjacency.setdefault(member_id, set()).add(
+                        group_id
+                    )
+
+                fallback_visited = {target_id}
+                fallback_frontier = [target_id]
+                while fallback_frontier:
+                    member_id = fallback_frontier.pop()
+                    for group_id in reverse_adjacency.get(member_id, ()):
+                        if group_id in proposed_ids:
+                            raise ScimGraphError(
+                                'SCIM Group membership would create a cycle'
+                            )
+                        if group_id not in fallback_visited:
+                            fallback_visited.add(group_id)
+                            fallback_frontier.append(group_id)
+                return
+
+            chunk = frontier[
+                start:start + _SCIM_GRAPH_PROBE_CHUNK_SIZE
+            ]
+            group_ids = db.session.execute(
+                sqlalchemy.select(ScimGroupMember.group_id)
+                .where(
+                    ScimGroupMember.member_id.in_(chunk),
+                    ScimGroupMember.group_id != target_id,
+                )
+                .with_for_update()
+            ).scalars()
+            probe_queries += 1
+            for group_id in group_ids:
+                if group_id in proposed_ids:
+                    raise ScimGraphError(
+                        'SCIM Group membership would create a cycle'
+                    )
+                if group_id not in visited:
+                    visited.add(group_id)
+                    next_frontier.append(group_id)
+        frontier = next_frontier
 
 
 def permit_scim_managed_alias_edit(alias):

--- a/core/admin/mailu/models.py
+++ b/core/admin/mailu/models.py
@@ -1676,22 +1676,60 @@ def canonicalize_scim_destination(value):
     return destination
 
 
-def _active_scim_resource(resource_id):
-    resource = db.session.execute(
-        sqlalchemy.select(ScimResource)
-        .where(ScimResource.id == resource_id)
-        .with_for_update()
-        .execution_options(populate_existing=True)
-    ).scalar_one_or_none()
-    if (
-        resource is None
-        or resource.id != resource_id
-        or resource.deleted_at is not None
-    ):
-        raise ScimGraphError(
-            f'SCIM member {resource_id!r} is not an active resource'
-        )
-    return resource
+_SCIM_GRAPH_PROBE_CHUNK_SIZE = 500
+
+
+def _active_scim_resources(resource_ids):
+    active = []
+    for start in range(0, len(resource_ids), _SCIM_GRAPH_PROBE_CHUNK_SIZE):
+        chunk = resource_ids[start:start + _SCIM_GRAPH_PROBE_CHUNK_SIZE]
+        resources = {}
+        for resource in db.session.execute(
+            sqlalchemy.select(ScimResource)
+            .where(ScimResource.id.in_(chunk))
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        ).scalars():
+            resources[resource.id] = resource
+        for resource_id in chunk:
+            resource = resources.get(resource_id)
+            if (
+                resource is None
+                or resource.id != resource_id
+                or resource.deleted_at is not None
+            ):
+                raise ScimGraphError(
+                    f'SCIM member {resource_id!r} is not an active resource'
+                )
+            active.append(resource)
+    return active
+
+
+def _reject_local_scim_destinations(destinations):
+    for start in range(0, len(destinations), _SCIM_GRAPH_PROBE_CHUNK_SIZE):
+        chunk = destinations[start:start + _SCIM_GRAPH_PROBE_CHUNK_SIZE]
+        possible_conflict = db.session.execute(
+            sqlalchemy.select(MailAddress.email)
+            .where(MailAddress.email.in_(chunk))
+            .limit(1)
+            .with_for_update()
+        ).scalar_one_or_none()
+        if possible_conflict is None:
+            continue
+
+        # Routing-address equality follows the database collation.  A row
+        # returned for an IN probe is not necessarily byte-equal to the input,
+        # so retain scalar equality probes to identify the first conflict.
+        for destination in chunk:
+            local = db.session.execute(
+                sqlalchemy.select(MailAddress.email)
+                .where(MailAddress.email == destination)
+                .with_for_update()
+            ).scalar_one_or_none()
+            if local is not None:
+                raise ScimExternalDestinationError(
+                    f'External destination {destination!r} is locally owned'
+                )
 
 
 def _validate_scim_cycle(group, member_ids):
@@ -1788,23 +1826,14 @@ def replace_scim_group_graph(
     lock_scim_graph()
 
     member_ids = list(dict.fromkeys(member_ids or ()))
-    members = [_active_scim_resource(member_id) for member_id in member_ids]
+    members = _active_scim_resources(member_ids)
     _validate_scim_cycle(group, member_ids)
 
     normalized_destinations = sorted({
         canonicalize_scim_destination(value)
         for value in (external_destinations or ())
     })
-    for destination in normalized_destinations:
-        local = db.session.execute(
-            sqlalchemy.select(MailAddress.email)
-            .where(MailAddress.email == destination)
-            .with_for_update()
-        ).scalar_one_or_none()
-        if local is not None:
-            raise ScimExternalDestinationError(
-                f'External destination {destination!r} is locally owned'
-            )
+    _reject_local_scim_destinations(normalized_destinations)
 
     db.session.execute(
         sqlalchemy.delete(ScimGroupMember).where(

--- a/core/admin/mailu/schemas.py
+++ b/core/admin/mailu/schemas.py
@@ -1069,7 +1069,26 @@ class BaseSchema(ma.SQLAlchemyAutoSchema, Storage):
                     # reset password hash
                     inst = type(item)(password=attr.history.deleted[-1])
                     if inst.check_password(original):
-                        item.password = inst.password
+                        if isinstance(item, models.User):
+                            state = sqlalchemy.inspect(item)
+                            generation = state.attrs.auth_generation
+                            original_generation = (
+                                generation.history.deleted[-1]
+                                if generation.history.deleted
+                                else None
+                            )
+                            item._preserve_auth_generation = True
+                            try:
+                                item.password = inst.password
+                            finally:
+                                del item._preserve_auth_generation
+                            if (
+                                original_generation is not None
+                                and not state.attrs.enabled.history.has_changes()
+                            ):
+                                item.auth_generation = original_generation
+                        else:
+                            item.password = inst.password
                 except ValueError:
                     # hash in db is invalid
                     pass
@@ -1179,7 +1198,15 @@ class UserSchema(BaseSchema):
         model = models.User
         load_instance = True
         include_relationships = True
-        exclude = ['_email', 'domain', 'localpart', 'domain_name', 'quota_bytes_used']
+        exclude = [
+            '_email',
+            'address_type',
+            'domain',
+            'localpart',
+            'domain_name',
+            'quota_bytes_used',
+            'auth_generation',
+        ]
 
         primary_keys = ['email']
         exclude_by_value = {
@@ -1206,7 +1233,13 @@ class AliasSchema(BaseSchema):
         """ Schema config """
         model = models.Alias
         load_instance = True
-        exclude = ['_email', 'domain', 'localpart', 'domain_name']
+        exclude = [
+            '_email',
+            'address_type',
+            'domain',
+            'localpart',
+            'domain_name',
+        ]
 
         primary_keys = ['email']
         exclude_by_value = {

--- a/core/admin/mailu/schemas.py
+++ b/core/admin/mailu/schemas.py
@@ -12,7 +12,7 @@ import yaml
 
 import sqlalchemy
 
-from marshmallow import pre_load, post_load, post_dump, fields, Schema
+from marshmallow import missing, pre_load, post_load, post_dump, fields, Schema
 from marshmallow.utils import ensure_text_type
 from marshmallow.exceptions import ValidationError
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchemaOpts
@@ -814,6 +814,59 @@ class BaseSchema(ma.SQLAlchemyAutoSchema, Storage):
         res = super().get_instance(data)
         return res
 
+    def _replacement_default(self, name):
+        """Return the value a freshly-created model gets for one load field."""
+        if name == self._primary:
+            raise KeyError(name)
+
+        mapper_property = self.opts.model.__mapper__.attrs.get(name)
+        if isinstance(mapper_property, sqlalchemy.orm.RelationshipProperty):
+            return [] if mapper_property.uselist else None
+        if isinstance(mapper_property, sqlalchemy.orm.ColumnProperty):
+            column = mapper_property.columns[0]
+            if column.primary_key:
+                raise KeyError(name)
+            default = column.default
+            if default is None:
+                return None
+            if default.is_scalar:
+                return deepcopy(default.arg)
+            if default.is_callable:
+                return default.arg(None)
+            raise KeyError(name)
+
+        descriptor = getattr(self.opts.model, name, None)
+        if isinstance(descriptor, property) and descriptor.fset is not None:
+            return None
+        raise KeyError(name)
+
+    def _prepare_replacement_item(self, data):
+        """Reset omitted public fields while retaining the persistent row."""
+        if type(data) is not dict:
+            return data
+        instance = self.get_instance(data)
+        if instance is None:
+            return data
+        for name, field in self.load_fields.items():
+            if name in data:
+                continue
+            if field.required:
+                # Required fields without input must still fail normal schema
+                # validation. Do not manufacture ``None`` and crash a field
+                # serializer before Marshmallow can report the contract error.
+                continue
+            try:
+                value = self._replacement_default(name)
+            except KeyError:
+                pass
+            else:
+                data[name] = field._serialize( # pylint: disable=protected-access
+                    value,
+                    name,
+                    instance,
+                )
+        return data
+
     @pre_load(pass_many=True)
     def _patch_many(self, items, many, **kwargs): # pylint: disable=unused-argument
         """ - flush sqla session before serializing a section when requested
@@ -826,6 +879,20 @@ class BaseSchema(ma.SQLAlchemyAutoSchema, Storage):
         # flush sqla session
         if not self.Meta.sibling:
             self.opts.sqla_session.flush()
+
+        # A default full import preserves rows by primary key but otherwise
+        # retains replacement semantics. Populate omitted public fields with
+        # the values a newly-created row would receive; do not borrow the
+        # merge/list-union semantics used by --update.
+        if self.context.get('reconcile'):
+            originals = items if many else [items]
+            self.store('original', deepcopy(originals))
+            if many:
+                return [
+                    self._prepare_replacement_item(item)
+                    for item in items
+                ]
+            return self._prepare_replacement_item(items)
 
         # stop early when not updating
         if not self.context.get('update'):
@@ -1047,8 +1114,15 @@ class BaseSchema(ma.SQLAlchemyAutoSchema, Storage):
             self.opts.sqla_session.add(item)
             return item
 
-        # stop early when not updating or item has no password attribute
-        if not self.context.get('update') or not hasattr(item, 'password'):
+        # stop early when neither updating nor reconciling, or when the item
+        # has no password attribute
+        if (
+            not (
+                self.context.get('update')
+                or self.context.get('reconcile')
+            )
+            or not hasattr(item, 'password')
+        ):
             return item
 
         # did we hash a new plaintext password?
@@ -1206,6 +1280,7 @@ class UserSchema(BaseSchema):
             'domain_name',
             'quota_bytes_used',
             'auth_generation',
+            'scim_resource',
         ]
 
         primary_keys = ['email']
@@ -1252,10 +1327,31 @@ class AliasSchema(BaseSchema):
     # Anonymous Email Service metadata
     note = fields.String(allow_none=True)
     hostname = fields.String(allow_none=True)
-    owner_email = fields.String(allow_none=True, dump_only=True)
+    # Full config export/import must round-trip owned/anonmail aliases. Keep
+    # this relationship read-only for standalone and --update loads; default
+    # replacement enables it only after the reconciliation preflight.
+    owner_email = fields.String(allow_none=True)
     # No load_default: in merge mode (config-import --update) an omitted field must
     # keep the stored value. On create the model column default (False) applies.
     disabled = fields.Boolean(dump_default=False)
+
+    @pre_load
+    def _owner_email_replacement_only(
+        self,
+        data,
+        many,
+        **kwargs,
+    ): # pylint: disable=unused-argument
+        if (
+            type(data) is dict
+            and 'owner_email' in data
+            and not self.context.get('reconcile')
+        ):
+            raise ValidationError(
+                'Unknown field.',
+                field_name='owner_email',
+            )
+        return data
 
 
 @mapped
@@ -1297,15 +1393,368 @@ class MailuSchema(Schema, Storage):
     @pre_load
     def _clear_config(self, data, many, **kwargs): # pylint: disable=unused-argument
         """ create config object in context if missing
-            and clear it if requested
+            and reconcile it if replacement was requested
         """
         if 'config' not in self.context:
             self.context['config'] = models.MailuConfig()
         if self.context.get('clear'):
-            self.context['config'].clear(
-                models = {field.nested.opts.model for field in self.fields.values()}
-            )
+            self.context['reconcile'] = True
+            self._reconcile_config(data)
         return data
+
+    def _reconcile_config(self, data):
+        """Prune absent rows while retaining rows present by public key."""
+        if type(data) is not dict:
+            return
+
+        self._preflight_nested_identities(data)
+        self._preflight_related_owners(data)
+        retained = {}
+        routing_addresses = {}
+        for section, field in self.fields.items():
+            items = data.get(section, [])
+            if type(items) is not list:
+                raise ValidationError(
+                    'Not a valid list.',
+                    field_name=section,
+                )
+            nested = field.schema
+            model = nested.opts.model
+            identities = set()
+            primary_keys = set()
+            managed_alias_items = []
+            primary_column = (
+                model.__table__.primary_key.columns.values()[0]
+            )
+            bind_processor = primary_column.type.bind_processor(
+                models.db.session.get_bind().dialect
+            )
+            for position, item in enumerate(items):
+                if type(item) is not dict:
+                    raise ValidationError(
+                        'Not a valid mapping.',
+                        field_name=f'{section}.{position}',
+                    )
+                # This relationship was accidentally exposed by the first
+                # persistent-identity implementation. It is internal state,
+                # not configuration data, and must never be rebound.
+                if model is models.User:
+                    item.pop('scim_resource', None)
+                if nested._primary not in item:
+                    raise ValidationError(
+                        'Missing data for required field.',
+                        field_name=(
+                            f'{section}.{position}.{nested._primary}'
+                        ),
+                    )
+                try:
+                    primary_key = item[nested._primary]
+                    if bind_processor is not None:
+                        primary_key = bind_processor(primary_key)
+                except (AttributeError, TypeError, ValueError) as exc:
+                    raise ValidationError(
+                        f'Invalid {nested._primary}: '
+                        f'{item[nested._primary]!r}.',
+                        field_name=(
+                            f'{section}.{position}.{nested._primary}'
+                        ),
+                    ) from exc
+                if primary_key in primary_keys:
+                    raise ValidationError(
+                        f'Duplicate {nested._primary}: {primary_key!r}.',
+                        field_name=(
+                            f'{section}.{position}.{nested._primary}'
+                        ),
+                    )
+                primary_keys.add(primary_key)
+                if model in (models.User, models.Alias):
+                    owner = routing_addresses.get(primary_key)
+                    if owner is not None:
+                        raise ValidationError(
+                            f'Address {primary_key!r} is present in both '
+                            f'{owner} and {section}.',
+                            field_name=(
+                                f'{section}.{position}.{nested._primary}'
+                            ),
+                        )
+                    routing_addresses[primary_key] = section
+                instance = nested.get_instance(item)
+                if instance is not None:
+                    # SQL bind canonicalization can make two spellings the
+                    # same public key (notably IDNA U-labels/A-labels). Retain
+                    # the existing row without assigning the alternate
+                    # spelling back through a persisted primary-key setter.
+                    item[nested._primary] = getattr(
+                        instance,
+                        nested._primary,
+                    )
+                    identities.add(sqlalchemy.inspect(instance).identity)
+                    if (
+                        model is models.Alias
+                        and instance.scim_resource is not None
+                        and instance.scim_resource.deleted_at is None
+                    ):
+                        self._validate_managed_alias_input(
+                            nested,
+                            instance,
+                            item,
+                            position,
+                        )
+                        managed_alias_items.append(item)
+            retained[model] = identities
+            if managed_alias_items:
+                # The materialized Alias is a projection of normalized SCIM
+                # graph state, not an import authority. An unchanged projection
+                # establishes retention, then stays out of the generic loader
+                # so concurrent pruning cannot reload stale destinations.
+                items[:] = [
+                    item for item in items
+                    if item not in managed_alias_items
+                ]
+
+        obsolete = {
+            model: [
+                item for item in model.query.all()
+                if sqlalchemy.inspect(item).identity not in identities
+            ]
+            for model, identities in retained.items()
+        }
+
+        scim_deleted_aliases = set()
+        for alias in obsolete.get(models.Alias, []):
+            if (
+                alias.scim_resource is not None
+                and alias.scim_resource.deleted_at is None
+            ):
+                models.tombstone_scim_resource(alias.scim_resource)
+                # Match SCIM Group DELETE: persist the detached tombstone
+                # before deleting its formerly managed Alias.
+                models.db.session.flush()
+                models.db.session.delete(alias)
+                scim_deleted_aliases.add(alias)
+
+        retained_users = retained.get(models.User, set())
+        retained_aliases = retained.get(models.Alias, set())
+        for domain in obsolete.get(models.Domain, []):
+            has_retained_user = any(
+                sqlalchemy.inspect(user).identity in retained_users
+                for user in domain.users
+            )
+            has_retained_alias = any(
+                sqlalchemy.inspect(alias).identity in retained_aliases
+                for alias in domain.aliases
+            )
+            if has_retained_user or has_retained_alias:
+                raise ValidationError(
+                    f'Domain {domain.name} cannot be removed while retained '
+                    'users or aliases reference it.',
+                    field_name='domain',
+                )
+
+        for items in obsolete.values():
+            for item in items:
+                if item not in scim_deleted_aliases:
+                    models.db.session.delete(item)
+        models.db.session.flush()
+
+        # Deleting a User can rematerialize retained Group projections from
+        # inside the identity lifecycle hook. Settle those lifecycle-owned
+        # writes before the ordinary section loaders issue their own flushes.
+        dirty_managed_aliases = [
+            alias for alias in models.db.session.dirty
+            if (
+                isinstance(alias, models.Alias)
+                and alias.scim_resource is not None
+                and alias.scim_resource.deleted_at is None
+            )
+        ]
+        for alias in dirty_managed_aliases:
+            models.permit_scim_managed_alias_edit(alias)
+        if dirty_managed_aliases:
+            models.db.session.flush()
+
+    def _preflight_nested_identities(self, data):
+        """Reject duplicate nested database identities before any mutation."""
+        seen = {}
+        dialect = models.db.session.get_bind().dialect
+        for section, outer_field in self.fields.items():
+            outer_items = data.get(section, [])
+            if type(outer_items) is not list:
+                continue
+            outer_schema = outer_field.schema
+            for outer_position, outer_item in enumerate(outer_items):
+                if type(outer_item) is not dict:
+                    continue
+                for name, nested_field in outer_schema.load_fields.items():
+                    if (
+                        not isinstance(nested_field, fields.Nested)
+                        or not nested_field.many
+                        or name not in outer_item
+                    ):
+                        continue
+                    nested_items = outer_item[name]
+                    if type(nested_items) is not list:
+                        raise ValidationError(
+                            'Not a valid list.',
+                            field_name=(
+                                f'{section}.{outer_position}.{name}'
+                            ),
+                        )
+                    nested_schema = nested_field.schema
+                    primary = nested_schema._primary
+                    model = nested_schema.opts.model
+                    primary_column = (
+                        model.__table__.primary_key.columns.values()[0]
+                    )
+                    bind_processor = primary_column.type.bind_processor(
+                        dialect
+                    )
+                    model_seen = seen.setdefault(model, set())
+                    for nested_position, nested_item in enumerate(
+                        nested_items
+                    ):
+                        if type(nested_item) is not dict:
+                            raise ValidationError(
+                                'Not a valid mapping.',
+                                field_name=(
+                                    f'{section}.{outer_position}.{name}.'
+                                    f'{nested_position}'
+                                ),
+                            )
+                        if primary not in nested_item:
+                            continue
+                        value = nested_schema.load_fields[
+                            primary
+                        ].deserialize(nested_item[primary])
+                        if bind_processor is not None:
+                            value = bind_processor(value)
+                        if value in model_seen:
+                            raise ValidationError(
+                                f'Duplicate {primary}: {value!r}.',
+                                field_name=(
+                                    f'{section}.{outer_position}.{name}.'
+                                    f'{nested_position}.{primary}'
+                                ),
+                            )
+                        model_seen.add(value)
+
+    def _preflight_related_owners(self, data):
+        """Reject duplicate ownership of one-to-many related identities."""
+        dialect = models.db.session.get_bind().dialect
+        for section, outer_field in self.fields.items():
+            outer_items = data.get(section, [])
+            if type(outer_items) is not list:
+                continue
+            outer_schema = outer_field.schema
+            outer_model = outer_schema.opts.model
+            for name, related_field in outer_schema.load_fields.items():
+                if not isinstance(related_field, RelatedList):
+                    continue
+                relationship = outer_model.__mapper__.relationships.get(name)
+                if (
+                    relationship is None
+                    or relationship.direction
+                    is not sqlalchemy.orm.ONETOMANY
+                ):
+                    continue
+                primary_columns = relationship.mapper.primary_key
+                if len(primary_columns) != 1:
+                    continue
+                primary_column = primary_columns[0]
+                bind_processor = primary_column.type.bind_processor(dialect)
+                python_type = primary_column.type.python_type
+                seen = set()
+                for outer_position, outer_item in enumerate(outer_items):
+                    if type(outer_item) is not dict or name not in outer_item:
+                        continue
+                    related_items = outer_item[name]
+                    if type(related_items) is not list:
+                        raise ValidationError(
+                            'Not a valid list.',
+                            field_name=(
+                                f'{section}.{outer_position}.{name}'
+                            ),
+                        )
+                    for related_position, raw_value in enumerate(
+                        related_items
+                    ):
+                        path = (
+                            f'{section}.{outer_position}.{name}.'
+                            f'{related_position}'
+                        )
+                        try:
+                            related = related_field.inner.deserialize(
+                                raw_value
+                            )
+                            value = getattr(
+                                related,
+                                primary_column.key,
+                            )
+                            value = python_type(value)
+                            if bind_processor is not None:
+                                value = bind_processor(value)
+                        except (
+                            AttributeError,
+                            TypeError,
+                            ValueError,
+                            ValidationError,
+                        ) as exc:
+                            raise ValidationError(
+                                f'Invalid related identity: {raw_value!r}.',
+                                field_name=path,
+                            ) from exc
+                        if value in seen:
+                            raise ValidationError(
+                                f'Duplicate related identity: {value!r}.',
+                                field_name=path,
+                            )
+                        seen.add(value)
+
+    @staticmethod
+    def _validate_managed_alias_input(schema, alias, item, position):
+        """Reject attempts to mutate a retained SCIM-owned Alias."""
+        unknown = set(item) - set(schema.fields)
+        if unknown:
+            name = sorted(unknown)[0]
+            raise ValidationError(
+                'Unknown field.',
+                field_name=f'alias.{position}.{name}',
+            )
+
+        prepared = schema._prepare_replacement_item( # pylint: disable=protected-access
+            deepcopy(item)
+        )
+        for name, raw_value in prepared.items():
+            field = schema.load_fields.get(name)
+            if field is None:
+                continue
+            if name == schema._primary:
+                continue
+            value = field.deserialize(
+                raw_value,
+                attr=name,
+                data=prepared,
+            )
+            current_raw = field.serialize(name, alias)
+            current = (
+                None
+                if current_raw is missing
+                else field.deserialize(
+                    current_raw,
+                    attr=name,
+                    data={name: current_raw},
+                )
+            )
+            if name == 'destination':
+                value = sorted(set(value))
+                current = sorted(set(current))
+            if value != current:
+                raise ValidationError(
+                    f'SCIM-managed Group alias {alias.email} cannot be '
+                    f'modified by config import; field {name!r} is '
+                    'provider-owned.',
+                    field_name=f'alias.{position}.{name}',
+                )
 
     @post_load
     def _make_config(self, data, many, **kwargs): # pylint: disable=unused-argument

--- a/core/admin/mailu/sso/views/base.py
+++ b/core/admin/mailu/sso/views/base.py
@@ -53,7 +53,8 @@ def login():
         user = models.User.login(username, form.pw.data)
         if user:
             flask.session.regenerate()
-            flask_login.login_user(user)
+            if not utils.login_user(user):
+                flask.abort(403)
             if user.change_pw_next_login:
                 flask.session['redirect_to'] = destination
                 destination = flask.url_for('sso.pw_change')
@@ -89,11 +90,17 @@ def pw_change():
             return flask.redirect(flask.url_for('sso.pw_change'))
         user = models.User.login(flask_login.current_user.email, form.oldpw.data)
         if user:
-            flask.session.regenerate()
-            flask_login.login_user(user)
-            user.set_password(form.pw.data, keep_sessions=set(flask.session))
+            user.set_password(form.pw.data, keep_sessions=True)
             user.change_pw_next_login = False
+            expected_generation = user.auth_generation
+            uid = user.email
             models.db.session.commit()
+            utils.finish_session_authority_change(
+                user,
+                preserve_current=True,
+                expected_generation=expected_generation,
+                uid=uid,
+            )
             flask.current_app.logger.info(f'Forced password change by {user} from: {client_ip}/{client_port}: success: password: {form.pwned.data}')
             destination = flask.session.pop('redirect_to', None) or app.config['WEB_ADMIN']
             return flask.redirect(destination)
@@ -144,8 +151,15 @@ def _proxy():
 
     user = models.User.get(email)
     if user:
+        if not user.enabled:
+            flask.current_app.logger.warning(
+                f'Login failed by proxy - disabled user: {user} from '
+                f'{client_ip} through {flask.request.remote_addr}.'
+            )
+            return flask.abort(403)
         flask.session.regenerate()
-        flask_login.login_user(user)
+        if not utils.login_user(user):
+            return flask.abort(403)
         flask.current_app.logger.info(f'Login succeeded by proxy created user: {user} from {client_ip} through {flask.request.remote_addr}.')
         return flask.redirect(url)
 
@@ -164,11 +178,12 @@ def _proxy():
         flask.current_app.logger.warning('Too many users for domain %s' % domain)
         return flask.abort(500, 'Too many users in (domain=%s)' % domain)
     user = models.User(localpart=localpart, domain=domain)
-    user.set_password(secrets.token_urlsafe(), keep_sessions=set(flask.session))
+    user.set_password(secrets.token_urlsafe(), keep_sessions=True)
     models.db.session.add(user)
     models.db.session.commit()
     flask.session.regenerate()
-    flask_login.login_user(user)
+    if not utils.login_user(user):
+        return flask.abort(403)
     user.send_welcome()
     flask.current_app.logger.info(f'Login succeeded by proxy created user: {user} from {client_ip} through {flask.request.remote_addr}.')
     return flask.redirect(url)

--- a/core/admin/mailu/ui/views/aliases.py
+++ b/core/admin/mailu/ui/views/aliases.py
@@ -42,12 +42,19 @@ def alias_create(domain_name):
 @access.domain_admin(models.Alias, 'alias')
 def alias_edit(alias):
     alias = models.Alias.query.get(alias) or flask.abort(404)
+    domain_name = alias.domain_name
     form = forms.AliasForm(obj=alias)
     wtforms_components.read_only(form.localpart)
     form.localpart.validators = []
     if form.validate_on_submit():
         form.populate_obj(alias)
-        models.db.session.commit()
+        try:
+            models.db.session.commit()
+        except models.ScimManagedAliasError as exc:
+            models.db.session.rollback()
+            flask.flash(str(exc), 'error')
+            return flask.redirect(
+                flask.url_for('.alias_list', domain_name=domain_name))
         flask.flash('Alias %s updated' % alias)
         return flask.redirect(
             flask.url_for('.alias_list', domain_name=alias.domain.name))
@@ -60,12 +67,18 @@ def alias_edit(alias):
 @access.confirmation_required("delete {alias}")
 def alias_delete(alias):
     alias = models.Alias.query.get(alias) or flask.abort(404)
-    domain = alias.domain
-    models.db.session.delete(alias)
-    models.db.session.commit()
+    domain_name = alias.domain_name
+    try:
+        models.db.session.delete(alias)
+        models.db.session.commit()
+    except models.ScimManagedAliasError as exc:
+        models.db.session.rollback()
+        flask.flash(str(exc), 'error')
+        return flask.redirect(
+            flask.url_for('.alias_list', domain_name=domain_name))
     flask.flash('Alias %s deleted' % alias)
     return flask.redirect(
-        flask.url_for('.alias_list', domain_name=domain.name))
+        flask.url_for('.alias_list', domain_name=domain_name))
 
 
 @ui.route('/anonalias/list', methods=['GET'])

--- a/core/admin/mailu/ui/views/domains.py
+++ b/core/admin/mailu/ui/views/domains.py
@@ -70,8 +70,13 @@ def domain_edit(domain_name):
 @access.confirmation_required("delete {domain_name}")
 def domain_delete(domain_name):
     domain = models.Domain.query.get(domain_name) or flask.abort(404)
-    models.db.session.delete(domain)
-    models.db.session.commit()
+    try:
+        models.db.session.delete(domain)
+        models.db.session.commit()
+    except models.ScimManagedAliasError as exc:
+        models.db.session.rollback()
+        flask.flash(str(exc), 'error')
+        return flask.redirect(flask.url_for('.domain_list'))
     flask.flash('Domain %s deleted' % domain)
     return flask.redirect(flask.url_for('.domain_list'))
 

--- a/core/admin/mailu/ui/views/users.py
+++ b/core/admin/mailu/ui/views/users.py
@@ -40,7 +40,7 @@ def user_create(domain_name):
         else:
             user = models.User(domain=domain)
             form.populate_obj(user)
-            user.set_password(form.pw.data)
+            user.set_password(form.pw.data, keep_sessions=True)
             models.db.session.add(user)
             models.db.session.commit()
             user.send_welcome()
@@ -76,10 +76,21 @@ def user_edit(user_email):
                 flask.flash(msg, "error")
                 return flask.render_template('user/edit.html', form=form, user=user,
                     domain=user.domain, max_quota_bytes=max_quota_bytes)
+        previous_generation = user.auth_generation
+        preserve_current = flask_login.current_user.email == user.email
         form.populate_obj(user)
         if form.pw.data:
-            user.set_password(form.pw.data, keep_sessions=set(flask.session))
+            user.set_password(form.pw.data, keep_sessions=True)
+        expected_generation = user.auth_generation
+        uid = user.email
         models.db.session.commit()
+        if expected_generation != previous_generation:
+            utils.finish_session_authority_change(
+                user,
+                preserve_current=preserve_current,
+                expected_generation=expected_generation,
+                uid=uid,
+            )
         flask.flash('User %s updated' % user)
         return flask.redirect(
             flask.url_for('.user_list', domain_name=user.domain.name))
@@ -125,9 +136,17 @@ def _process_password_change(form, user_email):
             if msg := utils.isBadOrPwned(form):
                 flask.flash(msg, "error")
                 return flask.render_template('user/password.html', form=form, user=user)
-            flask.session.regenerate()
-            user.set_password(form.pw.data, keep_sessions=set(flask.session))
+            preserve_current = flask_login.current_user.email == user.email
+            user.set_password(form.pw.data, keep_sessions=True)
+            expected_generation = user.auth_generation
+            uid = user.email
             models.db.session.commit()
+            utils.finish_session_authority_change(
+                user,
+                preserve_current=preserve_current,
+                expected_generation=expected_generation,
+                uid=uid,
+            )
             flask.flash('Password updated for %s' % user)
             if user_email:
                 return flask.redirect(flask.url_for('.user_list',
@@ -194,7 +213,7 @@ def user_signup(domain_name=None):
             user = models.User(domain=domain)
             form.populate_obj(user)
             user.change_pw_next_login = True
-            user.set_password(form.pw.data)
+            user.set_password(form.pw.data, keep_sessions=True)
             user.quota_bytes = quota_bytes
             models.db.session.add(user)
             models.db.session.commit()

--- a/core/admin/mailu/utils.py
+++ b/core/admin/mailu/utils.py
@@ -42,6 +42,91 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 login = flask_login.LoginManager()
 login.login_view = "sso.login"
 
+INITIAL_AUTH_GENERATION = '0' * 32
+SESSION_AUTH_GENERATION_KEY = '_auth_generation'
+_MISSING_AUTH_GENERATION = object()
+
+
+def _auth_generation(user):
+    """Return a User generation, failing closed on corrupt database state."""
+    generation = user.auth_generation
+    if (
+        not isinstance(generation, str)
+        or len(generation) != 32
+        or any(character not in string.hexdigits for character in generation)
+    ):
+        raise RuntimeError(f'Invalid auth generation for User {user.email!r}')
+    return generation.lower()
+
+
+def _session_generation_matches(session_data, user, *, backfill_legacy=False):
+    """Whether a server-side session belongs to the User's current generation."""
+    current = _auth_generation(user)
+    stored = session_data.get(
+        SESSION_AUTH_GENERATION_KEY,
+        _MISSING_AUTH_GENERATION,
+    )
+    if stored is _MISSING_AUTH_GENERATION:
+        if current != INITIAL_AUTH_GENERATION:
+            return False
+        if backfill_legacy:
+            session_data[SESSION_AUTH_GENERATION_KEY] = current
+        return True
+    return isinstance(stored, str) and stored == current
+
+
+def _invalidate_current_session(reason, user_id=None):
+    """Fail closed even when physical session-store deletion fails."""
+    try:
+        flask.session.destroy()
+    except Exception:
+        flask.current_app.logger.exception(
+            'Session cleanup failed after authority rejection: '
+            'reason=%s user=%r',
+            reason,
+            user_id,
+        )
+        # Do not let a Redis failure preserve authenticated state in the
+        # in-memory request session or write it back during response handling.
+        flask.session.pop('_user_id', None)
+        flask.session.pop(SESSION_AUTH_GENERATION_KEY, None)
+        flask.session.pop('_fresh', None)
+        flask.session.pop('_id', None)
+        flask.session.pop('_remember', None)
+        flask.session.pop('_remember_seconds', None)
+    return None
+
+
+def load_session_user(user_id):
+    """Flask-Login loader with SQL-backed session authority."""
+    # Import locally: models imports this module for password/session helpers.
+    from mailu import models
+
+    user = models.User.get(user_id)
+    if user is None:
+        return _invalidate_current_session('missing_user', user_id)
+    if not user.enabled:
+        return _invalidate_current_session('disabled', user_id)
+    if not _session_generation_matches(
+        flask.session,
+        user,
+        backfill_legacy=True,
+    ):
+        return _invalidate_current_session('generation_mismatch', user_id)
+    return user
+
+
+def login_user(user, **kwargs):
+    """Issue a Flask-Login session bound to the authenticated User generation."""
+    if not user.enabled:
+        return False
+    generation = _auth_generation(user)
+    if not flask_login.login_user(user, **kwargs):
+        return False
+    flask.session[SESSION_AUTH_GENERATION_KEY] = generation
+    return True
+
+
 @login.unauthorized_handler
 def handle_needs_login():
     """ redirect unauthorized requests to login page """
@@ -172,16 +257,16 @@ class DictStore:
 
     def get(self, key):
         """ load item from store. """
-        return self.dict[key]
+        return self.dict[want_bytes(key)]
 
     def put(self, key, value, ttl=None):
         """ save item to store. """
-        self.dict[key] = value
+        self.dict[want_bytes(key)] = value
 
     def delete(self, key):
         """ delete item from store. """
         try:
-            del self.dict[key]
+            del self.dict[want_bytes(key)]
         except KeyError:
             pass
 
@@ -189,6 +274,7 @@ class DictStore:
         """ return list of keys starting with prefix """
         if prefix is None:
             return list(self.dict.keys())
+        prefix = want_bytes(prefix)
         return [key for key in self.dict if key.startswith(prefix)]
 
 class MailuSession(CallbackDict, SessionMixin):
@@ -459,7 +545,7 @@ class MailuSessionExtension:
             keep: keep listed sessions
         """
 
-        keep = keep or set()
+        keep = {want_bytes(key) for key in (keep or set())}
         app = app or flask.current_app
 
         prefix = None if uid is None else app.session_config.gen_uid(uid)
@@ -467,7 +553,11 @@ class MailuSessionExtension:
         count = 0
         for key in app.session_store.list(prefix):
             if key not in keep and not key.startswith(b'token-'):
-                app.session_store.delete(key)
+                stored_session = MailuSession(key, app)
+                if stored_session.saved:
+                    stored_session.delete()
+                else:
+                    app.session_store.delete(key)
                 count += 1
 
         return count
@@ -502,16 +592,117 @@ class MailuSessionExtension:
 cleaned = Value('i', False)
 session = MailuSessionExtension()
 
-# this is used by the webmail to authenticate IMAP/SMTP
-def verify_temp_token(email, token):
+
+def prune_sessions_best_effort(uid):
+    """Physically remove stale sessions after SQL authority has committed."""
     try:
-        if token.startswith('token-'):
+        count = MailuSessionExtension.prune_sessions(uid=uid)
+    except Exception:
+        flask.current_app.logger.exception(
+            'Physical session cleanup failed after authority was revoked: '
+            'user=%r authority_revoked=true',
+            uid,
+        )
+        return False
+    flask.current_app.logger.info(
+        'Physical session cleanup completed: user=%r deleted=%d',
+        uid,
+        count,
+    )
+    return True
+
+
+def finish_session_authority_change(
+    user,
+    *,
+    preserve_current=False,
+    expected_generation=None,
+    uid=None,
+):
+    """Run non-authoritative session cleanup after a successful SQL commit.
+
+    Callers must commit the password/enablement change and auth generation
+    before entering this helper.
+    """
+    uid = uid or user.email
+    if (
+        preserve_current
+        and flask.has_request_context()
+        and flask.session.get('_user_id') == uid
+    ):
+        try:
+            current_generation = _auth_generation(user)
+            expected_generation = (
+                current_generation
+                if expected_generation is None
+                else expected_generation
+            )
+            if (
+                not user.enabled
+                or current_generation != expected_generation
+            ):
+                _invalidate_current_session(
+                    'post_commit_generation_changed',
+                    uid,
+                )
+                return prune_sessions_best_effort(uid)
+            # The replacement session is not in the store yet, so the
+            # subsequent prefix prune cannot delete it.
+            flask.session.regenerate()
+            if not login_user(user):
+                _invalidate_current_session('post_commit_rebind_failed', uid)
+        except Exception:
+            flask.current_app.logger.exception(
+                'Current session could not be rebound after authority change: '
+                'user=%r',
+                uid,
+            )
+            _invalidate_current_session('post_commit_rebind_failed', uid)
+    return prune_sessions_best_effort(uid)
+
+
+# this is used by the webmail to authenticate IMAP/SMTP
+def verify_temp_token(user, token):
+    """Validate a webmail token against its User and session generation."""
+    backing_session = None
+    try:
+        if user and user.enabled and token.startswith('token-'):
             if sessid := app.session_store.get(token):
-                session = MailuSession(sessid, app)
-                if session.get('_user_id', '') == email:
+                backing_session = MailuSession(sessid, app)
+                had_generation = (
+                    SESSION_AUTH_GENERATION_KEY in backing_session
+                )
+                if (
+                    backing_session.get('_user_id', '') == user.email
+                    and _session_generation_matches(
+                        backing_session,
+                        user,
+                        backfill_legacy=True,
+                    )
+                ):
+                    if not had_generation:
+                        backing_session.save()
                     return True
-    except:
-        pass
+    except KeyError:
+        return False
+    except Exception:
+        app.logger.exception(
+            'Temporary webmail token validation failed closed: user=%r',
+            getattr(user, 'email', None),
+        )
+        return False
+
+    # A mismatch is authoritative. Physical deletion remains best effort.
+    try:
+        if backing_session is not None:
+            backing_session.delete()
+        app.session_store.delete(token)
+    except Exception:
+        app.logger.exception(
+            'Stale temporary webmail token cleanup failed: user=%r',
+            getattr(user, 'email', None),
+        )
+    return False
 
 def gen_temp_token(email, session):
     token = session.get('webmail_token', 'token-'+secrets.token_urlsafe())

--- a/core/admin/migrations/versions/d4a6f2b8c901_.py
+++ b/core/admin/migrations/versions/d4a6f2b8c901_.py
@@ -1,0 +1,401 @@
+"""Enforce global User/Alias routing-address uniqueness
+
+Revision ID: d4a6f2b8c901
+Revises: 9a5866105f5a
+Create Date: 2026-07-29 14:00:00.000000
+
+User and Alias historically had independent email primary keys. A shared
+mail_address registry now serializes ownership of a canonical routing address.
+Existing cross-table collisions are ambiguous operator data, so the migration
+refuses to mutate the schema until an administrator resolves them.
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'd4a6f2b8c901'
+down_revision = '9a5866105f5a'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+naming_convention = {
+    'fk': '%(table_name)s_%(column_0_name)s_fkey',
+    'pk': '%(table_name)s_pkey',
+}
+
+metadata = sa.MetaData()
+user = sa.Table(
+    'user',
+    metadata,
+    sa.Column('email', sa.String(255), primary_key=True),
+)
+alias = sa.Table(
+    'alias',
+    metadata,
+    sa.Column('email', sa.String(255), primary_key=True),
+)
+mail_address = sa.Table(
+    'mail_address',
+    metadata,
+    sa.Column('email', sa.String(255), primary_key=True),
+    sa.Column('address_type', sa.String(5), nullable=False),
+)
+
+
+def _registry_string_types(connection):
+    """Match the existing routing-key collation before creating the registry.
+
+    MariaDB/MySQL do not permit a foreign key between string columns whose
+    character set or collation differs.  More importantly, creating the new
+    table with the *database's current* default can make the registry compare
+    addresses more broadly than the existing User/Alias primary keys.  That
+    turns an otherwise valid populated upgrade into a non-transactional,
+    half-applied migration.
+    """
+    if connection.dialect.name != 'mysql':
+        return sa.String(length=255), sa.String(length=5)
+
+    rows = connection.execute(
+        sa.text(
+            """
+            SELECT TABLE_NAME, CHARACTER_SET_NAME, COLLATION_NAME
+              FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME IN ('user', 'alias')
+               AND COLUMN_NAME = 'email'
+            """
+        )
+    ).all()
+    if len(rows) != 2:
+        raise RuntimeError(
+            'Cannot inspect both User and Alias email column collations '
+            'before creating the global mail-address registry.'
+        )
+    storage = {
+        (character_set, collation)
+        for _table, character_set, collation in rows
+    }
+    if len(storage) != 1:
+        details = ', '.join(
+            f'{table}={character_set}/{collation}'
+            for table, character_set, collation in sorted(rows)
+        )
+        raise RuntimeError(
+            'Cannot enforce global mail-address uniqueness because User and '
+            f'Alias use different email storage semantics: {details}. '
+            'Align the columns, then retry.'
+        )
+    character_set, collation = storage.pop()
+    if not character_set or not collation:
+        raise RuntimeError(
+            'Cannot determine the User/Alias email storage collation before '
+            'creating the global mail-address registry.'
+        )
+    return (
+        sa.String(length=255, collation=collation),
+        sa.String(length=5, collation=collation),
+    )
+
+
+def _cross_table_collisions(connection):
+    users = {
+        email.lower(): email
+        for (email,) in connection.execute(sa.select(user.c.email))
+    }
+    aliases = {
+        email.lower(): email
+        for (email,) in connection.execute(sa.select(alias.c.email))
+    }
+    collisions = {
+        (users[canonical], aliases[canonical]): canonical
+        for canonical in users.keys() & aliases.keys()
+    }
+
+    # The application canonicalizer catches case/IDNA aliases.  MariaDB may
+    # use a still-broader accent-insensitive collation, so also ask the target
+    # database which values compare equal before creating any DDL.
+    native_pairs = connection.execute(
+        sa.select(user.c.email, alias.c.email).select_from(
+            user.join(alias, user.c.email == alias.c.email)
+        )
+    )
+    for user_email, alias_email in native_pairs:
+        collisions.setdefault(
+            (user_email, alias_email),
+            user_email.lower(),
+        )
+
+    return [
+        (canonical, user_email, alias_email)
+        for (user_email, alias_email), canonical in sorted(
+            collisions.items(),
+            key=lambda item: (item[1], item[0]),
+        )
+    ]
+
+
+def _requires_sqlite_reference_rebuild(connection):
+    """SQLite table copies require inbound FK removal; native ALTER does not."""
+    return connection.dialect.name == 'sqlite'
+
+
+def _drop_user_references():
+    with op.batch_alter_table(
+        'alias',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.drop_constraint(
+            'alias_owner_email_fkey',
+            type_='foreignkey',
+        )
+    with op.batch_alter_table(
+        'fetch',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.drop_constraint(
+            'fetch_user_email_fkey',
+            type_='foreignkey',
+        )
+    with op.batch_alter_table(
+        'token',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.drop_constraint(
+            'token_user_email_fkey',
+            type_='foreignkey',
+        )
+    with op.batch_alter_table(
+        'manager',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.drop_constraint(
+            'manager_user_email_fkey',
+            type_='foreignkey',
+        )
+    with op.batch_alter_table(
+        'domain_access',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.drop_constraint(
+            'domain_access_user_email_fkey',
+            type_='foreignkey',
+        )
+
+
+def _restore_user_references():
+    with op.batch_alter_table(
+        'alias',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.create_foreign_key(
+            'alias_owner_email_fkey',
+            'user',
+            ['owner_email'],
+            ['email'],
+        )
+    with op.batch_alter_table(
+        'fetch',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.create_foreign_key(
+            'fetch_user_email_fkey',
+            'user',
+            ['user_email'],
+            ['email'],
+        )
+    with op.batch_alter_table(
+        'token',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.create_foreign_key(
+            'token_user_email_fkey',
+            'user',
+            ['user_email'],
+            ['email'],
+        )
+    with op.batch_alter_table(
+        'manager',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.create_foreign_key(
+            'manager_user_email_fkey',
+            'user',
+            ['user_email'],
+            ['email'],
+        )
+    with op.batch_alter_table(
+        'domain_access',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.create_foreign_key(
+            'domain_access_user_email_fkey',
+            'user',
+            ['user_email'],
+            ['email'],
+        )
+
+
+def upgrade():
+    connection = op.get_bind()
+
+    # MySQL/MariaDB may auto-commit DDL, so this destructive ambiguity check
+    # must remain the first operation.
+    registry_email_type, registry_address_type = _registry_string_types(
+        connection
+    )
+    collisions = _cross_table_collisions(connection)
+    if collisions:
+        listing = '\n'.join(
+            f'  {canonical}: User={user_email}, Alias={alias_email}'
+            for canonical, user_email, alias_email in collisions
+        )
+        raise RuntimeError(
+            'Cannot enforce global mail-address uniqueness. These addresses '
+            'exist as both User and Alias:\n'
+            f'{listing}\n'
+            'Remove or rename one owner of each address, then retry.'
+        )
+
+    op.create_table(
+        'mail_address',
+        sa.Column('email', registry_email_type, nullable=False),
+        sa.Column('address_type', registry_address_type, nullable=False),
+        sa.CheckConstraint(
+            "address_type IN ('user', 'alias')",
+            name='mail_address_type_check',
+        ),
+        sa.PrimaryKeyConstraint(
+            'email',
+            name='mail_address_pkey',
+        ),
+        sa.UniqueConstraint(
+            'email',
+            'address_type',
+            name='mail_address_email_type_key',
+        ),
+    )
+
+    connection.execute(
+        mail_address.insert().from_select(
+            ['email', 'address_type'],
+            sa.select(
+                user.c.email,
+                sa.literal('user'),
+            ),
+        )
+    )
+    connection.execute(
+        mail_address.insert().from_select(
+            ['email', 'address_type'],
+            sa.select(
+                alias.c.email,
+                sa.literal('alias'),
+            ),
+        )
+    )
+
+    rebuild_references = _requires_sqlite_reference_rebuild(connection)
+    if rebuild_references:
+        _drop_user_references()
+
+    with op.batch_alter_table(
+        'user',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.add_column(
+            sa.Column(
+                'address_type',
+                registry_address_type,
+                nullable=False,
+                server_default='user',
+            )
+        )
+        batch.create_check_constraint(
+            'user_address_type_check',
+            "address_type = 'user'",
+        )
+        batch.create_foreign_key(
+            'user_mail_address_fkey',
+            'mail_address',
+            ['email', 'address_type'],
+            ['email', 'address_type'],
+        )
+
+    with op.batch_alter_table(
+        'alias',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.add_column(
+            sa.Column(
+                'address_type',
+                registry_address_type,
+                nullable=False,
+                server_default='alias',
+            )
+        )
+        batch.create_check_constraint(
+            'alias_address_type_check',
+            "address_type = 'alias'",
+        )
+        batch.create_foreign_key(
+            'alias_mail_address_fkey',
+            'mail_address',
+            ['email', 'address_type'],
+            ['email', 'address_type'],
+        )
+
+    if rebuild_references:
+        _restore_user_references()
+
+    expected = connection.scalar(
+        sa.select(sa.func.count()).select_from(user)
+    ) + connection.scalar(
+        sa.select(sa.func.count()).select_from(alias)
+    )
+    actual = connection.scalar(
+        sa.select(sa.func.count()).select_from(mail_address)
+    )
+    if actual != expected:
+        raise RuntimeError(
+            f'mail_address backfill count mismatch: expected {expected}, '
+            f'found {actual}'
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    rebuild_references = _requires_sqlite_reference_rebuild(connection)
+    if rebuild_references:
+        _drop_user_references()
+
+    with op.batch_alter_table(
+        'user',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.drop_constraint(
+            'user_mail_address_fkey',
+            type_='foreignkey',
+        )
+        batch.drop_constraint(
+            'user_address_type_check',
+            type_='check',
+        )
+        batch.drop_column('address_type')
+
+    with op.batch_alter_table(
+        'alias',
+        naming_convention=naming_convention,
+    ) as batch:
+        batch.drop_constraint(
+            'alias_mail_address_fkey',
+            type_='foreignkey',
+        )
+        batch.drop_constraint(
+            'alias_address_type_check',
+            type_='check',
+        )
+        batch.drop_column('address_type')
+
+    if rebuild_references:
+        _restore_user_references()
+    op.drop_table('mail_address')

--- a/core/admin/migrations/versions/d4a6f2b8c901_.py
+++ b/core/admin/migrations/versions/d4a6f2b8c901_.py
@@ -104,16 +104,45 @@ def _cross_table_collisions(connection):
     """Return a fixed-size diagnostic sample of cross-table collisions."""
     collisions = {}
     truncated = False
-    conditions = (
-        sa.func.lower(user.c.email) == sa.func.lower(alias.c.email),
-        user.c.email == alias.c.email,
+
+    missing_email = sa.type_coerce(
+        sa.null(),
+        sa.String(length=255),
     )
-    for condition in conditions:
+    lowered_addresses = sa.union_all(
+        sa.select(
+            sa.func.lower(user.c.email).label('canonical'),
+            user.c.email.label('user_email'),
+            missing_email.label('alias_email'),
+        ),
+        sa.select(
+            sa.func.lower(alias.c.email).label('canonical'),
+            missing_email.label('user_email'),
+            alias.c.email.label('alias_email'),
+        ),
+    ).subquery('lowered_address')
+    lowered_user_email = sa.func.min(lowered_addresses.c.user_email)
+    lowered_alias_email = sa.func.min(lowered_addresses.c.alias_email)
+
+    probes = (
+        sa.select(
+            lowered_user_email.label('user_email'),
+            lowered_alias_email.label('alias_email'),
+        )
+        .select_from(lowered_addresses)
+        .group_by(lowered_addresses.c.canonical)
+        .having(
+            lowered_user_email.is_not(None),
+            lowered_alias_email.is_not(None),
+        )
+        .order_by(lowered_user_email, lowered_alias_email),
+        sa.select(user.c.email, alias.c.email)
+        .select_from(user.join(alias, user.c.email == alias.c.email))
+        .order_by(user.c.email, alias.c.email),
+    )
+    for probe in probes:
         rows = connection.execute(
-            sa.select(user.c.email, alias.c.email)
-            .select_from(user.join(alias, condition))
-            .order_by(user.c.email, alias.c.email)
-            .limit(COLLISION_PROBE_LIMIT)
+            probe.limit(COLLISION_PROBE_LIMIT)
         ).all()
         if len(rows) > COLLISION_REPORT_LIMIT:
             truncated = True

--- a/core/admin/migrations/versions/d4a6f2b8c901_.py
+++ b/core/admin/migrations/versions/d4a6f2b8c901_.py
@@ -18,6 +18,9 @@ from alembic import op
 import sqlalchemy as sa
 
 
+COLLISION_REPORT_LIMIT = 20
+COLLISION_PROBE_LIMIT = COLLISION_REPORT_LIMIT + 1
+
 naming_convention = {
     'fk': '%(table_name)s_%(column_0_name)s_fkey',
     'pk': '%(table_name)s_pkey',
@@ -52,7 +55,7 @@ def _registry_string_types(connection):
     turns an otherwise valid populated upgrade into a non-transactional,
     half-applied migration.
     """
-    if connection.dialect.name != 'mysql':
+    if connection.dialect.name not in {'mysql', 'mariadb'}:
         return sa.String(length=255), sa.String(length=5)
 
     rows = connection.execute(
@@ -98,40 +101,39 @@ def _registry_string_types(connection):
 
 
 def _cross_table_collisions(connection):
-    users = {
-        email.lower(): email
-        for (email,) in connection.execute(sa.select(user.c.email))
-    }
-    aliases = {
-        email.lower(): email
-        for (email,) in connection.execute(sa.select(alias.c.email))
-    }
-    collisions = {
-        (users[canonical], aliases[canonical]): canonical
-        for canonical in users.keys() & aliases.keys()
-    }
-
-    # The application canonicalizer catches case/IDNA aliases.  MariaDB may
-    # use a still-broader accent-insensitive collation, so also ask the target
-    # database which values compare equal before creating any DDL.
-    native_pairs = connection.execute(
-        sa.select(user.c.email, alias.c.email).select_from(
-            user.join(alias, user.c.email == alias.c.email)
-        )
+    """Return a fixed-size diagnostic sample of cross-table collisions."""
+    collisions = {}
+    truncated = False
+    conditions = (
+        sa.func.lower(user.c.email) == sa.func.lower(alias.c.email),
+        user.c.email == alias.c.email,
     )
-    for user_email, alias_email in native_pairs:
-        collisions.setdefault(
-            (user_email, alias_email),
-            user_email.lower(),
-        )
+    for condition in conditions:
+        rows = connection.execute(
+            sa.select(user.c.email, alias.c.email)
+            .select_from(user.join(alias, condition))
+            .order_by(user.c.email, alias.c.email)
+            .limit(COLLISION_PROBE_LIMIT)
+        ).all()
+        if len(rows) > COLLISION_REPORT_LIMIT:
+            truncated = True
+        for user_email, alias_email in rows[:COLLISION_REPORT_LIMIT]:
+            collisions.setdefault(
+                (user_email, alias_email),
+                user_email.lower(),
+            )
 
-    return [
+    ordered = [
         (canonical, user_email, alias_email)
         for (user_email, alias_email), canonical in sorted(
             collisions.items(),
             key=lambda item: (item[1], item[0]),
         )
     ]
+    if len(ordered) > COLLISION_REPORT_LIMIT:
+        truncated = True
+        ordered = ordered[:COLLISION_REPORT_LIMIT]
+    return ordered, truncated
 
 
 def _requires_sqlite_reference_rebuild(connection):
@@ -243,12 +245,14 @@ def upgrade():
     registry_email_type, registry_address_type = _registry_string_types(
         connection
     )
-    collisions = _cross_table_collisions(connection)
+    collisions, collisions_truncated = _cross_table_collisions(connection)
     if collisions:
         listing = '\n'.join(
             f'  {canonical}: User={user_email}, Alias={alias_email}'
             for canonical, user_email, alias_email in collisions
         )
+        if collisions_truncated:
+            listing += '\n  ... additional collisions omitted'
         raise RuntimeError(
             'Cannot enforce global mail-address uniqueness. These addresses '
             'exist as both User and Alias:\n'

--- a/core/admin/migrations/versions/e7c9a4f2b631_.py
+++ b/core/admin/migrations/versions/e7c9a4f2b631_.py
@@ -1,0 +1,351 @@
+"""Add persistent SCIM identity, graph state, and session authority
+
+Revision ID: e7c9a4f2b631
+Revises: d4a6f2b8c901
+Create Date: 2026-07-29 14:30:00.000000
+
+Existing Users retain their published email IDs and receive the all-zero
+migration generation.  Existing Aliases are deliberately not adopted as
+Groups.  New application-created Users receive random generations and UUID
+SCIM mappings at the model boundary.
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'e7c9a4f2b631'
+down_revision = 'd4a6f2b8c901'
+
+from datetime import date
+
+from alembic import op
+import idna
+import sqlalchemy as sa
+
+
+INITIAL_AUTH_GENERATION = '0' * 32
+
+metadata = sa.MetaData()
+user = sa.Table(
+    'user',
+    metadata,
+    sa.Column('email', sa.String(255), primary_key=True),
+    sa.Column('created_at', sa.Date, nullable=False),
+    sa.Column('updated_at', sa.Date, nullable=True),
+)
+scim_resource = sa.Table(
+    'scim_resource',
+    metadata,
+    sa.Column('id', sa.String(255), primary_key=True),
+    sa.Column('resource_type', sa.String(5), nullable=False),
+    sa.Column('external_id_bytes', sa.LargeBinary(1024), nullable=True),
+    sa.Column('user_email', sa.String(255), nullable=True),
+    sa.Column('alias_email', sa.String(255), nullable=True),
+    sa.Column('subject_address', sa.String(255), nullable=False),
+    sa.Column('deleted_at', sa.DateTime, nullable=True),
+    sa.Column('created_at', sa.Date, nullable=False),
+    sa.Column('updated_at', sa.Date, nullable=True),
+    sa.Column('comment', sa.String(255), nullable=True),
+)
+
+
+def _published_email_id(stored_email):
+    """Reproduce IdnaEmail's externally published Unicode representation."""
+    localpart, domain_name = stored_email.lower().rsplit('@', 1)
+    return f'{localpart}@{idna.decode(domain_name)}'
+
+
+def _x_arguments():
+    arguments = op.get_context().opts.get('x_argument') or []
+    parsed = {}
+    for argument in arguments:
+        key, separator, value = argument.partition('=')
+        parsed[key] = value if separator else 'true'
+    return parsed
+
+
+def _destructive_downgrade_allowed():
+    arguments = _x_arguments()
+    return (
+        arguments.get('allow_destructive_scim_identity', '').lower()
+        in ('1', 'true', 'yes')
+        and arguments.get('scim_identity_exported', '').lower()
+        in ('1', 'true', 'yes')
+    )
+
+
+def _storage_types(connection):
+    """Resolve routing-key and byte-exact provider-ID storage types."""
+    if connection.dialect.name != 'mysql':
+        return sa.String(length=255), sa.String(length=255)
+
+    rows = connection.execute(
+        sa.text(
+            """
+            SELECT TABLE_NAME, CHARACTER_SET_NAME, COLLATION_NAME
+              FROM information_schema.COLUMNS
+             WHERE TABLE_SCHEMA = DATABASE()
+               AND TABLE_NAME IN ('user', 'alias')
+               AND COLUMN_NAME = 'email'
+            """
+        )
+    ).all()
+    storage = {
+        (character_set, collation)
+        for _table, character_set, collation in rows
+    }
+    if len(rows) != 2 or len(storage) != 1:
+        details = ', '.join(
+            f'{table}={character_set}/{collation}'
+            for table, character_set, collation in sorted(rows)
+        )
+        raise RuntimeError(
+            'Cannot create SCIM identity foreign keys because User and Alias '
+            f'email storage semantics differ or are unavailable: {details}.'
+        )
+    character_set, collation = storage.pop()
+    if not collation:
+        raise RuntimeError(
+            'Cannot determine the User/Alias email collation before creating '
+            'SCIM identity tables.'
+        )
+    binary_collation = connection.scalar(
+        sa.text(
+            """
+            SELECT COLLATION_NAME
+              FROM information_schema.COLLATIONS
+             WHERE CHARACTER_SET_NAME = :character_set
+               AND COLLATION_NAME = :collation
+            """
+        ),
+        {
+            'character_set': character_set,
+            'collation': f'{character_set}_bin',
+        },
+    )
+    if binary_collation is None:
+        raise RuntimeError(
+            'Cannot find a binary collation for exact SCIM provider IDs '
+            f'in character set {character_set!r}.'
+        )
+    return (
+        sa.String(length=255, collation=collation),
+        sa.String(length=255, collation=binary_collation),
+    )
+
+
+def upgrade():
+    connection = op.get_bind()
+    routing_email_type, exact_id_type = _storage_types(connection)
+
+    with op.batch_alter_table('user') as batch:
+        batch.add_column(
+            sa.Column(
+                'auth_generation',
+                sa.String(length=32),
+                nullable=False,
+                server_default=INITIAL_AUTH_GENERATION,
+            )
+        )
+
+    op.create_table(
+        'scim_state',
+        sa.Column(
+            'id',
+            sa.Integer(),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column(
+            'revision',
+            sa.BigInteger(),
+            nullable=False,
+            server_default='0',
+        ),
+        sa.CheckConstraint('id = 1', name='scim_state_singleton_check'),
+        sa.PrimaryKeyConstraint('id', name='scim_state_pkey'),
+    )
+    op.create_table(
+        'scim_resource',
+        sa.Column('id', exact_id_type, nullable=False),
+        sa.Column('resource_type', sa.String(length=5), nullable=False),
+        sa.Column(
+            'external_id_bytes',
+            sa.LargeBinary(length=1024),
+            nullable=True,
+        ),
+        sa.Column('user_email', routing_email_type, nullable=True),
+        sa.Column('alias_email', routing_email_type, nullable=True),
+        sa.Column('subject_address', routing_email_type, nullable=False),
+        sa.Column('deleted_at', sa.DateTime(), nullable=True),
+        sa.Column('created_at', sa.Date(), nullable=False),
+        sa.Column('updated_at', sa.Date(), nullable=True),
+        sa.Column(
+            'comment',
+            sa.String(length=255),
+            nullable=True,
+            server_default='',
+        ),
+        sa.CheckConstraint(
+            "resource_type IN ('User', 'Group')",
+            name='scim_resource_type_check',
+        ),
+        sa.CheckConstraint(
+            '('
+            "deleted_at IS NULL AND resource_type = 'User' "
+            'AND user_email IS NOT NULL AND alias_email IS NULL '
+            'AND subject_address = user_email'
+            ') OR ('
+            "deleted_at IS NULL AND resource_type = 'Group' "
+            'AND user_email IS NULL AND alias_email IS NOT NULL '
+            'AND subject_address = alias_email'
+            ') OR ('
+            'deleted_at IS NOT NULL '
+            'AND user_email IS NULL AND alias_email IS NULL'
+            ')',
+            name='scim_resource_lifecycle_check',
+        ),
+        sa.ForeignKeyConstraint(
+            ['user_email'],
+            ['user.email'],
+            name='scim_resource_user_email_fkey',
+        ),
+        sa.ForeignKeyConstraint(
+            ['alias_email'],
+            ['alias.email'],
+            name='scim_resource_alias_email_fkey',
+        ),
+        sa.PrimaryKeyConstraint('id', name='scim_resource_pkey'),
+        sa.UniqueConstraint(
+            'user_email',
+            name='scim_resource_user_email_key',
+        ),
+        sa.UniqueConstraint(
+            'alias_email',
+            name='scim_resource_alias_email_key',
+        ),
+    )
+    op.create_table(
+        'scim_group_member',
+        sa.Column('group_id', exact_id_type, nullable=False),
+        sa.Column('member_id', exact_id_type, nullable=False),
+        sa.ForeignKeyConstraint(
+            ['group_id'],
+            ['scim_resource.id'],
+            name='scim_group_member_group_id_fkey',
+        ),
+        sa.ForeignKeyConstraint(
+            ['member_id'],
+            ['scim_resource.id'],
+            name='scim_group_member_member_id_fkey',
+        ),
+        sa.PrimaryKeyConstraint(
+            'group_id',
+            'member_id',
+            name='scim_group_member_pkey',
+        ),
+    )
+    op.create_table(
+        'scim_group_destination',
+        sa.Column('group_id', exact_id_type, nullable=False),
+        sa.Column('destination', routing_email_type, nullable=False),
+        sa.ForeignKeyConstraint(
+            ['group_id'],
+            ['scim_resource.id'],
+            name='scim_group_destination_group_id_fkey',
+        ),
+        sa.PrimaryKeyConstraint(
+            'group_id',
+            'destination',
+            name='scim_group_destination_pkey',
+        ),
+    )
+    op.create_index(
+        'scim_group_destination_destination_idx',
+        'scim_group_destination',
+        ['destination'],
+    )
+
+    connection.execute(
+        sa.text(
+            'INSERT INTO scim_state (id, revision) VALUES (1, 0)'
+        )
+    )
+
+    rows = connection.execute(
+        sa.select(
+            user.c.email,
+            user.c.created_at,
+            user.c.updated_at,
+        ).order_by(user.c.email)
+    ).all()
+    for email, created_at, updated_at in rows:
+        connection.execute(
+            scim_resource.insert().values(
+                id=_published_email_id(email),
+                resource_type='User',
+                external_id_bytes=None,
+                user_email=email,
+                alias_email=None,
+                subject_address=email,
+                deleted_at=None,
+                created_at=created_at or date.today(),
+                updated_at=updated_at,
+                comment='',
+            )
+        )
+
+    expected_users = connection.scalar(
+        sa.select(sa.func.count()).select_from(user)
+    )
+    actual_users = connection.scalar(
+        sa.select(sa.func.count()).select_from(scim_resource).where(
+            scim_resource.c.resource_type == 'User'
+        )
+    )
+    actual_groups = connection.scalar(
+        sa.select(sa.func.count()).select_from(scim_resource).where(
+            scim_resource.c.resource_type == 'Group'
+        )
+    )
+    if actual_users != expected_users or actual_groups != 0:
+        raise RuntimeError(
+            'SCIM identity backfill mismatch: '
+            f'expected {expected_users} Users/0 Groups, found '
+            f'{actual_users} Users/{actual_groups} Groups'
+        )
+
+    # Zero is a migration compatibility marker, never the ORM default for a
+    # new principal.  Native ALTER can drop the temporary server default
+    # without rebuilding User.  SQLite retains it only for unsupported raw
+    # INSERTs; every supported ORM writer supplies a random generation.
+    if connection.dialect.name != 'sqlite':
+        op.alter_column(
+            'user',
+            'auth_generation',
+            existing_type=sa.String(length=32),
+            nullable=False,
+            server_default=None,
+        )
+
+
+def downgrade():
+    connection = op.get_bind()
+    identity_count = connection.scalar(
+        sa.select(sa.func.count()).select_from(scim_resource)
+    )
+    if identity_count and not _destructive_downgrade_allowed():
+        raise RuntimeError(
+            'Refusing destructive SCIM identity downgrade. Complete an '
+            'identity export including tombstone data, then pass both '
+            '-x allow_destructive_scim_identity=true and '
+            '-x scim_identity_exported=true.'
+        )
+
+    op.drop_table('scim_group_destination')
+    op.drop_table('scim_group_member')
+    op.drop_table('scim_resource')
+    op.drop_table('scim_state')
+    if connection.dialect.name == 'sqlite':
+        op.drop_column('user', 'auth_generation')
+    else:
+        with op.batch_alter_table('user') as batch:
+            batch.drop_column('auth_generation')

--- a/core/admin/migrations/versions/e7c9a4f2b631_.py
+++ b/core/admin/migrations/versions/e7c9a4f2b631_.py
@@ -19,9 +19,14 @@ from datetime import date
 from alembic import op
 import idna
 import sqlalchemy as sa
+from sqlalchemy.dialects import mysql
 
 
 INITIAL_AUTH_GENERATION = '0' * 32
+SCIM_BACKFILL_BATCH_SIZE = 128
+MYSQL_EXACT_ID_CHARSET = 'utf8mb4'
+MYSQL_EXACT_ID_COLLATION = 'utf8mb4_bin'
+STAGING_TABLE_NAME = '_mailu_scim_resource_stage'
 
 metadata = sa.MetaData()
 user = sa.Table(
@@ -74,7 +79,7 @@ def _destructive_downgrade_allowed():
 
 def _storage_types(connection):
     """Resolve routing-key and byte-exact provider-ID storage types."""
-    if connection.dialect.name != 'mysql':
+    if connection.dialect.name not in {'mysql', 'mariadb'}:
         return sa.String(length=255), sa.String(length=255)
 
     rows = connection.execute(
@@ -107,7 +112,7 @@ def _storage_types(connection):
             'Cannot determine the User/Alias email collation before creating '
             'SCIM identity tables.'
         )
-    binary_collation = connection.scalar(
+    exact_collation = connection.scalar(
         sa.text(
             """
             SELECT COLLATION_NAME
@@ -117,24 +122,157 @@ def _storage_types(connection):
             """
         ),
         {
-            'character_set': character_set,
-            'collation': f'{character_set}_bin',
+            'character_set': MYSQL_EXACT_ID_CHARSET,
+            'collation': MYSQL_EXACT_ID_COLLATION,
         },
     )
-    if binary_collation is None:
+    if exact_collation is None:
         raise RuntimeError(
-            'Cannot find a binary collation for exact SCIM provider IDs '
-            f'in character set {character_set!r}.'
+            'Cannot find the required utf8mb4_bin collation for exact SCIM '
+            'provider IDs.'
         )
     return (
-        sa.String(length=255, collation=collation),
-        sa.String(length=255, collation=binary_collation),
+        mysql.VARCHAR(
+            length=255,
+            charset=character_set,
+            collation=collation,
+        ),
+        mysql.VARCHAR(
+            length=255,
+            charset=MYSQL_EXACT_ID_CHARSET,
+            collation=exact_collation,
+        ),
     )
+
+
+def _staging_table(routing_email_type, exact_id_type):
+    return sa.Table(
+        STAGING_TABLE_NAME,
+        sa.MetaData(),
+        sa.Column('id', exact_id_type, primary_key=True),
+        sa.Column('resource_type', sa.String(5), nullable=False),
+        sa.Column('external_id_bytes', sa.LargeBinary(1024), nullable=True),
+        sa.Column('user_email', routing_email_type, nullable=True),
+        sa.Column('alias_email', routing_email_type, nullable=True),
+        sa.Column('subject_address', routing_email_type, nullable=False),
+        sa.Column('deleted_at', sa.DateTime, nullable=True),
+        sa.Column('created_at', sa.Date, nullable=False),
+        sa.Column('updated_at', sa.Date, nullable=True),
+        sa.Column('comment', sa.String(255), nullable=True),
+        prefixes=['TEMPORARY'],
+    )
+
+
+def _drop_staging_table(connection):
+    if connection.dialect.name in {'mysql', 'mariadb'}:
+        connection.exec_driver_sql(
+            f'DROP TEMPORARY TABLE IF EXISTS {STAGING_TABLE_NAME}'
+        )
+    else:
+        connection.exec_driver_sql(
+            f'DROP TABLE IF EXISTS {STAGING_TABLE_NAME}'
+        )
+
+
+def _prepare_user_resource(email, created_at, updated_at):
+    try:
+        resource_id = _published_email_id(email)
+    except (idna.IDNAError, UnicodeError, ValueError) as exc:
+        raise RuntimeError(
+            f'Cannot publish a SCIM ID for legacy User {email!r}: {exc}'
+        ) from exc
+    if len(resource_id) > 255:
+        raise RuntimeError(
+            f'Published SCIM ID for legacy User {email!r} exceeds '
+            '255 characters'
+        )
+    return {
+        'id': resource_id,
+        'resource_type': 'User',
+        'external_id_bytes': None,
+        'user_email': email,
+        'alias_email': None,
+        'subject_address': email,
+        'deleted_at': None,
+        'created_at': created_at or date.today(),
+        'updated_at': updated_at,
+        'comment': '',
+    }
+
+
+def _stage_user_resources(connection, routing_email_type, exact_id_type):
+    """Validate and stage legacy identities in population-independent memory."""
+    staging = _staging_table(routing_email_type, exact_id_type)
+    staging.create(connection)
+    last_email = None
+    try:
+        while True:
+            query = sa.select(
+                user.c.email,
+                user.c.created_at,
+                user.c.updated_at,
+            ).order_by(user.c.email).limit(SCIM_BACKFILL_BATCH_SIZE)
+            if last_email is not None:
+                query = query.where(user.c.email > last_email)
+            rows = connection.execute(query).all()
+            if not rows:
+                break
+
+            prepared = [
+                _prepare_user_resource(email, created_at, updated_at)
+                for email, created_at, updated_at in rows
+            ]
+            connection.execute(staging.insert(), prepared)
+
+            expected = {item['id'] for item in prepared}
+            stored = set(connection.execute(
+                sa.select(staging.c.id).where(staging.c.id.in_(expected))
+            ).scalars())
+            if stored != expected:
+                raise RuntimeError(
+                    'Exact SCIM ID storage is not a lossless round trip'
+                )
+            last_email = rows[-1][0]
+    except sa.exc.SQLAlchemyError as exc:
+        # PostgreSQL rejects cleanup SQL after a statement aborts the
+        # transaction. Alembic closes this NullPool connection on failure, so
+        # the temporary table is discarded without masking the real error.
+        raise RuntimeError(
+            'Cannot stage every legacy SCIM ID without loss or collision'
+        ) from exc
+    except Exception:
+        _drop_staging_table(connection)
+        raise
+    return staging
+
+
+def _copy_staged_user_resources(connection, staging):
+    column_names = [column.name for column in scim_resource.columns]
+    last_id = None
+    while True:
+        query = sa.select(*(
+            staging.c[name] for name in column_names
+        )).order_by(staging.c.id).limit(SCIM_BACKFILL_BATCH_SIZE)
+        if last_id is not None:
+            query = query.where(staging.c.id > last_id)
+        rows = connection.execute(query).mappings().all()
+        if not rows:
+            return
+        connection.execute(
+            scim_resource.insert(),
+            [dict(row) for row in rows],
+        )
+        last_id = rows[-1]['id']
 
 
 def upgrade():
     connection = op.get_bind()
     routing_email_type, exact_id_type = _storage_types(connection)
+    staged_users = _stage_user_resources(
+        connection,
+        routing_email_type,
+        exact_id_type,
+    )
 
     with op.batch_alter_table('user') as batch:
         batch.add_column(
@@ -243,6 +381,11 @@ def upgrade():
             name='scim_group_member_pkey',
         ),
     )
+    op.create_index(
+        'scim_group_member_member_id_idx',
+        'scim_group_member',
+        ['member_id'],
+    )
     op.create_table(
         'scim_group_destination',
         sa.Column('group_id', exact_id_type, nullable=False),
@@ -270,28 +413,7 @@ def upgrade():
         )
     )
 
-    rows = connection.execute(
-        sa.select(
-            user.c.email,
-            user.c.created_at,
-            user.c.updated_at,
-        ).order_by(user.c.email)
-    ).all()
-    for email, created_at, updated_at in rows:
-        connection.execute(
-            scim_resource.insert().values(
-                id=_published_email_id(email),
-                resource_type='User',
-                external_id_bytes=None,
-                user_email=email,
-                alias_email=None,
-                subject_address=email,
-                deleted_at=None,
-                created_at=created_at or date.today(),
-                updated_at=updated_at,
-                comment='',
-            )
-        )
+    _copy_staged_user_resources(connection, staged_users)
 
     expected_users = connection.scalar(
         sa.select(sa.func.count()).select_from(user)
@@ -325,6 +447,7 @@ def upgrade():
             nullable=False,
             server_default=None,
         )
+    _drop_staging_table(connection)
 
 
 def downgrade():

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,7 +21,7 @@ For more information refer to the detailed descriptions in the
 Swagger.json
 ------------
 
-The swagger.json file can be retrieved via: https://myserver/api/v1/swagger.json
+The swagger.json file can be retrieved via: https://example.com/api/v1/swagger.json
 (WEB_API=/api)
 The swagger.json file can be consumed in programs such as Postman for generating all API calls.
 
@@ -32,16 +32,16 @@ The Mailu API comes with an in-built SwaggerUI. It is a web client that allows
 anyone to visualize and interact with the Mailu API.
 
 Assuming ``/api`` is configured as value for ``WEB_API``, it
-is accessible via the URL: https://myserver/api/
+is accessible via the URL: https://example.com/api/
 
 
 SCIM provisioning
 -----------------
 
-Mailu exposes a SCIM 2.0 user provisioning endpoint at
+Mailu exposes a SCIM 2.0 provisioning endpoint at
 ``<WEB_API>/scim/v2``. With the default ``WEB_API=/api``, the SCIM base URL is::
 
-  https://myserver/api/scim/v2
+  https://example.com/api/scim/v2
 
 The SCIM endpoint uses the same bearer token as the REST API::
 
@@ -52,20 +52,78 @@ Supported SCIM resources:
 * ``/ServiceProviderConfig``
 * ``/ResourceTypes``
 * ``/Schemas``
+* ``/Bulk`` for up to 100 operations in a request of at most 1 MiB
 * ``/Users`` for listing, creating, reading, replacing, patching, and deprovisioning users
-* ``/Groups`` returns an empty list; group provisioning is not supported
+* ``/Groups`` for listing, creating, reading, replacing, patching, and deleting
+  alias-backed groups
 
 Mailu maps SCIM users to mailbox users:
 
 * ``userName`` is the mailbox email address.
 * ``displayName`` or ``name.formatted`` maps to the Mailu displayed name.
 * ``active`` maps to the Mailu enabled flag.
-* ``password`` sets the mailbox password when supplied. If no password is supplied during creation, Mailu generates a random mailbox password.
+* ``password`` sets the mailbox password only during creation. If no password
+  is supplied, Mailu generates a random mailbox password. SCIM cannot change
+  an existing mailbox password (``changePassword.supported`` is false).
+* Mailbox email addresses are also used as SCIM ``id`` values. Mailbox rename
+  and persistent client ``externalId`` correlation are not supported.
 
 SCIM user creation requires the mailbox domain to already exist in Mailu. Mailu does not create domains from SCIM requests. SCIM ``DELETE`` deprovisions users by disabling the mailbox instead of deleting mailbox data.
 
+Mailu maps SCIM groups to aliases:
+
+* The group ``id`` is the alias email address. On creation, Mailu uses ``id``
+  when supplied; otherwise ``displayName`` must contain the alias email
+  address. Mailu cannot derive an alias domain from an arbitrary human group
+  label. Accepting the client-supplied ``id`` here is a Mailu mapping
+  extension; core SCIM normally treats ``id`` as server-assigned.
+* ``members[].value`` entries map directly to the alias ``destination`` list.
+  Destinations are email addresses and may refer to local Mailu users or
+  external forwarding addresses.
+* ``PUT`` replaces the alias destination list. ``PATCH`` can add, replace, or
+  remove destinations. ``DELETE`` deletes the alias.
+* The alias domain must already exist, and normal Mailu alias limits still
+  apply.
+* ``/Groups`` is a direct view of Mailu aliases, not a separate set of
+  SCIM-managed records. Existing aliases are therefore visible and can be
+  changed or deleted through the Group endpoints.
+
+SCIM user and group responses include the current entity tag in both
+``meta.version`` and the HTTP ``ETag`` header. Clients can send that value in
+``If-Match`` on ``PUT``, ``PATCH``, and ``DELETE``. Mailu rejects stale values
+with ``412 Precondition Failed`` without applying the requested change.
+Conditional reads support ``If-Match`` and ``If-None-Match``; a matching
+``If-None-Match`` returns ``304 Not Modified``.
+
+Resource ``POST`` and ``PUT`` bodies must contain exactly the corresponding
+User or Group schema URI. ``PATCH`` bodies must contain exactly the PatchOp
+schema URI, and a Bulk request must contain exactly the BulkRequest schema URI.
+Each Bulk operation's ``data`` object has the same schema requirement as the
+equivalent direct operation. Schema URI comparisons are case-insensitive;
+duplicates and unsupported extensions are rejected. ``bulkId`` references are
+substituted only after the referenced resource is created; circular dependency
+graphs are rejected rather than guessed.
+
+User and Group endpoints support the mutually exclusive ``attributes`` and
+``excludedAttributes`` projection parameters on every response that returns a
+resource. Comma-separated top-level and supported sub-attribute paths are
+accepted. ``schemas`` and ``id`` are always returned, while ``password`` is
+never returned. Projection does not remove HTTP ``ETag`` or
+``Content-Location`` headers. Discovery endpoints ignore these query
+parameters as required by RFC 7644.
+
+User ``DELETE`` retains mailbox data by setting ``active`` to false. The
+disabled User remains visible to SCIM reads and can be reactivated. This is a
+Mailu deprovisioning behavior, not RFC 7644 tombstone semantics.
+
+List filtering is limited to ``userName eq "..."`` for Users and
+``displayName eq "..."`` for Groups. Attribute names and ``eq`` are
+case-insensitive. Because this compatibility subset is not the RFC 7644 filter
+grammar, ``ServiceProviderConfig`` advertises filtering as unsupported; clients
+must not infer general filter support from these two accepted forms.
+
 For authentik, create a SCIM provider for the Mailu application and configure:
 
-* SCIM base URL: ``https://myserver/api/scim/v2``
+* SCIM base URL: ``https://example.com/api/scim/v2``
 * Authentication mode: static token
 * Token: the Mailu ``API_TOKEN`` value

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,3 +33,39 @@ anyone to visualize and interact with the Mailu API.
 
 Assuming ``/api`` is configured as value for ``WEB_API``, it
 is accessible via the URL: https://myserver/api/
+
+
+SCIM provisioning
+-----------------
+
+Mailu exposes a SCIM 2.0 user provisioning endpoint at
+``<WEB_API>/scim/v2``. With the default ``WEB_API=/api``, the SCIM base URL is::
+
+  https://myserver/api/scim/v2
+
+The SCIM endpoint uses the same bearer token as the REST API::
+
+  Authorization: Bearer <API_TOKEN>
+
+Supported SCIM resources:
+
+* ``/ServiceProviderConfig``
+* ``/ResourceTypes``
+* ``/Schemas``
+* ``/Users`` for listing, creating, reading, replacing, patching, and deprovisioning users
+* ``/Groups`` returns an empty list; group provisioning is not supported
+
+Mailu maps SCIM users to mailbox users:
+
+* ``userName`` is the mailbox email address.
+* ``displayName`` or ``name.formatted`` maps to the Mailu displayed name.
+* ``active`` maps to the Mailu enabled flag.
+* ``password`` sets the mailbox password when supplied. If no password is supplied during creation, Mailu generates a random mailbox password.
+
+SCIM user creation requires the mailbox domain to already exist in Mailu. Mailu does not create domains from SCIM requests. SCIM ``DELETE`` deprovisions users by disabling the mailbox instead of deleting mailbox data.
+
+For authentik, create a SCIM provider for the Mailu application and configure:
+
+* SCIM base URL: ``https://myserver/api/scim/v2``
+* Authentication mode: static token
+* Token: the Mailu ``API_TOKEN`` value

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -65,28 +65,53 @@ Mailu maps SCIM users to mailbox users:
 * ``password`` sets the mailbox password only during creation. If no password
   is supplied, Mailu generates a random mailbox password. SCIM cannot change
   an existing mailbox password (``changePassword.supported`` is false).
-* Mailbox email addresses are also used as SCIM ``id`` values. Mailbox rename
-  and persistent client ``externalId`` correlation are not supported.
+* ``id`` is an immutable provider identifier. Users that existed before the
+  persistent-identity migration retain their already-published email ID; newly
+  created resources receive a UUID. Client-supplied ``id`` values are ignored.
+* ``externalId`` is preserved as a case-exact client correlation value and can
+  be created, replaced, patched, and used by the supported equality filter.
 
-SCIM user creation requires the mailbox domain to already exist in Mailu. Mailu does not create domains from SCIM requests. SCIM ``DELETE`` deprovisions users by disabling the mailbox instead of deleting mailbox data.
+SCIM user creation requires the mailbox domain to already exist in Mailu.
+Mailu does not create domains from SCIM requests. User ``DELETE`` tombstones
+the SCIM resource: every later operation on the old ID returns ``404`` and
+list results omit it. Mailbox data may remain in a disabled Mailu User below
+the SCIM boundary, but browser sessions, application tokens, and Mailu
+administrator grants are revoked. Re-provisioning the same ``userName``
+is rejected: the retained mailbox and tombstone permanently reserve that
+routing address, so old principal authority cannot transfer to a new SCIM
+identity.
 
-Mailu maps SCIM groups to aliases:
+Mailu maps explicitly SCIM-managed Groups to aliases. Ordinary Mailu aliases
+are not Groups and are neither listed nor mutable through SCIM. A retained
+legacy alias can be transferred into exclusive SCIM ownership during the
+maintenance window with::
 
-* The group ``id`` is the alias email address. On creation, Mailu uses ``id``
-  when supplied; otherwise ``displayName`` must contain the alias email
-  address. Mailu cannot derive an alias domain from an arbitrary human group
-  label. Accepting the client-supplied ``id`` here is a Mailu mapping
-  extension; core SCIM normally treats ``id`` as server-assigned.
-* ``members[].value`` entries map directly to the alias ``destination`` list.
-  Destinations are email addresses and may refer to local Mailu users or
-  external forwarding addresses.
-* ``PUT`` replaces the alias destination list. ``PATCH`` can add, replace, or
-  remove destinations. ``DELETE`` deletes the alias.
+  flask mailu scim-group-adopt alias@example.com
+
+Adoption accepts only an enabled, unowned, non-wildcard alias and blocks later
+ordinary alias edits. It is deliberately explicit: the old implementation
+recorded no ownership and exposing every alias to destructive SCIM operations
+was unsafe.
+
+Group requests and representations use the core Group schema plus the required
+Mailu extension ``https://mailu.io/schemas/scim/2.0/Group``:
+
+* ``displayName`` is the human Group label. It is not an email address.
+* The extension's immutable ``aliasAddress`` is the Mailu routing address.
+* Core ``members[].value`` entries are active SCIM User or Group IDs.
+  Responses include a dereferenceable ``$ref`` and resource ``type``.
+* The extension's ``externalDestinations`` contains external forwarding
+  addresses. A local Mailu User or Alias must not be placed there; local
+  resources use normalized member IDs so cycle and deletion checks remain
+  effective.
+* ``PUT`` atomically replaces normalized members and external destinations.
+  ``PATCH`` supports core member operations and the fully-qualified extension
+  path. ``aliasAddress`` cannot be changed. ``DELETE`` tombstones the Group
+  ID and deletes its managed Alias.
 * The alias domain must already exist, and normal Mailu alias limits still
   apply.
-* ``/Groups`` is a direct view of Mailu aliases, not a separate set of
-  SCIM-managed records. Existing aliases are therefore visible and can be
-  changed or deleted through the Group endpoints.
+* The materialized Alias destination list is limited to 1023 characters.
+  Oversized Group mutations fail before changing the database.
 
 SCIM user and group responses include the current entity tag in both
 ``meta.version`` and the HTTP ``ETag`` header. Clients can send that value in
@@ -95,32 +120,33 @@ with ``412 Precondition Failed`` without applying the requested change.
 Conditional reads support ``If-Match`` and ``If-None-Match``; a matching
 ``If-None-Match`` returns ``304 Not Modified``.
 
-Resource ``POST`` and ``PUT`` bodies must contain exactly the corresponding
-User or Group schema URI. ``PATCH`` bodies must contain exactly the PatchOp
-schema URI, and a Bulk request must contain exactly the BulkRequest schema URI.
+User ``POST`` and ``PUT`` bodies must contain exactly the User schema URI.
+Group ``POST`` and ``PUT`` bodies must contain exactly the core Group and
+required Mailu extension URIs. ``PATCH`` bodies contain exactly the PatchOp
+schema URI, and a Bulk request contains exactly the BulkRequest schema URI.
 Each Bulk operation's ``data`` object has the same schema requirement as the
 equivalent direct operation. Schema URI comparisons are case-insensitive;
 duplicates and unsupported extensions are rejected. ``bulkId`` references are
-substituted only after the referenced resource is created; circular dependency
-graphs are rejected rather than guessed.
+substituted only in reference-valued fields such as ``members[].value`` and
+resource paths; raw extension destinations beginning with ``bulkId:`` remain
+literal. Circular dependency graphs are rejected rather than guessed.
 
 User and Group endpoints support the mutually exclusive ``attributes`` and
 ``excludedAttributes`` projection parameters on every response that returns a
 resource. Comma-separated top-level and supported sub-attribute paths are
-accepted. ``schemas`` and ``id`` are always returned, while ``password`` is
-never returned. Projection does not remove HTTP ``ETag`` or
-``Content-Location`` headers. Discovery endpoints ignore these query
+accepted, including fully qualified Mailu Group extension paths. ``schemas``
+and ``id`` are always returned; Group ``displayName`` is also always returned,
+while ``password`` is never returned. Projection does not remove HTTP ``ETag``
+or ``Content-Location`` headers. Discovery endpoints ignore these query
 parameters as required by RFC 7644.
 
-User ``DELETE`` retains mailbox data by setting ``active`` to false. The
-disabled User remains visible to SCIM reads and can be reactivated. This is a
-Mailu deprovisioning behavior, not RFC 7644 tombstone semantics.
-
-List filtering is limited to ``userName eq "..."`` for Users and
-``displayName eq "..."`` for Groups. Attribute names and ``eq`` are
-case-insensitive. Because this compatibility subset is not the RFC 7644 filter
-grammar, ``ServiceProviderConfig`` advertises filtering as unsupported; clients
-must not infer general filter support from these two accepted forms.
+List filtering is limited to ``userName eq "..."`` or
+``externalId eq "..."`` for Users and ``displayName eq "..."`` or
+``externalId eq "..."`` for Groups. Attribute names and ``eq`` are
+case-insensitive; ``externalId`` values are case-exact. Because this
+compatibility subset is not the RFC 7644 filter grammar,
+``ServiceProviderConfig`` advertises filtering as unsupported; clients must
+not infer general filter support from these accepted forms.
 
 For authentik, create a SCIM provider for the Mailu application and configure:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -107,7 +107,9 @@ Mailu extension ``https://mailu.io/schemas/scim/2.0/Group``:
 * ``PUT`` atomically replaces normalized members and external destinations.
   ``PATCH`` supports core member operations and the fully-qualified extension
   path. ``aliasAddress`` cannot be changed. ``DELETE`` tombstones the Group
-  ID and deletes its managed Alias.
+  ID and deletes its managed Alias. The routing address is then available for
+  an operator to recreate and explicitly adopt as a new Group; the old ID stays
+  tombstoned and never transfers to the replacement.
 * The alias domain must already exist, and normal Mailu alias limits still
   apply.
 * The materialized Alias destination list is limited to 1023 characters.

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -13,6 +13,7 @@ Managing domains, users and aliases can be done from CLI using the commands:
 * config-update
 * config-export
 * config-import
+* scim-group-adopt
 
 alias
 -----
@@ -28,6 +29,31 @@ alias-delete
 .. code-block:: bash
 
   docker compose exec admin flask mailu alias-delete foo@example.net
+
+
+scim-group-adopt
+----------------
+
+SCIM exposes only aliases explicitly owned by a provisioning provider. Existing
+aliases are not silently exposed as SCIM Groups. To adopt one existing alias,
+run the one-shot maintenance command:
+
+.. code-block:: bash
+
+  docker compose exec admin flask mailu scim-group-adopt list@example.net
+
+The alias must be enabled, non-wildcard, unowned, and not already managed.
+Every local destination must already be an active SCIM User or Group; remote
+destinations are recorded in the Mailu Group extension. Adoption validates the
+whole member graph, rejects cycles, and commits the identity and normalized
+routing snapshot atomically. Ordinary alias editing is blocked after adoption.
+
+The optional provider correlation value is case-sensitive:
+
+.. code-block:: bash
+
+  docker compose exec admin flask mailu scim-group-adopt \
+    --external-id directory-group-7 list@example.net
 
 
 domain

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -47,6 +47,9 @@ Every local destination must already be an active SCIM User or Group; remote
 destinations are recorded in the Mailu Group extension. Adoption validates the
 whole member graph, rejects cycles, and commits the identity and normalized
 routing snapshot atomically. Ordinary alias editing is blocked after adoption.
+Adoption assigns a new opaque Group ID. If SCIM later deletes the Group, the
+old ID remains tombstoned while an operator may recreate the Alias and adopt it
+as a distinct Group with a different ID.
 
 The optional provider correlation value is case-sensitive:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -347,6 +347,10 @@ to be stored and SQLite is deemed both sufficient, simpler and more reliable ove
 For PostgreSQL use driver postgresql (``SQLALCHEMY_DATABASE_URI=postgresql://mailu:mailu_secret_password@database/mailu``).
 
 For MariaDB/MySQL use driver mysql+mysqlconnector (``SQLALCHEMY_DATABASE_URI= mysql+mysqlconnector://mailu:mailu_secret_password@database/mailu``).
+Mailu automatically uses ``READ COMMITTED`` transaction isolation for the admin service's MariaDB/MySQL connection.
+When binary logging is active, its ``binlog_format`` must be ``ROW`` or ``MIXED``;
+Mailu rejects admin connections using ``STATEMENT`` because ``READ COMMITTED`` InnoDB writes cannot be logged safely in that format.
+The Roundcube database connection is not changed.
 
 For Roundcube, refer to the `roundcube documentation`_ for the URL specification.
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -341,7 +341,7 @@ Alternatives hosted options like PostgreSQL and MariaDB/MySQL can be configured 
 but the development team recommends against it. Indeed, there is currently very little data
 to be stored and SQLite is deemed both sufficient, simpler and more reliable overall.
 
-- ``SQLALCHEMY_DATABASE_URI`` (default: ``sqlite:////data/main.db``): the SQLAlchemy database URL for accessing the database
+- ``SQLALCHEMY_DATABASE_URI`` (default: ``sqlite:////data/main.db?timeout=30``): the SQLAlchemy database URL for accessing the database. The default SQLite URL waits up to 30 seconds for a concurrent writer; explicitly configured URLs retain their own driver timeout.
 - ``SQLALCHEMY_DATABASE_URI_ROUNDCUBE`` (default: ``sqlite:////data/roundcube.db``): the Roundcube database URL for accessing the Roundcube database
 
 For PostgreSQL use driver postgresql (``SQLALCHEMY_DATABASE_URI=postgresql://mailu:mailu_secret_password@database/mailu``).

--- a/docs/scim-performance-amdahl-report-20260813.md
+++ b/docs/scim-performance-amdahl-report-20260813.md
@@ -1,0 +1,186 @@
+# Mailu SCIM full-scan endpoint and Amdahl report
+
+Date: 2026-08-13 (America/Chicago)  
+Final source: `9a1269977f01775dfedf207f877aa05e5b26dd3a`  
+Whole-pass baseline: `e8e3d7267fc4975540c80e2d7ed3b979846c38ae`
+
+## Ruling
+
+The one-query iterative full-edge scan is the correct production mechanism and
+the q64 probe/fallback policy remains rejected. The final source passed the
+relevant correctness gates on SQLite, PostgreSQL 17, MariaDB 11 through
+`mysqlconnector`, and MariaDB 11 through `mariadbconnector`.
+
+The strict 2026-08-01 benchmark protocol is **not fully satisfied**, so this
+report does not claim unconditional final performance admission. The
+load-bearing blockers are explicit:
+
+1. SQLite concurrency-4 Group replacement returns HTTP 500 `database is locked`
+   at the singleton graph lock on both the completion baseline and final source.
+   This is inherited, not introduced by `9a126997`, but it makes the required
+   SQLite c4 throughput cells invalid.
+2. The 15-cell latency/Amdahl matrix is instrumented. A distinct 1,000-sample
+   uninstrumented latency matrix and empty-wrapper control were not completed.
+3. Endpoint performance was measured through MariaDB `mysqlconnector` only.
+   `mariadbconnector` passed correctness/migration/race gates but did not receive
+   a separate endpoint performance corpus.
+4. The adaptive-slice `6c741940` versus final endpoint comparison was not rerun.
+   The architecture rejection still rests on the preserved 2,222-case selector
+   corpus and the earlier q64 evidence, not a new endpoint slice.
+5. The locked endpoint contract required PATCH parity and a pathological-wide
+   workload. This corpus measures PUT only and has no wide endpoint cell.
+6. The main A/B cohorts ran one complete build after the other. Reverse-order
+   controls changed the direction of PostgreSQL S latency and MariaDB T/c1
+   throughput; therefore the fixed-order ratios are descriptive observations,
+   not admissible causal estimates. A block/window-level randomized or ABBA
+   rerun is required for final performance admission.
+
+Those are evidence gaps, not excuses. No PR, merge, deployment, or known-good
+marker is authorized by this report.
+
+## Implementation
+
+P2.3's q64 probe/fallback was replaced narrowly with:
+
+- one complete locked `scim_group_member` edge query;
+- a reverse-adjacency map;
+- an iterative worklist traversal;
+- preserved zero-query empty and direct-self handling;
+- no counter, threshold, query cap, row budget, cache, migration, recursion, or
+  driver-specific production policy.
+
+The final patch is 52 insertions and 110 deletions across `models.py`, its
+focused tests, and the CI selector. It removes mechanism and policy rather than
+adding another abstraction.
+
+## Correctness and backend gates
+
+All recorded gates passed:
+
+- SQLite: 9 focused full-scan tests; 16 related graph tests; 351 broad tests
+  with 9 expected skips.
+- PostgreSQL 17: 5 migration tests with 2 skips; 289 runtime tests with 7 skips.
+- MariaDB 11/mysqlconnector: 6 migration tests with 1 skip; 37 graph/race tests
+  with 170 deselected.
+- MariaDB 11/mariadbconnector: 6 migration tests with 1 skip; 37 graph/race
+  tests with 170 deselected.
+- Rebuilt admin image manifest-list digest:
+  `sha256:a7e7fe10c1f9e65051ccb139397c73a6f01b4e362f692a032a8cf7688c4f7adc`.
+
+Exact copies of the XML and image metadata are in
+`correctness/final-20260813/` and are bound by this corpus manifest. The test
+runner did not embed source commit or expanded command properties; that
+identity remains an operator record and does not satisfy the strict
+self-identifying evidence requirement.
+
+## Instrumented HTTP latency and Amdahl matrix
+
+Each of 15 lane/workload cells contains 1,000 baseline and 1,000 final measured
+requests: 40 fixture-reset blocks, 10 warmups, and 25 admitted samples per
+block. Total admitted samples: 30,000. Every admitted request returned HTTP 200,
+SCIM JSON, matching ETag/meta.version, exact members, and exact destinations.
+
+The table below reports observed mean HTTP speedup, p95 ratio, measured program
+hotspot speedup, predicted Amdahl speedup, and residual. Ratios above 1 favor
+final.
+
+| Lane | Workload | Mean | p95 | Hotspot | Predicted | Residual |
+|---|---:|---:|---:|---:|---:|---:|
+| SQLite | S | 0.968x | 1.129x | 0.970x | 0.971x | -0.3% |
+| SQLite | T | 1.013x | 1.241x | 1.019x | 1.018x | -0.5% |
+| SQLite | L | 1.072x | 0.990x | 1.075x | 1.074x | -0.1% |
+| SQLite | P | 1.417x | 1.342x | 1.432x | 1.425x | -0.6% |
+| SQLite | B | 1.056x | 1.064x | 1.058x | 1.056x | -0.0% |
+| PostgreSQL | S | 0.891x | 0.697x | 0.882x | 0.901x | -1.1% |
+| PostgreSQL | T | 1.190x | 1.080x | 1.230x | 1.203x | -1.0% |
+| PostgreSQL | L | 1.204x | 1.196x | 1.214x | 1.205x | -0.0% |
+| PostgreSQL | P | 1.969x | 1.666x | 2.006x | 1.973x | -0.2% |
+| PostgreSQL | B | 1.264x | 1.168x | 1.281x | 1.260x | +0.3% |
+| MariaDB/mysqlconnector | S | 1.151x | 1.217x | 1.164x | 1.133x | +1.6% |
+| MariaDB/mysqlconnector | T | 1.557x | 1.497x | 1.637x | 1.545x | +0.8% |
+| MariaDB/mysqlconnector | L | 1.148x | 1.138x | 1.151x | 1.147x | +0.1% |
+| MariaDB/mysqlconnector | P | 1.943x | 1.868x | 1.966x | 1.938x | +0.2% |
+| MariaDB/mysqlconnector | B | 1.240x | 1.188x | 1.253x | 1.240x | -0.0% |
+
+The exact unrounded substitutions are in `tables/amdahl.csv`. For every row:
+
+```text
+P = H_baseline / T_baseline
+S_hotspot = H_baseline / H_final
+S_pred = 1 / ((1 - P) + P / S_hotspot)
+S_observed = T_baseline / T_final
+```
+
+Every residual is below 2%; the phase decomposition explains the instrumented
+cohort without pretending the cycle-only ratio is overall endpoint speedup.
+
+### PostgreSQL small reverse-order control
+
+The first cohort showed an apparent 10.9% mean regression. A second 1,000-sample
+cohort ran final before baseline and reversed the result: final was 2.4% faster
+on mean and 5.6% faster at p95. Pooling both cohorts gives 2,000 samples/build:
+baseline 27.445 ms mean versus final 28.662 ms, a 4.44% regression. The pooled
+result stays below the 5% materiality threshold but demonstrates substantial
+run-order drift. Both cohorts remain preserved.
+
+## Throughput
+
+PostgreSQL and MariaDB each have 20 complete build/workload/concurrency cells:
+seven windows, five-second warmup, fifteen-second measurement, fixture restore
+between windows, one Gunicorn worker, closed-loop c1/c4, exact response/ETag
+validation, and zero HTTP errors. `tables/throughput.csv` contains all 30
+expected rows, including SQLite failure/N/A states.
+
+Representative median requests/second:
+
+| Lane/workload | c1 baseline | c1 final | c1 ratio | c4 baseline | c4 final | c4 ratio |
+|---|---:|---:|---:|---:|---:|---:|
+| PostgreSQL T | 21.71 | 26.37 | 1.21x | 14.31 | 17.38 | 1.21x |
+| PostgreSQL P | 3.06 | 5.91 | 1.93x | 3.24 | 6.19 | 1.91x |
+| PostgreSQL B | 11.40 | 10.85 | 0.952x | 9.54 | 10.29 | 1.08x |
+| MariaDB T, first cohort | 13.61 | 12.71 | 0.934x | 9.81 | 13.37 | 1.36x |
+| MariaDB P | 2.24 | 4.20 | 1.88x | 1.98 | 4.09 | 2.06x |
+| MariaDB B | 5.46 | 6.82 | 1.25x | 5.91 | 7.51 | 1.27x |
+
+MariaDB T/c1 was rerun in reverse order because the first median contradicted
+total completions. The reverse cohort was baseline 13.22 versus final 19.48
+requests/s. Across all 14 windows, pooled medians are baseline 13.45 and final
+19.37 requests/s. This is reported as order-sensitive evidence, not a stable
+single-run guarantee.
+
+SQLite T/c1 completed at 4.52 baseline versus 4.76 final requests/s. SQLite T/c4
+failed on both sources with the same `sqlite3.OperationalError: database is
+locked` at `UPDATE scim_state ...`; remaining SQLite throughput cells were not
+run after the inherited failure was established.
+
+## Query, row, and byte work
+
+The final source uses 19 or 21 queries in the mandatory cells versus baseline
+21, 40, or 147. The full-scan cycle query returns exactly E fixture rows; raw
+records preserve the logical UTF-8 value-byte lower bound, bind bytes, request
+bytes, and response bytes. These are application-visible values, not database
+wire bytes or rows examined. The detailed SQL-result proxy and backend plan
+appendix required by the strict protocol were not completed; timing claims do
+not rely on fabricated row-wrapper timings.
+
+## Environment
+
+- Host: Linux 7.1.5-arch1-2, AMD EPYC 7551P, 32 cores/64 threads, 220 GiB RAM.
+- Container engine: Docker 29.7.1.
+- PostgreSQL: 17.10.
+- MariaDB: 11.8.8.
+- Runner: rebuilt `mailu/admin:scim-final-9a126997`.
+
+## Final call
+
+The code change is smaller, mechanically understandable, correctness-clean,
+and strongly better on the pathological endpoint workload. It does not justify
+an unconditional final-admission claim because the strict evidence contract is
+incomplete and SQLite c4 fails on both revisions. The honest ruling is:
+**accept the full-scan implementation with constraints; reject any claim that
+the complete benchmark/admission protocol is clean.**
+
+Two independent cold reviews reached the same split verdict: no production
+source defect was found, but final performance admission is rejected. Review 1
+is `reviews/review-1.md`; review 2 is `reviews/review-2.md`. Their blockers and
+the resulting conditions are incorporated into `FINAL-RULING.md`.

--- a/tests/address_registry_test.py
+++ b/tests/address_registry_test.py
@@ -1,0 +1,539 @@
+"""Focused regressions for the global User/Alias address registry.
+
+The registry is a routing-address invariant, not a SCIM identity mapping.
+These tests deliberately exercise ORM writers, raw SQL bypass attempts,
+concurrent transactions, and the Alembic migration from the legacy schema.
+"""
+
+import importlib.util
+import pathlib
+import threading
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from mailu import models
+
+
+MIGRATION = (
+    pathlib.Path(models.__file__).resolve().parent.parent
+    / 'migrations' / 'versions' / 'd4a6f2b8c901_.py'
+)
+
+
+def _domain(name='example.com'):
+    domain = models.Domain(name=name)
+    models.db.session.add(domain)
+    models.db.session.commit()
+    return domain
+
+
+def _user(domain, localpart='shared'):
+    return models.User(
+        localpart=localpart,
+        domain=domain,
+        password='not-a-real-password-hash',
+    )
+
+
+def _alias(domain, localpart='shared'):
+    return models.Alias(
+        localpart=localpart,
+        domain=domain,
+        destination=['destination@example.net'],
+    )
+
+
+def _enable_sqlite_foreign_keys(session):
+    session.execute(sa.text('PRAGMA foreign_keys=ON'))
+
+
+def _bearer(app):
+    return {'Authorization': f'Bearer {app.config["API_TOKEN"]}'}
+
+
+def test_registry_shares_user_alias_metadata_and_creation_order(app, tmp_path):
+    assert models.MailAddress.__table__.metadata is models.User.__table__.metadata
+    assert models.MailAddress.__table__.metadata is models.Alias.__table__.metadata
+    assert models.MailAddress.__table__.metadata is models.db.metadata
+
+    engine = sa.create_engine(f'sqlite:///{tmp_path / "metadata.sqlite"}')
+    models.db.metadata.create_all(engine)
+    models.Base.metadata.create_all(engine)
+    try:
+        tables = set(sa.inspect(engine).get_table_names())
+        assert {'mail_address', 'user', 'alias', 'manager'} <= tables
+    finally:
+        models.Base.metadata.drop_all(engine)
+        models.db.metadata.drop_all(engine)
+        engine.dispose()
+
+
+def test_user_then_alias_same_address_is_rejected_by_database(app):
+    domain = _domain()
+    models.db.session.add(_user(domain))
+    models.db.session.commit()
+
+    models.db.session.add(_alias(domain))
+    with pytest.raises(models.AddressConflict):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    assert models.User.query.count() == 1
+    assert models.Alias.query.count() == 0
+    assert models.MailAddress.query.count() == 1
+
+
+def test_alias_then_user_same_address_is_rejected_by_database(app):
+    domain = _domain()
+    models.db.session.add(_alias(domain))
+    models.db.session.commit()
+
+    models.db.session.add(_user(domain))
+    with pytest.raises(models.AddressConflict):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    assert models.User.query.count() == 0
+    assert models.Alias.query.count() == 1
+    assert models.MailAddress.query.count() == 1
+
+
+def test_concurrent_user_alias_claim_has_exactly_one_winner(app, tmp_path):
+    database = tmp_path / 'address-race.sqlite'
+    engine = sa.create_engine(
+        f'sqlite:///{database}',
+        connect_args={'check_same_thread': False, 'timeout': 10},
+    )
+
+    @sa.event.listens_for(engine, 'connect')
+    def enable_foreign_keys(connection, _record):
+        connection.execute('PRAGMA foreign_keys=ON')
+
+    models.db.metadata.create_all(engine)
+    models.Base.metadata.create_all(engine)
+    with Session(engine) as seed:
+        seed.add(models.Domain(name='example.com'))
+        seed.commit()
+
+    barrier = threading.Barrier(2)
+    outcomes = []
+    outcome_lock = threading.Lock()
+
+    def claim(model):
+        with app.app_context(), Session(engine) as session:
+            domain = session.get(models.Domain, 'example.com')
+            resource = (
+                models.User(
+                    localpart='race',
+                    domain=domain,
+                    password='not-a-real-password-hash',
+                )
+                if model is models.User
+                else models.Alias(
+                    localpart='race',
+                    domain=domain,
+                    destination=['destination@example.net'],
+                )
+            )
+            session.add(resource)
+            barrier.wait()
+            try:
+                session.commit()
+            except models.AddressConflict:
+                session.rollback()
+                result = 'conflict'
+            else:
+                result = model.__name__
+            with outcome_lock:
+                outcomes.append(result)
+
+    user_thread = threading.Thread(target=claim, args=(models.User,))
+    alias_thread = threading.Thread(target=claim, args=(models.Alias,))
+    user_thread.start()
+    alias_thread.start()
+    user_thread.join(timeout=15)
+    alias_thread.join(timeout=15)
+
+    assert not user_thread.is_alive()
+    assert not alias_thread.is_alive()
+    assert sorted(outcomes) in (
+        ['Alias', 'conflict'],
+        ['User', 'conflict'],
+    )
+    with Session(engine) as session:
+        assert session.query(models.MailAddress).count() == 1
+        assert (
+            session.query(models.User).count()
+            + session.query(models.Alias).count()
+        ) == 1
+    engine.dispose()
+
+
+def test_delete_release_and_rollback_are_atomic(app):
+    domain = _domain()
+    user = _user(domain)
+    models.db.session.add(user)
+    models.db.session.commit()
+    email = user.email
+    assert models.db.session.get(models.MailAddress, email) is not None
+
+    models.db.session.delete(user)
+    models.db.session.flush()
+    assert models.db.session.get(models.MailAddress, email) is None
+    models.db.session.rollback()
+    models.db.session.expire_all()
+
+    assert models.db.session.get(models.User, email) is not None
+    assert models.db.session.get(models.MailAddress, email) is not None
+
+    user = models.db.session.get(models.User, email)
+    models.db.session.delete(user)
+    models.db.session.commit()
+    assert models.db.session.get(models.MailAddress, email) is None
+
+    domain = models.db.session.get(models.Domain, 'example.com')
+    models.db.session.add(_alias(domain))
+    models.db.session.commit()
+    assert models.db.session.get(models.Alias, email) is not None
+
+
+def test_persisted_address_rename_is_rejected_without_registry_drift(app):
+    domain = _domain()
+    user = _user(domain, localpart='before')
+    models.db.session.add(user)
+    models.db.session.commit()
+
+    user.email = 'after@example.com'
+    with pytest.raises(models.AddressRenameError):
+        models.db.session.flush()
+    models.db.session.rollback()
+    models.db.session.expire_all()
+
+    assert models.db.session.get(models.User, 'before@example.com') is not None
+    assert models.db.session.get(models.User, 'after@example.com') is None
+    assert models.db.session.get(models.MailAddress, 'before@example.com') is not None
+    assert models.db.session.get(models.MailAddress, 'after@example.com') is None
+
+
+def test_raw_child_insert_without_registry_row_fails_closed(app):
+    domain = _domain()
+    _enable_sqlite_foreign_keys(models.db.session)
+
+    with pytest.raises(IntegrityError):
+        models.db.session.execute(
+            models.Alias.__table__.insert().values(
+                email='raw@example.com',
+                localpart='raw',
+                domain_name=domain.name,
+                destination=['destination@example.net'],
+            )
+        )
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    assert models.db.session.get(models.Alias, 'raw@example.com') is None
+    assert models.db.session.get(models.MailAddress, 'raw@example.com') is None
+
+
+def test_v1_user_create_maps_alias_collision_to_409(app, client):
+    domain = _domain()
+    models.db.session.add(_alias(domain, localpart='v1-user'))
+    models.db.session.commit()
+
+    response = client.post(
+        '/api/v1/user',
+        json={
+            'email': 'v1-user@example.com',
+            'raw_password': 'not-a-real-password',
+        },
+        headers=_bearer(app),
+    )
+
+    assert response.status_code == 409
+    assert models.db.session.get(models.User, 'v1-user@example.com') is None
+
+
+def test_v1_alias_create_maps_user_collision_to_409(app, client):
+    domain = _domain()
+    models.db.session.add(_user(domain, localpart='v1-alias'))
+    models.db.session.commit()
+
+    response = client.post(
+        '/api/v1/alias',
+        json={
+            'email': 'v1-alias@example.com',
+            'destination': ['v1-alias@example.com'],
+        },
+        headers=_bearer(app),
+    )
+
+    assert response.status_code == 409
+    assert models.db.session.get(models.Alias, 'v1-alias@example.com') is None
+
+
+def test_v1_user_create_maps_external_reservation_to_409(app, client):
+    domain = _domain()
+    group_alias = _alias(domain, localpart='managed-group')
+    models.db.session.add(group_alias)
+    models.db.session.commit()
+    group = models.create_scim_group_mapping(group_alias)
+    models.db.session.commit()
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[],
+        external_destinations=['reserved@example.com'],
+    )
+    models.db.session.commit()
+
+    response = client.post(
+        '/api/v1/user',
+        json={
+            'email': 'reserved@example.com',
+            'raw_password': 'not-a-real-password',
+        },
+        headers=_bearer(app),
+    )
+
+    assert response.status_code == 409
+    assert models.db.session.get(models.User, 'reserved@example.com') is None
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location(
+        'mail_address_registry_migration',
+        MIGRATION,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _legacy_engine():
+    engine = sa.create_engine('sqlite://')
+
+    @sa.event.listens_for(engine, 'connect')
+    def enable_foreign_keys(connection, _record):
+        connection.execute('PRAGMA foreign_keys=ON')
+
+    metadata = sa.MetaData()
+    sa.Table(
+        'domain',
+        metadata,
+        sa.Column('name', sa.String(80), primary_key=True),
+    )
+    sa.Table(
+        'user',
+        metadata,
+        sa.Column('email', sa.String(255), primary_key=True),
+        sa.Column('localpart', sa.String(80), nullable=False),
+        sa.Column(
+            'domain_name',
+            sa.String(80),
+            sa.ForeignKey('domain.name', name='user_domain_name_fkey'),
+            nullable=False,
+        ),
+    )
+    sa.Table(
+        'alias',
+        metadata,
+        sa.Column('email', sa.String(255), primary_key=True),
+        sa.Column('localpart', sa.String(80), nullable=False),
+        sa.Column(
+            'domain_name',
+            sa.String(80),
+            sa.ForeignKey('domain.name', name='alias_domain_name_fkey'),
+            nullable=False,
+        ),
+        sa.Column(
+            'owner_email',
+            sa.String(255),
+            sa.ForeignKey('user.email', name='alias_owner_email_fkey'),
+            nullable=True,
+        ),
+    )
+    sa.Table(
+        'fetch',
+        metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column(
+            'user_email',
+            sa.String(255),
+            sa.ForeignKey('user.email', name='fetch_user_email_fkey'),
+            nullable=False,
+        ),
+    )
+    sa.Table(
+        'token',
+        metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column(
+            'user_email',
+            sa.String(255),
+            sa.ForeignKey('user.email', name='token_user_email_fkey'),
+            nullable=False,
+        ),
+    )
+    sa.Table(
+        'manager',
+        metadata,
+        sa.Column(
+            'domain_name',
+            sa.String(80),
+            sa.ForeignKey('domain.name', name='manager_domain_name_fkey'),
+        ),
+        sa.Column(
+            'user_email',
+            sa.String(255),
+            sa.ForeignKey('user.email', name='manager_user_email_fkey'),
+        ),
+    )
+    sa.Table(
+        'domain_access',
+        metadata,
+        sa.Column('id', sa.Integer, primary_key=True),
+        sa.Column(
+            'domain_name',
+            sa.String(80),
+            sa.ForeignKey(
+                'domain.name',
+                name='domain_access_domain_name_fkey',
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            'user_email',
+            sa.String(255),
+            sa.ForeignKey(
+                'user.email',
+                name='domain_access_user_email_fkey',
+            ),
+            nullable=False,
+        ),
+    )
+    metadata.create_all(engine)
+    return engine
+
+
+def _run_migration(engine, operation):
+    migration = _load_migration()
+    with engine.connect() as connection:
+        context = MigrationContext.configure(connection)
+        migration.op = Operations(context)
+        with connection.begin():
+            getattr(migration, operation)()
+
+
+def _seed_legacy(engine, *, collision=False):
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            "INSERT INTO domain (name) VALUES ('example.com')"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO user (email, localpart, domain_name) "
+            "VALUES ('user@example.com', 'user', 'example.com')"
+        )
+        alias_email = 'user@example.com' if collision else 'alias@example.com'
+        alias_localpart = 'user' if collision else 'alias'
+        connection.execute(
+            sa.text(
+                'INSERT INTO alias '
+                '(email, localpart, domain_name, owner_email) '
+                'VALUES (:email, :localpart, :domain, :owner)'
+            ),
+            {
+                'email': alias_email,
+                'localpart': alias_localpart,
+                'domain': 'example.com',
+                'owner': 'user@example.com',
+            },
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO fetch (id, user_email) "
+            "VALUES (1, 'user@example.com')"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO token (id, user_email) "
+            "VALUES (1, 'user@example.com')"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO manager (domain_name, user_email) "
+            "VALUES ('example.com', 'user@example.com')"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO domain_access (id, domain_name, user_email) "
+            "VALUES (1, 'example.com', 'user@example.com')"
+        )
+
+
+def test_migration_refuses_cross_table_collision_before_ddl():
+    engine = _legacy_engine()
+    _seed_legacy(engine, collision=True)
+
+    with pytest.raises(RuntimeError, match='user@example.com'):
+        _run_migration(engine, 'upgrade')
+
+    inspector = sa.inspect(engine)
+    assert 'mail_address' not in inspector.get_table_names()
+    assert 'address_type' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql(
+            'SELECT COUNT(*) FROM "user"'
+        ).scalar_one() == 1
+        assert connection.exec_driver_sql(
+            'SELECT COUNT(*) FROM alias'
+        ).scalar_one() == 1
+    engine.dispose()
+
+
+def test_migration_backfills_constraints_and_downgrades_without_data_loss():
+    engine = _legacy_engine()
+    _seed_legacy(engine)
+
+    _run_migration(engine, 'upgrade')
+
+    inspector = sa.inspect(engine)
+    assert 'mail_address' in inspector.get_table_names()
+    assert {column['name'] for column in inspector.get_columns('user')} >= {
+        'email',
+        'address_type',
+    }
+    assert {column['name'] for column in inspector.get_columns('alias')} >= {
+        'email',
+        'address_type',
+    }
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql(
+            'SELECT email, address_type FROM mail_address ORDER BY email'
+        ).all() == [
+            ('alias@example.com', 'alias'),
+            ('user@example.com', 'user'),
+        ]
+        assert connection.exec_driver_sql(
+            'PRAGMA foreign_key_check'
+        ).all() == []
+
+    _run_migration(engine, 'downgrade')
+
+    inspector = sa.inspect(engine)
+    assert 'mail_address' not in inspector.get_table_names()
+    assert 'address_type' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    assert 'address_type' not in {
+        column['name'] for column in inspector.get_columns('alias')
+    }
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql(
+            'SELECT email FROM "user"'
+        ).all() == [('user@example.com',)]
+        assert connection.exec_driver_sql(
+            'SELECT email FROM alias'
+        ).all() == [('alias@example.com',)]
+    engine.dispose()

--- a/tests/address_registry_test.py
+++ b/tests/address_registry_test.py
@@ -49,7 +49,8 @@ def _alias(domain, localpart='shared'):
 
 
 def _enable_sqlite_foreign_keys(session):
-    session.execute(sa.text('PRAGMA foreign_keys=ON'))
+    if session.get_bind().dialect.name == 'sqlite':
+        session.execute(sa.text('PRAGMA foreign_keys=ON'))
 
 
 def _bearer(app):

--- a/tests/address_registry_test.py
+++ b/tests/address_registry_test.py
@@ -493,6 +493,80 @@ def test_migration_refuses_cross_table_collision_before_ddl():
     engine.dispose()
 
 
+def test_migration_caps_case_collision_diagnostic_and_retries():
+    engine = _legacy_engine()
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            "INSERT INTO domain (name) VALUES ('example.com')"
+        )
+        connection.execute(
+            sa.text(
+                'INSERT INTO user (email, localpart, domain_name) '
+                'VALUES (:email, :localpart, :domain)'
+            ),
+            [
+                {
+                    'email': f'User{index:02d}@example.com',
+                    'localpart': f'User{index:02d}',
+                    'domain': 'example.com',
+                }
+                for index in range(22)
+            ],
+        )
+        connection.execute(
+            sa.text(
+                'INSERT INTO alias '
+                '(email, localpart, domain_name, owner_email) '
+                'VALUES (:email, :localpart, :domain, NULL)'
+            ),
+            [
+                {
+                    'email': f'user{index:02d}@example.com',
+                    'localpart': f'user{index:02d}',
+                    'domain': 'example.com',
+                }
+                for index in range(22)
+            ],
+        )
+
+    with pytest.raises(RuntimeError) as collision_error:
+        _run_migration(engine, 'upgrade')
+
+    diagnostic = str(collision_error.value)
+    assert diagnostic.splitlines() == [
+        'Cannot enforce global mail-address uniqueness. These addresses '
+        'exist as both User and Alias:',
+        *[
+            f'  user{index:02d}@example.com: '
+            f'User=User{index:02d}@example.com, '
+            f'Alias=user{index:02d}@example.com'
+            for index in range(20)
+        ],
+        '  ... additional collisions omitted',
+        'Remove or rename one owner of each address, then retry.',
+    ]
+    inspector = sa.inspect(engine)
+    assert 'mail_address' not in inspector.get_table_names()
+    assert 'address_type' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+
+    with engine.begin() as connection:
+        connection.execute(sa.text(
+            "UPDATE alias SET email = 'alias' || substr(email, 5)"
+        ))
+
+    _run_migration(engine, 'upgrade')
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql(
+            'SELECT COUNT(*) FROM mail_address'
+        ).scalar_one() == 44
+        assert connection.exec_driver_sql(
+            'PRAGMA foreign_key_check'
+        ).all() == []
+    engine.dispose()
+
+
 def test_migration_backfills_constraints_and_downgrades_without_data_loss():
     engine = _legacy_engine()
     _seed_legacy(engine)

--- a/tests/anonmail/test_domain_admin_privesc.py
+++ b/tests/anonmail/test_domain_admin_privesc.py
@@ -22,6 +22,7 @@ class TestDomainAdminPrivesc:
     def _login(client, user):
         with client.session_transaction() as sess:
             sess['_user_id'] = user.get_id()
+            sess['_auth_generation'] = user.auth_generation
             sess['_fresh'] = True
 
     @staticmethod

--- a/tests/anonmail/test_domain_list.py
+++ b/tests/anonmail/test_domain_list.py
@@ -26,6 +26,7 @@ class TestDomainListCounts:
 
             with client.session_transaction() as sess:
                 sess['_user_id'] = admin.email
+                sess['_auth_generation'] = admin.auth_generation
                 sess['_fresh'] = True
 
             statements = []

--- a/tests/anonmail/test_fetch_folders.py
+++ b/tests/anonmail/test_fetch_folders.py
@@ -17,6 +17,7 @@ class TestFetchEmptyFolders:
     def _login(client, user):
         with client.session_transaction() as sess:
             sess['_user_id'] = user.get_id()
+            sess['_auth_generation'] = user.auth_generation
             sess['_fresh'] = True
 
     @staticmethod

--- a/tests/auth_generation_model_test.py
+++ b/tests/auth_generation_model_test.py
@@ -1,0 +1,186 @@
+from mailu import models, utils
+from mailu.schemas import MailuSchema
+
+
+INITIAL_GENERATION = utils.INITIAL_AUTH_GENERATION
+
+
+def create_user(localpart='authority-model'):
+    domain = models.db.session.get(models.Domain, 'example.com')
+    if domain is None:
+        domain = models.Domain(name='example.com')
+        models.db.session.add(domain)
+    user = models.User(localpart=localpart, domain=domain)
+    user.set_password('initial-password', keep_sessions=True)
+    models.db.session.add(user)
+    models.db.session.commit()
+    return user
+
+
+def update_import(source):
+    context = {
+        'import': True,
+        'update': True,
+        'clear': False,
+        'callback': lambda *args, **kwargs: None,
+    }
+    schema = MailuSchema(only=MailuSchema.Meta.order, context=context)
+    with models.db.session.no_autoflush:
+        schema.loads(source)
+    models.db.session.commit()
+
+
+def test_new_user_starts_at_random_generation(app):
+    user = create_user()
+
+    assert user.auth_generation != INITIAL_GENERATION
+    assert len(user.auth_generation) == 32
+    assert set(user.auth_generation) <= set('0123456789abcdef')
+    assert user.is_active is True
+
+
+def test_logical_password_replacement_rotates_generation_in_sql(app):
+    user = create_user(localpart='password-rotation')
+    before = user.auth_generation
+
+    user.set_password('replacement-password', keep_sessions=True)
+    rotated = user.auth_generation
+    models.db.session.commit()
+
+    assert rotated != before
+    assert len(rotated) == 32
+    assert set(rotated) <= set('0123456789abcdef')
+    assert models.db.session.get(models.User, user.email).auth_generation == rotated
+
+
+def test_raw_hash_replacement_rotates_but_same_hash_does_not(app):
+    user = create_user(localpart='raw-rotation')
+    existing_hash = user.password
+    before = user.auth_generation
+
+    user.set_password(existing_hash, raw=True, keep_sessions=True)
+    assert user.auth_generation == before
+
+    user.set_password('{CRYPT}$6$replacement', raw=True, keep_sessions=True)
+    assert user.auth_generation != before
+
+
+def test_direct_orm_password_assignment_rotates_for_config_import(app):
+    user = create_user(localpart='import-rotation')
+    before = user.auth_generation
+
+    user.password = user.password + '-imported'
+
+    assert user.auth_generation != before
+
+
+def test_update_import_same_plaintext_password_keeps_generation(app):
+    user = create_user(localpart='same-import-password')
+    before_hash = user.password
+    before_generation = user.auth_generation
+
+    update_import(
+        'user:\n'
+        f'  - email: {user.email}\n'
+        '    password: initial-password\n'
+        '    hash_password: true\n'
+    )
+
+    assert user.password == before_hash
+    assert user.auth_generation == before_generation
+
+
+def test_update_import_same_password_with_disable_still_rotates(app):
+    user = create_user(localpart='same-import-password-disable')
+    before_hash = user.password
+    before_generation = user.auth_generation
+
+    update_import(
+        'user:\n'
+        f'  - email: {user.email}\n'
+        '    password: initial-password\n'
+        '    hash_password: true\n'
+        '    enabled: false\n'
+    )
+
+    assert user.password == before_hash
+    assert user.enabled is False
+    assert user.auth_generation != before_generation
+
+
+def test_update_import_same_plaintext_token_keeps_hash(app):
+    user = create_user(localpart='same-import-token')
+    raw_token = 'a' * 32
+    token = models.Token(user_email=user.email)
+    token.set_password(raw_token)
+    models.db.session.add(token)
+    models.db.session.commit()
+    before_hash = token.password
+
+    update_import(
+        'user:\n'
+        f'  - email: {user.email}\n'
+        '    tokens:\n'
+        f'      - id: {token.id}\n'
+        f'        password: {raw_token}\n'
+        '        hash_password: true\n'
+    )
+
+    assert models.db.session.get(
+        models.Token,
+        token.id,
+    ).password == before_hash
+
+
+def test_enablement_change_rotates_but_same_value_does_not(app):
+    user = create_user(localpart='enabled-rotation')
+    before = user.auth_generation
+
+    user.enabled = True
+    assert user.auth_generation == before
+
+    user.enabled = False
+    disabled_generation = user.auth_generation
+    assert disabled_generation != before
+    assert user.is_active is False
+
+    user.enabled = False
+    assert user.auth_generation == disabled_generation
+
+    user.enabled = True
+    assert user.auth_generation != disabled_generation
+    assert user.is_active is True
+
+
+def test_rollback_restores_generation_and_authority(app):
+    user = create_user(localpart='rollback-generation')
+    before = user.auth_generation
+
+    user.enabled = False
+    assert user.auth_generation != before
+    models.db.session.rollback()
+
+    restored = models.db.session.get(models.User, user.email)
+    assert restored.enabled is True
+    assert restored.auth_generation == before
+
+
+def test_transparent_password_rehash_does_not_rotate_generation(app, monkeypatch):
+    user = create_user(localpart='rehash-generation')
+    before = user.auth_generation
+    replacement_hash = user.password + '-rehash'
+
+    class _Context:
+        @staticmethod
+        def verify_and_update(_password, _reference):
+            return True, replacement_hash
+
+    monkeypatch.setattr(
+        models.User,
+        'get_password_context',
+        classmethod(lambda _cls: _Context()),
+    )
+
+    assert user.check_password('initial-password') is True
+    assert user.password == replacement_hash
+    assert user.auth_generation == before

--- a/tests/config_import_reconcile_test.py
+++ b/tests/config_import_reconcile_test.py
@@ -1,0 +1,610 @@
+"""Full config replacement must preserve persistent SCIM identity."""
+
+from copy import deepcopy
+
+import pytest
+from marshmallow import ValidationError
+
+from mailu import models
+from mailu.schemas import MailuSchema, RenderYAML
+
+
+def _domain(name='example.com'):
+    domain = models.db.session.get(models.Domain, name)
+    if domain is None:
+        domain = models.Domain(name=name)
+        models.db.session.add(domain)
+        models.db.session.commit()
+    return domain
+
+
+def _user(localpart, *, domain=None):
+    user = models.User(
+        localpart=localpart,
+        domain=domain or _domain(),
+    )
+    user.set_password('not-a-real-password')
+    models.db.session.add(user)
+    models.db.session.commit()
+    return user
+
+
+def _export_data():
+    schema = MailuSchema(
+        only=MailuSchema.Meta.order,
+        context={'secrets': True},
+    )
+    return schema.dump(models.MailuConfig())
+
+
+def _invoke(app, command, *arguments, input=None):
+    return app.test_cli_runner().invoke(
+        args=['mailu', command, *arguments],
+        input=input,
+    )
+
+
+def _replace_import(data, *, dry_run=False):
+    context = {
+        'import': True,
+        'update': False,
+        'clear': True,
+        'callback': lambda *args, **kwargs: None,
+    }
+    schema = MailuSchema(only=MailuSchema.Meta.order, context=context)
+    source = RenderYAML.dumps(deepcopy(data))
+    with models.db.session.no_autoflush:
+        config = schema.loads(source)
+    models.db.session.flush()
+    config.check()
+    if dry_run:
+        models.db.session.rollback()
+    else:
+        models.db.session.commit()
+
+
+def _managed_group(localpart='list'):
+    member = _user('member')
+    alias = models.Alias(
+        localpart=localpart,
+        domain=_domain(),
+        destination=[
+            member.email,
+            'pager@outside.example',
+        ],
+    )
+    models.db.session.add(alias)
+    models.db.session.commit()
+    group = models.create_scim_group_mapping(
+        alias,
+        external_id='directory-group-7',
+    )
+    models.db.session.flush()
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[member.scim_resource.id],
+        external_destinations=['pager@outside.example'],
+    )
+    models.db.session.commit()
+    return group, member
+
+
+def test_export_default_import_preserves_user_identity_and_authority(
+    app,
+    tmp_path,
+):
+    with app.app_context():
+        user = _user('alice')
+        user.scim_resource.external_id = 'directory-user-7'
+        models.db.session.commit()
+        email = user.email
+        resource_id = user.scim_resource.id
+        generation = user.auth_generation
+        password = user.password
+        token = models.Token(user_email=user.email)
+        token.set_password('a' * 32)
+        models.db.session.add(token)
+        models.db.session.commit()
+        token_id = token.id
+        token_password = token.password
+
+    export_path = tmp_path / 'mailu-config.yaml'
+    exported = _invoke(
+        app,
+        'config-export',
+        '--secrets',
+        '--output-file',
+        str(export_path),
+    )
+    assert exported.exit_code == 0, exported.output
+    source = export_path.read_text(encoding='utf-8')
+    exported_data = RenderYAML.loads(source)
+    assert 'scim_resource' not in exported_data['user'][0]
+
+    imported = _invoke(
+        app,
+        'config-import',
+        '--quiet',
+        '-',
+        input=source,
+    )
+    assert imported.exit_code == 0, imported.output
+
+    with app.app_context():
+        models.db.session.remove()
+        restored = models.db.session.get(models.User, email)
+        assert restored.scim_resource.id == resource_id
+        assert restored.scim_resource.external_id == 'directory-user-7'
+        assert restored.auth_generation == generation
+        assert restored.password == password
+        restored_token = models.db.session.get(models.Token, token_id)
+        assert restored_token.password == token_password
+        assert models.ScimResource.query.count() == 1
+        assert models.ScimResource.query.filter(
+            models.ScimResource.deleted_at.is_not(None)
+        ).count() == 0
+
+
+def test_export_default_import_preserves_managed_group_graph(app):
+    with app.app_context():
+        group, member = _managed_group()
+        group_id = group.id
+        member_id = member.scim_resource.id
+
+        _replace_import(_export_data())
+
+        restored = models.ScimResource.get_exact(
+            group_id,
+            resource_type='Group',
+        )
+        assert restored is group
+        assert restored.external_id == 'directory-group-7'
+        assert restored.alias.destination == [
+            member.email,
+            'pager@outside.example',
+        ]
+        assert [edge.member_id for edge in restored.member_edges] == [member_id]
+        assert [
+            destination.destination
+            for destination in restored.destinations
+        ] == ['pager@outside.example']
+
+
+def test_export_default_import_preserves_owned_alias(app):
+    with app.app_context():
+        owner = _user('alias-owner')
+        alias = models.Alias(
+            localpart='owned',
+            domain=_domain(),
+            destination=['outside@example.net'],
+            owner_email=owner.email,
+            hostname='app.example.net',
+        )
+        models.db.session.add(alias)
+        models.db.session.commit()
+        owner_id = owner.scim_resource.id
+
+        _replace_import(_export_data())
+
+        restored = models.db.session.get(models.Alias, alias.email)
+        assert restored.owner_email == owner.email
+        assert restored.hostname == 'app.example.net'
+        assert owner.scim_resource.id == owner_id
+
+
+def test_default_import_prunes_group_member_without_reloading_projection(app):
+    with app.app_context():
+        group, member = _managed_group('pruned-member-list')
+        group_id = group.id
+        member_id = member.scim_resource.id
+        data = _export_data()
+        data['user'] = [
+            item for item in data['user']
+            if item['email'] != member.email
+        ]
+
+        _replace_import(data)
+
+        restored = models.ScimResource.get_exact(
+            group_id,
+            resource_type='Group',
+        )
+        assert restored is group
+        assert restored.member_edges == []
+        assert restored.alias.destination == ['pager@outside.example']
+        assert models.ScimResource.get_exact(
+            member_id,
+            active_only=False,
+        ).deleted_at is not None
+
+
+def test_default_import_prunes_absent_user_once(app):
+    with app.app_context():
+        retained = _user('retained')
+        removed = _user('removed')
+        retained_id = retained.scim_resource.id
+        retained_generation = retained.auth_generation
+        removed_id = removed.scim_resource.id
+        data = _export_data()
+        data['user'] = [
+            item for item in data['user']
+            if item['email'] == retained.email
+        ]
+
+        _replace_import(data)
+
+        assert models.db.session.get(models.User, retained.email) is retained
+        assert retained.scim_resource.id == retained_id
+        assert retained.auth_generation == retained_generation
+        assert models.db.session.get(models.User, removed.email) is None
+        tombstone = models.ScimResource.get_exact(
+            removed_id,
+            active_only=False,
+        )
+        assert tombstone.deleted_at is not None
+        assert models.ScimResource.query.count() == 2
+
+        _replace_import(_export_data())
+
+        assert models.db.session.get(models.User, retained.email) is retained
+        assert retained.scim_resource.id == retained_id
+        assert retained.auth_generation == retained_generation
+        assert models.ScimResource.query.count() == 2
+        assert models.ScimResource.get_exact(
+            removed_id,
+            active_only=False,
+        ).deleted_at == tombstone.deleted_at
+
+
+def test_default_import_releases_absent_user_address_before_alias_load(app):
+    with app.app_context():
+        user = _user('address-swap')
+        email = user.email
+        resource_id = user.scim_resource.id
+        data = _export_data()
+        data['user'] = [
+            item for item in data['user']
+            if item['email'] != email
+        ]
+        data['alias'].append({
+            'email': email,
+            'destination': ['outside@example.net'],
+        })
+
+        _replace_import(data)
+
+        assert models.db.session.get(models.User, email) is None
+        assert models.db.session.get(models.Alias, email) is not None
+        assert models.ScimResource.get_exact(
+            resource_id,
+            active_only=False,
+        ).deleted_at is not None
+
+
+def test_default_import_dry_run_rolls_back_reconciliation(app):
+    with app.app_context():
+        retained = _user('dry-run')
+        resource_id = retained.scim_resource.id
+        data = _export_data()
+        data['user'] = []
+
+        _replace_import(data, dry_run=True)
+
+        restored = models.db.session.get(models.User, retained.email)
+        assert restored is not None
+        assert restored.scim_resource.id == resource_id
+        assert models.ScimResource.get_exact(resource_id) is not None
+
+
+def test_failed_default_import_cannot_defer_rejected_dkim_write(
+    app,
+    tmp_path,
+):
+    with app.app_context():
+        app.config['DKIM_PATH'] = str(
+            tmp_path / '{domain}.{selector}.key'
+        )
+        domain = _domain('dkim.example')
+        domain.generate_dkim_key()
+        models.db.session.commit()
+        key_path = domain._dkim_file()  # pylint: disable=protected-access
+        with open(key_path, 'rb') as handle:
+            original_key = handle.read()
+        user = _user('dkim-user', domain=domain)
+        data = _export_data()
+        domain_data = next(
+            item for item in data['domain']
+            if item['name'] == domain.name
+        )
+        user_data = next(
+            item for item in data['user']
+            if item['email'] == user.email
+        )
+        domain_data['dkim_key'] = '-generate-'
+        user_data.pop('password')
+
+        result = _invoke(
+            app,
+            'config-import',
+            '--quiet',
+            '-',
+            input=RenderYAML.dumps(data),
+        )
+        assert result.exit_code != 0
+        with open(key_path, 'rb') as handle:
+            assert handle.read() == original_key
+
+        restored = models.db.session.get(models.Domain, domain.name)
+        restored.signup_enabled = not restored.signup_enabled
+        models.db.session.commit()
+        with open(key_path, 'rb') as handle:
+            assert handle.read() == original_key
+
+
+def test_default_import_keeps_replacement_semantics(app):
+    with app.app_context():
+        domain = _domain()
+        user = _user('replace', domain=domain)
+        user.displayed_name = 'Old name'
+        user.allow_spoofing = True
+        user.forward_enabled = True
+        user.forward_destination = [
+            'old-one@outside.example',
+            'old-two@outside.example',
+        ]
+        alias = models.Alias(
+            localpart='replace-list',
+            domain=domain,
+            destination=[
+                'old-one@outside.example',
+                'old-two@outside.example',
+            ],
+        )
+        models.db.session.add(alias)
+        models.db.session.commit()
+        resource_id = user.scim_resource.id
+        generation = user.auth_generation
+        data = _export_data()
+        user_data = next(
+            item for item in data['user']
+            if item['email'] == user.email
+        )
+        for field in (
+            'displayed_name',
+            'allow_spoofing',
+            'forward_enabled',
+            'forward_destination',
+        ):
+            user_data.pop(field, None)
+        alias_data = next(
+            item for item in data['alias']
+            if item['email'] == alias.email
+        )
+        alias_data['destination'] = ['new@outside.example']
+
+        _replace_import(data)
+
+        assert user.scim_resource.id == resource_id
+        assert user.auth_generation == generation
+        assert user.displayed_name == ''
+        assert user.allow_spoofing is False
+        assert user.forward_enabled is False
+        assert user.forward_destination == []
+        assert alias.destination == ['new@outside.example']
+
+
+def test_default_import_rejects_duplicate_canonical_keys(app):
+    with app.app_context():
+        user = _user('duplicate')
+        resource_id = user.scim_resource.id
+        data = _export_data()
+        duplicate = deepcopy(data['user'][0])
+        duplicate['email'] = duplicate['email'].upper()
+        data['user'].append(duplicate)
+
+        with pytest.raises(ValidationError, match='Duplicate email'):
+            _replace_import(data)
+        models.db.session.rollback()
+
+        assert models.db.session.get(models.User, user.email) is not None
+        assert models.ScimResource.get_exact(resource_id) is not None
+
+
+def test_default_import_rejects_duplicate_nested_token_identity(app):
+    with app.app_context():
+        first = _user('token-owner')
+        second = _user('token-target')
+        token = models.Token(user_email=first.email)
+        token.set_password('b' * 32)
+        models.db.session.add(token)
+        models.db.session.commit()
+        token_id = token.id
+        data = _export_data()
+        first_data = next(
+            item for item in data['user']
+            if item['email'] == first.email
+        )
+        second_data = next(
+            item for item in data['user']
+            if item['email'] == second.email
+        )
+        second_data.setdefault('tokens', []).append(
+            deepcopy(first_data['tokens'][0])
+        )
+
+        with pytest.raises(ValidationError, match='Duplicate id'):
+            _replace_import(data)
+        models.db.session.rollback()
+
+        restored = models.db.session.get(models.Token, token_id)
+        assert restored.user_email == first.email
+
+
+def test_default_import_rejects_duplicate_domain_alternative_owner(app):
+    with app.app_context():
+        first = _domain('first.example')
+        second = _domain('second.example')
+        alternative = models.Alternative(
+            name='shared-alt.example',
+            domain=first,
+        )
+        models.db.session.add(alternative)
+        models.db.session.commit()
+        data = _export_data()
+        second_data = next(
+            item for item in data['domain']
+            if item['name'] == second.name
+        )
+        second_data.setdefault('alternatives', []).append(
+            alternative.name.upper()
+        )
+
+        with pytest.raises(
+            ValidationError,
+            match='Duplicate related identity',
+        ):
+            _replace_import(data)
+        models.db.session.rollback()
+
+        restored = models.db.session.get(
+            models.Alternative,
+            alternative.name,
+        )
+        assert restored.domain_name == first.name
+
+
+def test_default_import_rejects_duplicate_domain_access_owner(app):
+    with app.app_context():
+        domain = _domain()
+        first = _user('grant-owner', domain=domain)
+        second = _user('grant-target', domain=domain)
+        access = models.DomainAccess(
+            domain=domain,
+            user=first,
+        )
+        models.db.session.add(access)
+        models.db.session.commit()
+        data = _export_data()
+        second_data = next(
+            item for item in data['user']
+            if item['email'] == second.email
+        )
+        second_data.setdefault('domain_accesses', []).append(access.id)
+
+        with pytest.raises(
+            ValidationError,
+            match='Duplicate related identity',
+        ):
+            _replace_import(data)
+        models.db.session.rollback()
+
+        restored = models.db.session.get(models.DomainAccess, access.id)
+        assert restored.user_email == first.email
+
+
+def test_default_import_preserves_idna_equivalent_primary_keys(app):
+    with app.app_context():
+        domain = _domain('täst.example')
+        user = _user('alice', domain=domain)
+        user_id = user.scim_resource.id
+        data = _export_data()
+        domain_data = next(
+            item for item in data['domain']
+            if item['name'] == domain.name
+        )
+        user_data = next(
+            item for item in data['user']
+            if item['email'] == user.email
+        )
+        domain_data['name'] = 'xn--tst-qla.example'
+        user_data['email'] = 'alice@xn--tst-qla.example'
+
+        _replace_import(data)
+
+        assert models.db.session.get(models.Domain, domain.name) is domain
+        assert models.db.session.get(models.User, user.email) is user
+        assert user.scim_resource.id == user_id
+
+
+def test_default_import_missing_required_password_is_validation_error(app):
+    with app.app_context():
+        user = _user('missing-password')
+        resource_id = user.scim_resource.id
+        data = _export_data()
+        data['user'][0].pop('password')
+
+        with pytest.raises(ValidationError) as error:
+            _replace_import(data)
+        models.db.session.rollback()
+
+        assert 'password' in str(error.value)
+        assert models.ScimResource.get_exact(resource_id) is not None
+
+
+def test_default_import_tombstones_absent_managed_group(app):
+    with app.app_context():
+        group, _member = _managed_group('protected-list')
+        data = _export_data()
+        data['alias'] = [
+            item for item in data['alias']
+            if item['email'] != group.alias_email
+        ]
+
+        source = RenderYAML.dumps(data)
+        group_id = group.id
+        alias_email = group.alias_email
+
+    result = _invoke(
+        app,
+        'config-import',
+        '--quiet',
+        '-',
+        input=source,
+    )
+    assert result.exit_code == 0, result.output
+
+    with app.app_context():
+        models.db.session.remove()
+        tombstone = models.ScimResource.get_exact(
+            group_id,
+            active_only=False,
+        )
+        assert tombstone.deleted_at is not None
+        assert tombstone.alias_email is None
+        assert models.db.session.get(
+            models.Alias,
+            alias_email,
+        ) is None
+
+
+def test_default_import_rejects_managed_group_mutation_atomically(app):
+    with app.app_context():
+        group, member = _managed_group('immutable-list')
+        data = _export_data()
+        alias_data = next(
+            item for item in data['alias']
+            if item['email'] == group.alias_email
+        )
+        alias_data['destination'] = ['changed@outside.example']
+        source = RenderYAML.dumps(data)
+        group_id = group.id
+        member_id = member.scim_resource.id
+
+    result = _invoke(
+        app,
+        'config-import',
+        '--quiet',
+        '-',
+        input=source,
+    )
+    assert result.exit_code != 0
+    assert 'provider-owned' in result.output
+
+    with app.app_context():
+        models.db.session.remove()
+        restored = models.ScimResource.get_exact(group_id)
+        assert restored.alias.destination == [
+            'member@example.com',
+            'pager@outside.example',
+        ]
+        assert [edge.member_id for edge in restored.member_edges] == [member_id]

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -1,0 +1,135 @@
+import flask
+import pytest
+
+from mailu import configuration, models
+
+
+def _configured_app(monkeypatch, database_uri, engine_options=None):
+    monkeypatch.setenv('DB_FLAVOR', '')
+    monkeypatch.setenv('SQLALCHEMY_DATABASE_URI', database_uri)
+    app = flask.Flask(__name__)
+    if engine_options is not None:
+        app.config['SQLALCHEMY_ENGINE_OPTIONS'] = engine_options
+    configuration.ConfigManager().init_app(app)
+    return app
+
+
+@pytest.mark.parametrize(
+    'database_uri',
+    [
+        'mysql+mysqlconnector://mailu:secret@database/mailu',
+        'mariadb+mariadbconnector://mailu:secret@database/mailu',
+    ],
+)
+def test_mysql_engine_uses_read_committed_and_preserves_options(
+    env_setup,
+    monkeypatch,
+    database_uri,
+):
+    app = _configured_app(
+        monkeypatch,
+        database_uri,
+        {
+            'isolation_level': 'SERIALIZABLE',
+            'pool_pre_ping': True,
+        },
+    )
+
+    assert app.config['SQLALCHEMY_ENGINE_OPTIONS'] == {
+        'isolation_level': 'READ COMMITTED',
+        'pool_pre_ping': True,
+    }
+
+
+@pytest.mark.parametrize(
+    'database_uri',
+    [
+        'sqlite:////data/main.db',
+        'postgresql://mailu:secret@database/mailu',
+    ],
+)
+def test_other_database_engines_keep_existing_options(
+    env_setup,
+    monkeypatch,
+    database_uri,
+):
+    app = _configured_app(
+        monkeypatch,
+        database_uri,
+        {'pool_pre_ping': True},
+    )
+
+    assert app.config['SQLALCHEMY_ENGINE_OPTIONS'] == {
+        'pool_pre_ping': True,
+    }
+
+
+def test_generated_mysql_database_uri_uses_read_committed(
+    env_setup,
+    monkeypatch,
+):
+    monkeypatch.setenv('DB_FLAVOR', 'mysql')
+    monkeypatch.setenv('DB_PW', 'secret')
+    app = flask.Flask(__name__)
+
+    configuration.ConfigManager().init_app(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'].startswith(
+        'mysql+mysqlconnector://',
+    )
+    assert app.config['SQLALCHEMY_ENGINE_OPTIONS'] == {
+        'isolation_level': 'READ COMMITTED',
+    }
+
+
+class _BinlogCursor:
+    def __init__(self, settings):
+        self.settings = settings
+        self.statement = None
+        self.closed = False
+
+    def execute(self, statement):
+        self.statement = statement
+
+    def fetchone(self):
+        return self.settings
+
+    def close(self):
+        self.closed = True
+
+
+class _BinlogConnection:
+    def __init__(self, settings):
+        self.cursor_instance = _BinlogCursor(settings)
+
+    def cursor(self):
+        return self.cursor_instance
+
+
+@pytest.mark.parametrize(
+    ('settings', 'blocked'),
+    [
+        ((0, 1, 'STATEMENT'), False),
+        ((1, 0, 'STATEMENT'), False),
+        ((1, 1, 'ROW'), False),
+        ((1, 1, 'MIXED'), False),
+        ((1, 1, 'STATEMENT'), True),
+    ],
+)
+def test_mysql_binlog_preflight_rejects_only_active_statement_logging(
+    settings,
+    blocked,
+):
+    connection = _BinlogConnection(settings)
+
+    if blocked:
+        with pytest.raises(RuntimeError, match='binlog_format=STATEMENT'):
+            models._reject_mysql_statement_binlog(connection, None)
+    else:
+        models._reject_mysql_statement_binlog(connection, None)
+
+    assert connection.cursor_instance.statement == (
+        'SELECT @@GLOBAL.log_bin, @@SESSION.sql_log_bin, '
+        '@@SESSION.binlog_format'
+    )
+    assert connection.cursor_instance.closed is True

--- a/tests/configuration_test.py
+++ b/tests/configuration_test.py
@@ -62,6 +62,37 @@ def test_other_database_engines_keep_existing_options(
     assert app.config['SQLALCHEMY_ENGINE_OPTIONS'] == {
         'pool_pre_ping': True,
     }
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == database_uri
+
+
+def test_generated_sqlite_database_uri_waits_for_concurrent_writer(
+    env_setup,
+    monkeypatch,
+):
+    monkeypatch.setenv('DB_FLAVOR', 'sqlite')
+    monkeypatch.setenv('SQLITE_DATABASE_FILE', 'data/main.db')
+    app = flask.Flask(__name__)
+
+    configuration.ConfigManager().init_app(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == (
+        'sqlite:////data/main.db?timeout=30'
+    )
+
+
+def test_default_sqlite_database_uri_waits_for_concurrent_writer(
+    env_setup,
+    monkeypatch,
+):
+    monkeypatch.setenv('DB_FLAVOR', '')
+    monkeypatch.delenv('SQLALCHEMY_DATABASE_URI')
+    app = flask.Flask(__name__)
+
+    configuration.ConfigManager().init_app(app)
+
+    assert app.config['SQLALCHEMY_DATABASE_URI'] == (
+        'sqlite:////data/main.db?timeout=30'
+    )
 
 
 def test_generated_mysql_database_uri_uses_read_committed(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,8 +31,8 @@ def app(env_setup):
         models.Base.metadata.create_all(bind=models.db.engine)
         yield app
         models.db.session.remove()
-        models.db.drop_all()
         models.Base.metadata.drop_all(bind=models.db.engine)
+        models.db.drop_all()
 
 
 @pytest.fixture

--- a/tests/scim_group_adopt_test.py
+++ b/tests/scim_group_adopt_test.py
@@ -1,0 +1,128 @@
+"""Focused tests for the explicit legacy-alias SCIM adoption command."""
+
+from mailu import models
+
+
+def _domain(name='example.com'):
+    domain = models.db.session.get(models.Domain, name)
+    if domain is None:
+        domain = models.Domain(name=name)
+        models.db.session.add(domain)
+        models.db.session.commit()
+    return domain
+
+
+def _user(localpart='member'):
+    user = models.User(localpart=localpart, domain=_domain())
+    user.set_password('not-a-real-password')
+    models.db.session.add(user)
+    models.db.session.commit()
+    return user
+
+
+def _alias(localpart, destination, **values):
+    alias = models.Alias(
+        localpart=localpart,
+        domain=_domain(),
+        destination=destination,
+        **values,
+    )
+    models.db.session.add(alias)
+    models.db.session.commit()
+    return alias
+
+
+def _invoke(app, *arguments):
+    return app.test_cli_runner().invoke(
+        args=['mailu', 'scim-group-adopt', *arguments],
+    )
+
+
+def test_adopt_normalizes_existing_routing_without_changing_delivery(app):
+    with app.app_context():
+        member = _user()
+        member_id = member.scim_resource.id
+        _alias(
+            'legacy-list',
+            ['member@example.com', 'pager@outside.example'],
+        )
+
+    result = _invoke(
+        app,
+        'legacy-list@example.com',
+        '--external-id',
+        'directory-group-7',
+    )
+    assert result.exit_code == 0, result.output
+
+    with app.app_context():
+        group = models.ScimResource.get_exact(
+            'legacy-list@example.com',
+            resource_type='Group',
+        )
+        assert group is not None
+        assert group.external_id == 'directory-group-7'
+        assert group.alias.destination == [
+            'member@example.com',
+            'pager@outside.example',
+        ]
+        assert [edge.member_id for edge in group.member_edges] == [member_id]
+        assert [
+            edge.destination for edge in group.destinations
+        ] == ['pager@outside.example']
+
+
+def test_adopt_is_one_shot_and_second_attempt_changes_nothing(app):
+    with app.app_context():
+        _alias('one-shot', ['pager@outside.example'])
+
+    first = _invoke(app, 'one-shot@example.com')
+    assert first.exit_code == 0, first.output
+
+    second = _invoke(app, 'one-shot@example.com')
+    assert second.exit_code != 0
+    assert 'already' in second.output.lower()
+
+    with app.app_context():
+        groups = models.ScimResource.query.filter_by(
+            resource_type='Group',
+            subject_address='one-shot@example.com',
+        ).all()
+        assert len(groups) == 1
+        assert groups[0].alias.destination == ['pager@outside.example']
+
+
+def test_adopt_rejects_ineligible_alias_and_rolls_back(app):
+    with app.app_context():
+        _alias(
+            'disabled',
+            ['pager@outside.example'],
+            disabled=True,
+        )
+
+    result = _invoke(app, 'disabled@example.com')
+    assert result.exit_code != 0
+
+    with app.app_context():
+        alias = models.db.session.get(models.Alias, 'disabled@example.com')
+        assert alias.scim_resource is None
+        assert alias.destination == ['pager@outside.example']
+
+
+def test_adopt_rejects_unmanaged_local_alias_destination_atomically(app):
+    with app.app_context():
+        _alias('unmanaged-member', ['pager@outside.example'])
+        _alias('candidate', ['unmanaged-member@example.com'])
+
+    result = _invoke(app, 'candidate@example.com')
+    assert result.exit_code != 0
+    assert 'not an active SCIM resource' in result.output
+
+    with app.app_context():
+        candidate = models.db.session.get(models.Alias, 'candidate@example.com')
+        assert candidate.scim_resource is None
+        assert candidate.destination == ['unmanaged-member@example.com']
+        assert models.ScimResource.query.filter_by(
+            resource_type='Group',
+            subject_address='candidate@example.com',
+        ).count() == 0

--- a/tests/scim_group_adopt_test.py
+++ b/tests/scim_group_adopt_test.py
@@ -1,6 +1,49 @@
 """Focused tests for the explicit legacy-alias SCIM adoption command."""
 
+import os
+import re
+import select
+import subprocess
+import sys
+
+import pytest
+from sqlalchemy.orm import Session
+
 from mailu import models
+
+
+GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group'
+GROUP_EXTENSION = 'https://mailu.io/schemas/scim/2.0/Group'
+UUID_PATTERN = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-'
+    r'[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+)
+ALIAS_UPDATE_PROCESS = r'''
+from mailu import configuration, create_app_from_config, models
+
+app = create_app_from_config(configuration.ConfigManager())
+app.config['TESTING'] = True
+with app.app_context():
+    original_lock = models.lock_scim_graph
+
+    def observed_lock(session=None):
+        print('LOCK_ATTEMPT', flush=True)
+        return original_lock(session)
+
+    models.lock_scim_graph = observed_lock
+    alias = models.db.session.get(models.Alias, 'lock-winner@example.com')
+    alias.destination = ['lost@outside.example']
+    try:
+        models.db.session.commit()
+    except models.ScimManagedAliasError as exc:
+        models.db.session.rollback()
+        print(f'REJECTED:{exc}', flush=True)
+    else:
+        print('UPDATED', flush=True)
+        raise SystemExit(2)
+    finally:
+        models.db.session.remove()
+'''
 
 
 def _domain(name='example.com'):
@@ -56,11 +99,13 @@ def test_adopt_normalizes_existing_routing_without_changing_delivery(app):
     assert result.exit_code == 0, result.output
 
     with app.app_context():
-        group = models.ScimResource.get_exact(
+        alias = models.db.session.get(
+            models.Alias,
             'legacy-list@example.com',
-            resource_type='Group',
         )
+        group = alias.scim_resource
         assert group is not None
+        assert UUID_PATTERN.fullmatch(group.id)
         assert group.external_id == 'directory-group-7'
         assert group.alias.destination == [
             'member@example.com',
@@ -126,3 +171,172 @@ def test_adopt_rejects_unmanaged_local_alias_destination_atomically(app):
             resource_type='Group',
             subject_address='candidate@example.com',
         ).count() == 0
+
+
+def test_adopt_uses_routing_committed_before_graph_lock(app, monkeypatch):
+    if models.db.engine.dialect.name == 'sqlite':
+        pytest.skip('requires native row locking')
+
+    with app.app_context():
+        _alias('fresh-snapshot', ['old@outside.example'])
+
+    original_create = models.create_scim_group_mapping
+
+    def create_after_concurrent_update(alias, **values):
+        with Session(models.db.engine) as writer:
+            current = writer.get(models.Alias, alias.email)
+            current.destination = ['new@outside.example']
+            writer.commit()
+        return original_create(alias, **values)
+
+    monkeypatch.setattr(
+        models,
+        'create_scim_group_mapping',
+        create_after_concurrent_update,
+    )
+
+    result = _invoke(app, 'fresh-snapshot@example.com')
+    assert result.exit_code == 0, result.output
+
+    with app.app_context():
+        alias = models.db.session.get(
+            models.Alias,
+            'fresh-snapshot@example.com',
+        )
+        assert alias.destination == ['new@outside.example']
+        assert [
+            edge.destination for edge in alias.scim_resource.destinations
+        ] == ['new@outside.example']
+
+
+def test_alias_update_losing_adoption_lock_is_rejected(app):
+    if models.db.engine.dialect.name == 'sqlite':
+        pytest.skip('requires native row locking')
+
+    session = models.db.session()
+    alias = _alias('lock-winner', ['kept@outside.example'])
+    group = models.create_scim_group_mapping(alias)
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[],
+        external_destinations=['kept@outside.example'],
+    )
+
+    writer = subprocess.Popen(
+        [sys.executable, '-c', ALIAS_UPDATE_PROCESS],
+        env=os.environ.copy(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    stdout = ''
+    stderr = ''
+    try:
+        ready, _, _ = select.select([writer.stdout], [], [], 15)
+        assert ready, 'concurrent Alias writer did not reach the graph lock'
+        assert writer.stdout.readline().strip() == 'LOCK_ATTEMPT'
+        session.commit()
+        stdout, stderr = writer.communicate(timeout=15)
+    finally:
+        if writer.poll() is None:
+            writer.kill()
+            stdout, stderr = writer.communicate()
+        if session.in_transaction():
+            session.rollback()
+
+    assert writer.returncode == 0, stderr
+    assert stdout.startswith('REJECTED:Alias lock-winner@example.com')
+    session.expire_all()
+    alias = session.get(models.Alias, 'lock-winner@example.com')
+    assert alias.destination == ['kept@outside.example']
+    assert [
+        edge.destination for edge in alias.scim_resource.destinations
+    ] == ['kept@outside.example']
+
+
+@pytest.mark.parametrize('origin', ['legacy-adopted', 'scim-created'])
+def test_deleted_group_address_can_be_readopted_with_new_id(
+    app,
+    client,
+    origin,
+):
+    address = f'{origin}@example.com'
+    with app.app_context():
+        _domain()
+        if origin == 'legacy-adopted':
+            _alias(origin, ['pager@outside.example'])
+
+    headers = {
+        'Authorization': f'Bearer {app.config["API_TOKEN"]}',
+        'Content-Type': 'application/scim+json',
+    }
+    if origin == 'legacy-adopted':
+        with app.app_context():
+            alias = models.db.session.get(models.Alias, address)
+            group = models.create_scim_group_mapping(
+                alias,
+                resource_id=address,
+            )
+            models.replace_scim_group_graph(
+                group,
+                member_ids=[],
+                external_destinations=['pager@outside.example'],
+            )
+            models.db.session.commit()
+            old_id = group.id
+            assert old_id == address
+    else:
+        response = client.post(
+            '/api/scim/v2/Groups',
+            json={
+                'schemas': [GROUP_SCHEMA, GROUP_EXTENSION],
+                'displayName': 'SCIM-created group',
+                'members': [],
+                GROUP_EXTENSION: {
+                    'aliasAddress': address,
+                    'externalDestinations': ['pager@outside.example'],
+                },
+            },
+            headers=headers,
+        )
+        assert response.status_code == 201, response.get_json()
+        old_id = response.get_json()['id']
+
+    response = client.delete(
+        f'/api/scim/v2/Groups/{old_id}',
+        headers=headers,
+    )
+    assert response.status_code == 204
+
+    with app.app_context():
+        assert models.db.session.get(models.Alias, address) is None
+        _alias(origin, ['replacement@outside.example'])
+
+    result = _invoke(app, address)
+    assert result.exit_code == 0, result.output
+
+    with app.app_context():
+        replacement = models.db.session.get(models.Alias, address).scim_resource
+        assert UUID_PATTERN.fullmatch(replacement.id)
+        assert replacement.id != old_id
+        replacement_id = replacement.id
+        assert replacement.subject_address == address
+        assert replacement.alias.destination == [
+            'replacement@outside.example'
+        ]
+        assert [
+            edge.destination for edge in replacement.destinations
+        ] == ['replacement@outside.example']
+        tombstone = models.db.session.get(models.ScimResource, old_id)
+        assert tombstone.deleted_at is not None
+
+    assert client.get(
+        f'/api/scim/v2/Groups/{old_id}',
+        headers=headers,
+    ).status_code == 404
+    response = client.get(
+        f'/api/scim/v2/Groups/{replacement_id}',
+        headers=headers,
+    )
+    assert response.status_code == 200
+    assert response.get_json()[GROUP_EXTENSION]['aliasAddress'] == address

--- a/tests/scim_identity_model_test.py
+++ b/tests/scim_identity_model_test.py
@@ -429,9 +429,24 @@ def test_external_destination_reservation_blocks_later_local_address(app):
     models.db.session.rollback()
 
 
-def test_mysql_external_reservation_sees_local_commit_after_old_snapshot(app):
-    if models.db.engine.dialect.name != 'mysql':
-        pytest.skip('requires MySQL/MariaDB REPEATABLE READ')
+def test_mysql_engine_uses_read_committed(app):
+    if models.db.engine.dialect.name not in {'mysql', 'mariadb'}:
+        pytest.skip('requires MySQL/MariaDB')
+
+    assert sa.event.contains(
+        models.db.engine,
+        'connect',
+        models._reject_mysql_statement_binlog,
+    )
+    assert (
+        models.db.session.connection().get_isolation_level()
+        == 'READ COMMITTED'
+    )
+
+
+def test_mysql_external_reservation_sees_local_commit_after_prior_read(app):
+    if models.db.engine.dialect.name not in {'mysql', 'mariadb'}:
+        pytest.skip('requires MySQL/MariaDB')
 
     group = _managed_group('snapshot-external')
     group_id = group.id
@@ -489,9 +504,9 @@ def test_mysql_external_reservation_sees_local_commit_after_old_snapshot(app):
     ).count() == 0
 
 
-def test_mysql_local_claim_sees_external_commit_after_old_snapshot(app):
-    if models.db.engine.dialect.name != 'mysql':
-        pytest.skip('requires MySQL/MariaDB REPEATABLE READ')
+def test_mysql_local_claim_sees_external_commit_after_prior_read(app):
+    if models.db.engine.dialect.name not in {'mysql', 'mariadb'}:
+        pytest.skip('requires MySQL/MariaDB')
 
     group = _managed_group('snapshot-local')
     group_id = group.id
@@ -531,6 +546,128 @@ def test_mysql_local_claim_sees_external_commit_after_old_snapshot(app):
     assert models.ScimGroupDestination.query.filter_by(
         destination='future@future.example',
     ).count() == 1
+
+
+def test_mysql_external_reservation_sees_local_delete_after_prior_read(app):
+    if models.db.engine.dialect.name not in {'mysql', 'mariadb'}:
+        pytest.skip('requires MySQL/MariaDB')
+
+    group = _managed_group('delete-external')
+    group_id = group.id
+    domain = _domain('future.example')
+    candidate = models.User(localpart='future', domain=domain)
+    candidate.set_password('not-a-real-password')
+    models.db.session.add(candidate)
+    models.db.session.commit()
+    models.db.session.remove()
+
+    snapshot_ready = threading.Event()
+    local_deleted = threading.Event()
+    outcome = []
+
+    def reserve_external():
+        with app.app_context():
+            try:
+                stale_group = models.db.session.get(
+                    models.ScimResource,
+                    group_id,
+                )
+                models.db.session.execute(sa.select(models.Domain)).all()
+                snapshot_ready.set()
+                assert local_deleted.wait(timeout=10)
+                models.replace_scim_group_graph(
+                    stale_group,
+                    member_ids=[],
+                    external_destinations=['future@future.example'],
+                )
+                models.db.session.commit()
+            except Exception as error:
+                models.db.session.rollback()
+                outcome.append(error)
+            else:
+                outcome.append('reserved')
+            finally:
+                models.db.session.remove()
+
+    worker = threading.Thread(target=reserve_external)
+    worker.start()
+    assert snapshot_ready.wait(timeout=10)
+
+    current = models.db.session.get(
+        models.User,
+        'future@future.example',
+    )
+    models.db.session.delete(current)
+    models.db.session.commit()
+    local_deleted.set()
+    worker.join(timeout=15)
+
+    assert not worker.is_alive()
+    assert outcome == ['reserved']
+    assert models.db.session.get(
+        models.User,
+        'future@future.example',
+    ) is None
+    assert models.ScimGroupDestination.query.filter_by(
+        destination='future@future.example',
+    ).count() == 1
+
+
+def test_mysql_local_claim_sees_external_delete_after_prior_read(app):
+    if models.db.engine.dialect.name not in {'mysql', 'mariadb'}:
+        pytest.skip('requires MySQL/MariaDB')
+
+    group = _managed_group('delete-local')
+    group_id = group.id
+    domain = _domain('future.example')
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[],
+        external_destinations=['future@future.example'],
+    )
+    models.db.session.commit()
+    models.db.session.execute(sa.select(models.Domain)).all()
+    outcome = []
+
+    def remove_external():
+        with app.app_context():
+            try:
+                current_group = models.db.session.get(
+                    models.ScimResource,
+                    group_id,
+                )
+                models.replace_scim_group_graph(
+                    current_group,
+                    member_ids=[],
+                    external_destinations=[],
+                )
+                models.db.session.commit()
+            except Exception as error:
+                models.db.session.rollback()
+                outcome.append(error)
+            else:
+                outcome.append('removed')
+            finally:
+                models.db.session.remove()
+
+    worker = threading.Thread(target=remove_external)
+    worker.start()
+    worker.join(timeout=15)
+    assert not worker.is_alive()
+    assert outcome == ['removed']
+
+    candidate = models.User(localpart='future', domain=domain)
+    candidate.set_password('not-a-real-password')
+    models.db.session.add(candidate)
+    models.db.session.commit()
+
+    assert models.db.session.get(
+        models.User,
+        'future@future.example',
+    ) is not None
+    assert models.ScimGroupDestination.query.filter_by(
+        destination='future@future.example',
+    ).count() == 0
 
 
 def test_group_cycle_is_rejected_before_materialization(app):

--- a/tests/scim_identity_model_test.py
+++ b/tests/scim_identity_model_test.py
@@ -1,0 +1,777 @@
+"""Focused model and migration tests for persistent SCIM identity.
+
+These tests deliberately stay below the HTTP API.  They prove that identity,
+graph, deletion, and authority invariants exist at the model/migration layer
+instead of depending on one endpoint remembering a convention.
+"""
+
+import importlib.util
+import pathlib
+import re
+import threading
+import unicodedata
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy.exc import IntegrityError
+
+from mailu import models, utils
+
+
+MIGRATIONS = pathlib.Path(models.__file__).resolve().parent.parent / 'migrations' / 'versions'
+IDENTITY_MIGRATION = MIGRATIONS / 'e7c9a4f2b631_.py'
+ADDRESS_MIGRATION = MIGRATIONS / 'd4a6f2b8c901_.py'
+UUID_PATTERN = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-'
+    r'[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+)
+
+
+def _domain(name='example.com'):
+    domain = models.db.session.get(models.Domain, name)
+    if domain is None:
+        domain = models.Domain(name=name)
+        models.db.session.add(domain)
+        models.db.session.commit()
+    return domain
+
+
+def _user(localpart, domain=None):
+    user = models.User(localpart=localpart, domain=domain or _domain())
+    user.set_password('not-a-real-password')
+    models.db.session.add(user)
+    models.db.session.commit()
+    return user
+
+
+def _alias(localpart, *, domain=None, destination=None, **values):
+    alias = models.Alias(
+        localpart=localpart,
+        domain=domain or _domain(),
+        destination=destination or ['outside@example.net'],
+        **values,
+    )
+    models.db.session.add(alias)
+    models.db.session.commit()
+    return alias
+
+
+def _managed_group(localpart, *, destination=None):
+    alias = _alias(localpart, destination=destination)
+    resource = models.ScimResource(
+        id=models.new_scim_id(),
+        resource_type='Group',
+        alias_email=alias.email,
+        subject_address=alias.email,
+    )
+    models.db.session.add(resource)
+    models.db.session.commit()
+    return resource
+
+
+def test_sqlite_foreign_keys_are_enabled_without_fixture_pragma(app):
+    engine = sa.create_engine('sqlite://')
+    try:
+        with engine.connect() as connection:
+            assert connection.exec_driver_sql(
+                'PRAGMA foreign_keys'
+            ).scalar_one() == 1
+    finally:
+        engine.dispose()
+
+
+def test_address_conflict_preserves_integrity_error_contract():
+    assert issubclass(models.AddressConflict, IntegrityError)
+
+
+def test_new_orm_user_gets_random_generation_and_uuid_mapping(app):
+    user = _user('new-identity')
+    mapping = models.ScimResource.query.filter_by(
+        resource_type='User',
+        user_email=user.email,
+        deleted_at=None,
+    ).one()
+
+    assert user.auth_generation != utils.INITIAL_AUTH_GENERATION
+    assert re.fullmatch(r'[0-9a-f]{32}', user.auth_generation)
+    assert UUID_PATTERN.fullmatch(mapping.id)
+    assert mapping.subject_address == user.email
+    assert mapping.external_id is None
+    assert models.db.session.get(models.ScimState, 1).revision == 0
+
+
+def test_user_mapping_helper_reuses_automatic_mapping(app):
+    user = _user('mapping-helper')
+    automatic = user.scim_resource
+
+    assert models.create_scim_user_mapping(
+        user,
+        external_id='upstream-42',
+    ) is automatic
+    assert automatic.external_id == 'upstream-42'
+    assert models.create_scim_user_mapping(
+        user,
+        resource_id=automatic.id,
+    ) is automatic
+    with pytest.raises(models.ScimIdentityError, match='different'):
+        models.create_scim_user_mapping(
+            user,
+            resource_id=models.new_scim_id(),
+        )
+
+
+def test_hard_delete_recreate_cannot_reuse_identity_or_session_generation(app):
+    user = _user('recreated')
+    old_generation = user.auth_generation
+    old_mapping = user.scim_resource
+    old_id = old_mapping.id
+
+    models.db.session.delete(user)
+    models.db.session.commit()
+
+    tombstone = models.db.session.get(models.ScimResource, old_id)
+    assert tombstone.deleted_at is not None
+    assert tombstone.user_email is None
+    assert tombstone.subject_address == 'recreated@example.com'
+
+    replacement = _user('recreated')
+    assert replacement.auth_generation != old_generation
+    assert replacement.scim_resource.id != old_id
+    assert models.db.session.get(models.ScimResource, old_id) is tombstone
+
+
+def test_external_id_is_byte_exact_and_bounded(app):
+    user = _user('external-id')
+    mapping = user.scim_resource
+
+    mapping.external_id = 'Case-Sensitive-é'
+    models.db.session.commit()
+    assert mapping.external_id == 'Case-Sensitive-é'
+    assert mapping.external_id_bytes == 'Case-Sensitive-é'.encode()
+
+    mapping.external_id = 'a' * 1024
+    assert len(mapping.external_id_bytes) == 1024
+    with pytest.raises(ValueError, match='1024'):
+        mapping.external_id = 'é' * 513
+    with pytest.raises(TypeError):
+        mapping.external_id = b'not-a-string'
+
+
+def test_exact_provider_id_lookup_rejects_case_variant(app):
+    user = _user('exact-id')
+    mapping = user.scim_resource
+
+    assert models.ScimResource.get_exact(mapping.id) is mapping
+    assert models.ScimResource.get_exact(mapping.id.upper()) is None
+
+
+def test_scim_resource_hard_delete_is_rejected(app):
+    user = _user('immutable-tombstone')
+    resource_id = user.scim_resource.id
+
+    models.db.session.delete(user.scim_resource)
+    with pytest.raises(models.ScimIdentityError, match='tombstone'):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    assert models.ScimResource.get_exact(resource_id) is not None
+
+
+def test_scim_resource_principal_binding_is_immutable(app):
+    alice = _user('binding-alice')
+    bob = _user('binding-bob')
+    mapping = alice.scim_resource
+
+    mapping.user = bob
+    with pytest.raises(models.ScimIdentityError, match='binding'):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    assert mapping.user_email == alice.email
+
+
+def test_scim_tombstone_cannot_be_resurrected_or_edited(app):
+    user = _user('immutable-deleted-resource')
+    mapping = user.scim_resource
+    original_external_id = mapping.external_id
+    models.tombstone_scim_resource(mapping, retain_subject=True)
+    models.db.session.commit()
+    deleted_at = mapping.deleted_at
+
+    mapping.deleted_at = None
+    mapping.user = user
+    mapping.external_id = 'changed-after-delete'
+    with pytest.raises(models.ScimIdentityError, match='tombstone'):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    assert mapping.deleted_at == deleted_at
+    assert mapping.user_email is None
+    assert mapping.external_id == original_external_id
+
+
+def test_scim_tombstone_scrubs_retained_user_authority(app):
+    user = _user('authority')
+    user_domain = user.domain
+    user.global_admin = True
+    user.allow_spoofing = True
+    user.forward_enabled = True
+    user.forward_destination = ['old-owner@example.net']
+    user.reply_enabled = True
+    managed_domain = _domain('managed.example')
+    models.db.session.execute(
+        models.managers.insert().values(
+            domain_name=managed_domain.name,
+            user_email=user.email,
+        )
+    )
+    token = models.Token(user=user)
+    token.set_password('a' * 32)
+    access = models.DomainAccess(
+        domain_name='managed.example',
+        user=user,
+    )
+    owned_alias = models.Alias(
+        localpart='old-owner-alias',
+        domain=user_domain,
+        owner=user,
+        destination=[user.email],
+    )
+    fetch = models.Fetch(
+        user=user,
+        protocol='imap',
+        host='mail.old-owner.example',
+        port=993,
+        tls=True,
+        username='old-owner',
+        password='remote-secret',
+    )
+    models.db.session.add_all([token, access, owned_alias, fetch])
+    models.db.session.commit()
+    mapping = user.scim_resource
+
+    models.tombstone_scim_resource(
+        mapping,
+        retain_subject=True,
+        scrub_user_authority=True,
+    )
+    models.db.session.commit()
+
+    assert mapping.deleted_at is not None
+    assert mapping.user_email is None
+    assert user.enabled is False
+    assert user.global_admin is False
+    assert user.allow_spoofing is False
+    assert user.forward_enabled is False
+    assert user.forward_destination == []
+    assert user.reply_enabled is False
+    assert models.Token.query.filter_by(user_email=user.email).count() == 0
+    assert models.Fetch.query.filter_by(user_email=user.email).count() == 0
+    assert models.Alias.query.filter_by(owner_email=user.email).count() == 0
+    assert models.DomainAccess.query.filter_by(user_email=user.email).count() == 0
+    assert models.db.session.execute(
+        sa.select(sa.func.count()).select_from(models.managers).where(
+            models.managers.c.user_email == user.email
+        )
+    ).scalar_one() == 0
+
+
+def test_deleted_user_address_cannot_receive_a_new_scim_identity(app):
+    user = _user('reserved-authority')
+    mapping = user.scim_resource
+
+    models.tombstone_scim_resource(
+        mapping,
+        retain_subject=True,
+        scrub_user_authority=True,
+    )
+    models.db.session.commit()
+
+    with pytest.raises(
+        models.ScimIdentityError,
+        match='permanently reserved',
+    ):
+        models.create_scim_user_mapping(user)
+
+
+@pytest.mark.parametrize(
+    'values',
+    [
+        {'disabled': True},
+        {'wildcard': True},
+    ],
+)
+def test_group_adoption_rejects_ineligible_alias_state(app, values):
+    alias = _alias('ineligible', **values)
+    with pytest.raises(models.ScimGroupAdoptionError):
+        models.validate_scim_group_adoption(alias)
+
+
+def test_group_adoption_rejects_owned_alias(app):
+    owner = _user('owner')
+    alias = _alias('owned', owner=owner)
+    with pytest.raises(models.ScimGroupAdoptionError):
+        models.validate_scim_group_adoption(alias)
+
+
+def test_managed_alias_ordinary_edit_is_blocked_but_one_shot_edit_is_allowed(app):
+    group = _managed_group('managed-edit')
+    alias = group.alias
+
+    alias.comment = 'ordinary edit'
+    with pytest.raises(models.ScimManagedAliasError):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    alias = models.db.session.get(models.Alias, 'managed-edit@example.com')
+    models.permit_scim_managed_alias_edit(alias)
+    alias.comment = 'SCIM edit'
+    models.db.session.commit()
+    assert alias.comment == 'SCIM edit'
+
+
+def test_managed_alias_destination_edit_is_blocked(app):
+    group = _managed_group('managed-destination')
+    alias = group.alias
+
+    alias.destination = ['other@example.net']
+    with pytest.raises(models.ScimManagedAliasError):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+
+def test_managed_alias_ordinary_delete_is_blocked(app):
+    group = _managed_group('managed-delete')
+    resource_id = group.id
+    alias_email = group.alias.email
+
+    models.db.session.delete(group.alias)
+    with pytest.raises(models.ScimManagedAliasError):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    assert models.db.session.get(models.Alias, alias_email) is not None
+    assert models.ScimResource.get_exact(resource_id) is not None
+
+
+def test_managed_alias_edit_permit_does_not_survive_rollback(app):
+    group = _managed_group('managed-rollback')
+    alias = group.alias
+    models.permit_scim_managed_alias_edit(alias)
+    alias.comment = 'permitted but rolled back'
+    models.db.session.rollback()
+
+    alias = models.db.session.get(models.Alias, alias.email)
+    alias.comment = 'ordinary edit after rollback'
+    with pytest.raises(models.ScimManagedAliasError):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+
+def test_graph_materialization_uses_ids_and_rejects_local_external_values(app):
+    member = _user('member')
+    group = _managed_group('graph')
+
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[member.scim_resource.id],
+        external_destinations=['pager@outside.test'],
+    )
+    models.db.session.commit()
+
+    assert group.alias.destination == [
+        'member@example.com',
+        'pager@outside.test',
+    ]
+    assert {(edge.group_id, edge.member_id) for edge in group.member_edges} == {
+        (group.id, member.scim_resource.id)
+    }
+
+    with pytest.raises(models.ScimExternalDestinationError):
+        models.replace_scim_group_graph(
+            group,
+            member_ids=[],
+            external_destinations=['member@example.com'],
+        )
+    models.db.session.rollback()
+
+
+@pytest.mark.parametrize(
+    'destination',
+    [
+        'foo bar@example.com',
+        'foo..bar@example.com',
+        '.foo@example.com',
+    ],
+)
+def test_external_destination_rejects_malformed_localpart(app, destination):
+    with pytest.raises(models.ScimExternalDestinationError):
+        models.canonicalize_scim_destination(destination)
+
+
+def test_external_destination_reservation_blocks_later_local_address(app):
+    group = _managed_group('external-reservation')
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[],
+        external_destinations=['future@future.example'],
+    )
+    models.db.session.commit()
+
+    domain = _domain('future.example')
+    candidate = models.User(localpart='future', domain=domain)
+    candidate.set_password('not-a-real-password')
+    models.db.session.add(candidate)
+    with pytest.raises(models.AddressConflict):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+
+def test_mysql_external_reservation_sees_local_commit_after_old_snapshot(app):
+    if models.db.engine.dialect.name != 'mysql':
+        pytest.skip('requires MySQL/MariaDB REPEATABLE READ')
+
+    group = _managed_group('snapshot-external')
+    group_id = group.id
+    _domain('future.example')
+    models.db.session.remove()
+
+    snapshot_ready = threading.Event()
+    local_committed = threading.Event()
+    outcome = []
+
+    def reserve_external():
+        with app.app_context():
+            stale_group = models.db.session.get(
+                models.ScimResource,
+                group_id,
+            )
+            models.db.session.execute(sa.select(models.Domain)).all()
+            snapshot_ready.set()
+            assert local_committed.wait(timeout=10)
+            try:
+                models.replace_scim_group_graph(
+                    stale_group,
+                    member_ids=[],
+                    external_destinations=['future@future.example'],
+                )
+                models.db.session.commit()
+            except models.ScimExternalDestinationError:
+                models.db.session.rollback()
+                outcome.append('conflict')
+            else:
+                outcome.append('reserved')
+            finally:
+                models.db.session.remove()
+
+    worker = threading.Thread(target=reserve_external)
+    worker.start()
+    assert snapshot_ready.wait(timeout=10)
+
+    domain = models.db.session.get(models.Domain, 'future.example')
+    candidate = models.User(localpart='future', domain=domain)
+    candidate.set_password('not-a-real-password')
+    models.db.session.add(candidate)
+    models.db.session.commit()
+    local_committed.set()
+    worker.join(timeout=15)
+
+    assert not worker.is_alive()
+    assert outcome == ['conflict']
+    assert models.db.session.get(
+        models.User,
+        'future@future.example',
+    ) is not None
+    assert models.ScimGroupDestination.query.filter_by(
+        destination='future@future.example',
+    ).count() == 0
+
+
+def test_mysql_local_claim_sees_external_commit_after_old_snapshot(app):
+    if models.db.engine.dialect.name != 'mysql':
+        pytest.skip('requires MySQL/MariaDB REPEATABLE READ')
+
+    group = _managed_group('snapshot-local')
+    group_id = group.id
+    domain = _domain('future.example')
+    models.db.session.execute(sa.select(models.Domain)).all()
+
+    def reserve_external():
+        with app.app_context():
+            current_group = models.db.session.get(
+                models.ScimResource,
+                group_id,
+            )
+            models.replace_scim_group_graph(
+                current_group,
+                member_ids=[],
+                external_destinations=['future@future.example'],
+            )
+            models.db.session.commit()
+            models.db.session.remove()
+
+    worker = threading.Thread(target=reserve_external)
+    worker.start()
+    worker.join(timeout=15)
+    assert not worker.is_alive()
+
+    candidate = models.User(localpart='future', domain=domain)
+    candidate.set_password('not-a-real-password')
+    models.db.session.add(candidate)
+    with pytest.raises(models.AddressConflict):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+    assert models.db.session.get(
+        models.User,
+        'future@future.example',
+    ) is None
+    assert models.ScimGroupDestination.query.filter_by(
+        destination='future@future.example',
+    ).count() == 1
+
+
+def test_group_cycle_is_rejected_before_materialization(app):
+    first = _managed_group('cycle-a')
+    second = _managed_group('cycle-b')
+    original_projection = list(first.alias.destination)
+    models.replace_scim_group_graph(
+        second,
+        member_ids=[first.id],
+        external_destinations=[],
+    )
+    models.db.session.commit()
+
+    with pytest.raises(models.ScimGraphError):
+        models.replace_scim_group_graph(
+            first,
+            member_ids=[second.id],
+            external_destinations=[],
+        )
+    models.db.session.rollback()
+    assert first.alias.destination == original_projection
+
+
+def test_hard_deleted_member_is_tombstoned_and_removed_from_group(app):
+    member = _user('departing')
+    member_id = member.scim_resource.id
+    group = _managed_group('member-delete')
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[member_id],
+        external_destinations=['outside@example.net'],
+    )
+    models.db.session.commit()
+
+    models.db.session.delete(member)
+    models.db.session.commit()
+
+    tombstone = models.db.session.get(models.ScimResource, member_id)
+    assert tombstone.deleted_at is not None
+    assert models.ScimGroupMember.query.filter_by(member_id=member_id).count() == 0
+    assert group.alias.destination == ['outside@example.net']
+
+
+def _load_migration(path, module_name):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _identity_legacy_engine():
+    engine = sa.create_engine('sqlite://')
+    metadata = sa.MetaData()
+    sa.Table(
+        'user',
+        metadata,
+        sa.Column('email', sa.String(255), primary_key=True),
+        sa.Column('created_at', sa.Date, nullable=False),
+        sa.Column('updated_at', sa.Date),
+    )
+    sa.Table(
+        'alias',
+        metadata,
+        sa.Column('email', sa.String(255), primary_key=True),
+        sa.Column(
+            'owner_email',
+            sa.String(255),
+            sa.ForeignKey('user.email'),
+        ),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            "INSERT INTO user (email, created_at, updated_at) VALUES "
+            "('alice@example.com', '2024-01-02', NULL),"
+            "('idna@xn--bcher-kva.example', '2024-01-03', '2024-01-04')"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO alias (email, owner_email) VALUES "
+            "('ordinary@example.com', 'alice@example.com')"
+        )
+    return engine
+
+
+def _run_migration(engine, operation, *, destructive=False):
+    migration = _load_migration(
+        IDENTITY_MIGRATION,
+        f'scim_identity_migration_{operation}_{destructive}',
+    )
+    x_arguments = []
+    if destructive:
+        x_arguments = [
+            'allow_destructive_scim_identity=true',
+            'scim_identity_exported=true',
+        ]
+    with engine.connect() as connection:
+        context = MigrationContext.configure(
+            connection,
+            opts={'x_argument': x_arguments},
+        )
+        migration.op = Operations(context)
+        with connection.begin():
+            getattr(migration, operation)()
+
+
+def test_identity_migration_backfills_users_only_and_gates_downgrade():
+    engine = _identity_legacy_engine()
+    _run_migration(engine, 'upgrade')
+
+    inspector = sa.inspect(engine)
+    assert {
+        'scim_state',
+        'scim_resource',
+        'scim_group_member',
+        'scim_group_destination',
+    } <= set(inspector.get_table_names())
+    assert 'auth_generation' in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql(
+            'SELECT id, resource_type, user_email, alias_email '
+            'FROM scim_resource ORDER BY user_email'
+        ).all() == [
+            ('alice@example.com', 'User', 'alice@example.com', None),
+            (
+                'idna@bücher.example',
+                'User',
+                'idna@xn--bcher-kva.example',
+                None,
+            ),
+        ]
+        assert connection.exec_driver_sql(
+            "SELECT COUNT(*) FROM scim_resource WHERE resource_type='Group'"
+        ).scalar_one() == 0
+        assert connection.exec_driver_sql(
+            'SELECT id, revision FROM scim_state'
+        ).all() == [(1, 0)]
+        assert set(connection.exec_driver_sql(
+            'SELECT auth_generation FROM user'
+        ).scalars()) == {utils.INITIAL_AUTH_GENERATION}
+        assert connection.exec_driver_sql(
+            'PRAGMA foreign_key_check'
+        ).all() == []
+
+    with pytest.raises(RuntimeError, match='identity export'):
+        _run_migration(engine, 'downgrade')
+    assert 'scim_resource' in sa.inspect(engine).get_table_names()
+
+    _run_migration(engine, 'downgrade', destructive=True)
+    inspector = sa.inspect(engine)
+    assert 'scim_resource' not in inspector.get_table_names()
+    assert 'auth_generation' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql(
+            'SELECT email, owner_email FROM alias'
+        ).all() == [('ordinary@example.com', 'alice@example.com')]
+        assert connection.exec_driver_sql(
+            'PRAGMA foreign_key_check'
+        ).all() == []
+    engine.dispose()
+
+
+def test_address_preflight_uses_native_database_collation():
+    engine = sa.create_engine('sqlite://')
+
+    def accent_insensitive(left, right):
+        def normalized(value):
+            decomposed = unicodedata.normalize('NFKD', value)
+            return ''.join(
+                char for char in decomposed
+                if not unicodedata.combining(char)
+            ).casefold()
+
+        return (normalized(left) > normalized(right)) - (
+            normalized(left) < normalized(right)
+        )
+
+    @sa.event.listens_for(engine, 'connect')
+    def install_collation(connection, _record):
+        connection.create_collation('mailu_ai', accent_insensitive)
+
+    metadata = sa.MetaData()
+    sa.Table(
+        'user',
+        metadata,
+        sa.Column(
+            'email',
+            sa.String(255, collation='mailu_ai'),
+            primary_key=True,
+        ),
+    )
+    sa.Table(
+        'alias',
+        metadata,
+        sa.Column(
+            'email',
+            sa.String(255, collation='mailu_ai'),
+            primary_key=True,
+        ),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as connection:
+        connection.exec_driver_sql(
+            "INSERT INTO user (email) VALUES ('cafe@example.com')"
+        )
+        connection.exec_driver_sql(
+            "INSERT INTO alias (email) VALUES ('café@example.com')"
+        )
+
+    migration = _load_migration(
+        ADDRESS_MIGRATION,
+        'address_native_collation_preflight',
+    )
+    with engine.connect() as connection:
+        collisions = migration._cross_table_collisions(connection)
+    assert collisions == [
+        ('cafe@example.com', 'cafe@example.com', 'café@example.com')
+    ]
+    engine.dispose()
+
+
+def test_address_migration_rebuilds_inbound_user_fks_only_on_sqlite():
+    migration = _load_migration(
+        ADDRESS_MIGRATION,
+        'mail_address_backend_branching',
+    )
+
+    class Connection:
+        def __init__(self, dialect_name):
+            self.dialect = type('Dialect', (), {'name': dialect_name})()
+
+    assert migration._requires_sqlite_reference_rebuild(
+        Connection('sqlite')
+    ) is True
+    assert migration._requires_sqlite_reference_rebuild(
+        Connection('postgresql')
+    ) is False
+    assert migration._requires_sqlite_reference_rebuild(
+        Connection('mariadb')
+    ) is False

--- a/tests/scim_identity_model_test.py
+++ b/tests/scim_identity_model_test.py
@@ -1065,7 +1065,7 @@ def test_mysql_local_claim_sees_external_delete_after_prior_read(app):
     ).count() == 0
 
 
-def test_cycle_frontier_preserves_cycle_semantics_and_exact_ids(app):
+def test_cycle_full_scan_preserves_cycle_semantics_and_exact_ids(app):
     edges = [
         ('two:parent', 'two:target'),
         ('diamond:left', 'diamond:target'),
@@ -1136,7 +1136,7 @@ def test_cycle_frontier_preserves_cycle_semantics_and_exact_ids(app):
     )
 
 
-def test_cycle_frontier_shallow_sql_ignores_unrelated_edges(app):
+def test_cycle_full_scan_reads_one_complete_locked_snapshot(app):
     unrelated_ids = [
         f'unrelated:{index:04d}'
         for index in range(1025)
@@ -1158,19 +1158,12 @@ def test_cycle_frontier_shallow_sql_ignores_unrelated_edges(app):
         )
 
     cycle_statements = _cycle_statements(statements)
-    assert len(cycle_statements) == 3
-    assert all(
-        ' where scim_group_member.member_id in ' in statement
-        and 'scim_group_member.group_id !=' in statement
-        for statement, _bound_strings in cycle_statements
-    )
-    assert all(
-        set(bound_strings).isdisjoint(unrelated_ids)
-        for _statement, bound_strings in cycle_statements
-    )
+    assert len(cycle_statements) == 1
+    assert ' where ' not in cycle_statements[0][0]
+    assert cycle_statements[0][1] == ()
 
 
-def test_cycle_frontier_chunks_wide_fan_in_at_500_values(app):
+def test_cycle_full_scan_handles_wide_fan_in_in_one_query(app):
     parent_ids = [
         f'wide:parent:{index:04d}'
         for index in range(1201)
@@ -1180,35 +1173,34 @@ def test_cycle_frontier_chunks_wide_fan_in_at_500_values(app):
         extra_ids={'wide:outside'},
     )
 
-    with _captured_sql() as statements:
+    with _captured_sql() as safe_statements:
         models._validate_scim_cycle(
             SimpleNamespace(id='wide:target'),
             ['wide:outside'],
         )
 
-    cycle_statements = _cycle_statements(statements)
-    assert len(cycle_statements) == 4
-    assert all(
-        ' where scim_group_member.member_id in ' in statement
-        and 'scim_group_member.group_id !=' in statement
-        for statement, _bound_strings in cycle_statements
-    )
-    parent_id_set = set(parent_ids)
-    chunk_sizes = [
-        len(parent_id_set.intersection(bound_strings))
-        for _statement, bound_strings in cycle_statements[1:]
-    ]
-    assert chunk_sizes == [500, 500, 201]
-    assert all(
-        size <= models._SCIM_GRAPH_PROBE_CHUNK_SIZE
-        for size in chunk_sizes
-    )
+    with _captured_sql() as cycle_statements:
+        with pytest.raises(
+            models.ScimGraphError,
+            match=re.escape('SCIM Group membership would create a cycle'),
+        ):
+            models._validate_scim_cycle(
+                SimpleNamespace(id='wide:target'),
+                [parent_ids[-1]],
+            )
+
+    for statements in (safe_statements, cycle_statements):
+        cycle_queries = _cycle_statements(statements)
+        assert len(cycle_queries) == 1
+        assert ' where ' not in cycle_queries[0][0]
+        assert cycle_queries[0][1] == ()
 
 
-def test_cycle_frontier_fallback_is_iterative_correct_and_capped(app):
+@pytest.mark.parametrize('depth', [999, 1000, 1001, 2500, 10000])
+def test_cycle_full_scan_is_iterative_at_depth_boundaries(app, depth):
     parent_ids = [
-        f'deep:parent:{index:04d}'
-        for index in range(1105)
+        f'deep:parent:{index:05d}'
+        for index in range(depth)
     ]
     edges = [
         (parent_ids[0], 'deep:target'),
@@ -1237,24 +1229,12 @@ def test_cycle_frontier_fallback_is_iterative_correct_and_capped(app):
 
     for statements in (cyclic_statements, acyclic_statements):
         cycle_statements = _cycle_statements(statements)
-        probes = [
-            entry
-            for entry in cycle_statements
-            if ' where scim_group_member.member_id in ' in entry[0]
-            and 'scim_group_member.group_id !=' in entry[0]
-        ]
-        fallback = [
-            entry
-            for entry in cycle_statements
-            if ' where ' not in entry[0]
-        ]
-        assert len(probes) == 64
-        assert len(fallback) == 1
-        assert len(cycle_statements) == 65
-        assert cycle_statements[-1] == fallback[0]
+        assert len(cycle_statements) == 1
+        assert ' where ' not in cycle_statements[0][0]
+        assert cycle_statements[0][1] == ()
 
 
-def test_cycle_frontier_rejection_preserves_old_graph_and_projection(app):
+def test_cycle_full_scan_rejection_preserves_old_graph_and_projection(app):
     original_member = _user('cycle-original')
     first = _managed_group('cycle-a')
     second = _managed_group('cycle-b')

--- a/tests/scim_identity_model_test.py
+++ b/tests/scim_identity_model_test.py
@@ -10,6 +10,7 @@ import pathlib
 import re
 import threading
 import unicodedata
+from contextlib import contextmanager
 
 import pytest
 import sqlalchemy as sa
@@ -69,6 +70,49 @@ def _managed_group(localpart, *, destination=None):
     models.db.session.add(resource)
     models.db.session.commit()
     return resource
+
+
+@contextmanager
+def _captured_sql():
+    statements = []
+
+    def capture(_conn, _cursor, statement, _parameters, context, _executemany):
+        bound_strings = tuple(
+            value
+            for parameter_set in context.compiled_parameters
+            for value in parameter_set.values()
+            if isinstance(value, str)
+        )
+        statements.append((
+            ' '.join(statement.lower().split()),
+            bound_strings,
+        ))
+
+    sa.event.listen(models.db.engine, 'before_cursor_execute', capture)
+    try:
+        yield statements
+    finally:
+        sa.event.remove(models.db.engine, 'before_cursor_execute', capture)
+
+
+def _group_graph_snapshot(group_id):
+    group = models.db.session.get(models.ScimResource, group_id)
+    alias = models.db.session.get(models.Alias, group.alias_email)
+    return {
+        'alias_comment': alias.comment,
+        'alias_destination': tuple(alias.destination),
+        'destinations': tuple(models.db.session.execute(
+            sa.select(models.ScimGroupDestination.destination)
+            .where(models.ScimGroupDestination.group_id == group_id)
+            .order_by(models.ScimGroupDestination.destination)
+        ).scalars()),
+        'external_id': group.external_id,
+        'members': tuple(models.db.session.execute(
+            sa.select(models.ScimGroupMember.member_id)
+            .where(models.ScimGroupMember.group_id == group_id)
+            .order_by(models.ScimGroupMember.member_id)
+        ).scalars()),
+    }
 
 
 def test_sqlite_foreign_keys_are_enabled_without_fixture_pragma(app):
@@ -375,6 +419,270 @@ def test_managed_alias_edit_permit_does_not_survive_rollback(app):
 
     alias = models.db.session.get(models.Alias, alias.email)
     alias.comment = 'ordinary edit after rollback'
+    with pytest.raises(models.ScimManagedAliasError):
+        models.db.session.commit()
+    models.db.session.rollback()
+
+
+@pytest.mark.parametrize('population', [1, 8])
+def test_graph_validation_probe_count_is_population_independent(
+    app,
+    population,
+):
+    members = [
+        _user(f'batched-member-{population}-{index}')
+        for index in range(population)
+    ]
+    member_ids = [member.scim_resource.id for member in members]
+    group = _managed_group(f'batched-group-{population}')
+    assert group.alias is not None
+    destinations = [
+        f'external-{population}-{index}@outside.test'
+        for index in range(population)
+    ]
+    with _captured_sql() as statements:
+        models.replace_scim_group_graph(
+            group,
+            member_ids=member_ids,
+            external_destinations=destinations,
+        )
+
+    member_probes = [
+        statement
+        for statement, bound_strings in statements
+        if (
+            ' from scim_resource where scim_resource.id ' in statement
+            and set(bound_strings).intersection(member_ids)
+        )
+    ]
+    local_address_probes = [
+        statement
+        for statement, bound_strings in statements
+        if (
+            ' from mail_address where mail_address.email ' in statement
+            and set(bound_strings).intersection(destinations)
+        )
+    ]
+    assert (len(member_probes), len(local_address_probes)) == (1, 1), {
+        'member_probes': member_probes,
+        'local_address_probes': local_address_probes,
+    }
+
+    models.db.session.commit()
+    assert {edge.member_id for edge in group.member_edges} == set(member_ids)
+    assert {
+        destination.destination
+        for destination in group.destinations
+    } == set(destinations)
+
+
+def test_graph_validation_probe_chunk_boundary(app):
+    domain = _domain()
+    models.db.session.add_all(
+        models.User(
+            localpart=f'chunk-member-{index:03d}',
+            domain=domain,
+            password='not-a-real-password',
+        )
+        for index in range(models._SCIM_GRAPH_PROBE_CHUNK_SIZE)
+    )
+    models.db.session.commit()
+    member_ids = list(models.db.session.execute(
+        sa.select(models.ScimResource.id)
+        .where(models.ScimResource.resource_type == 'User')
+        .order_by(models.ScimResource.id)
+    ).scalars())
+    assert len(member_ids) == models._SCIM_GRAPH_PROBE_CHUNK_SIZE
+    missing_id = 'missing-member-id'
+    requested_member_ids = [*member_ids, missing_id]
+    destinations = [
+        f'chunk-destination-{index:03d}@outside.test'
+        for index in range(models._SCIM_GRAPH_PROBE_CHUNK_SIZE + 1)
+    ]
+
+    with _captured_sql() as statements:
+        with pytest.raises(
+            models.ScimGraphError,
+            match=re.escape(
+                f'SCIM member {missing_id!r} is not an active resource'
+            ),
+        ):
+            models._active_scim_resources(requested_member_ids)
+        models._reject_local_scim_destinations(destinations)
+
+    member_id_set = set(requested_member_ids)
+    destination_set = set(destinations)
+    member_probe_sizes = [
+        len(member_id_set.intersection(bound_strings))
+        for statement, bound_strings in statements
+        if ' from scim_resource where scim_resource.id in ' in statement
+    ]
+    destination_probe_sizes = [
+        len(destination_set.intersection(bound_strings))
+        for statement, bound_strings in statements
+        if ' from mail_address where mail_address.email in ' in statement
+    ]
+    assert member_probe_sizes == [500, 1]
+    assert destination_probe_sizes == [500, 1]
+
+
+@pytest.mark.parametrize('failure', ['wrong-case', 'tombstoned'])
+def test_graph_batch_member_failure_preserves_order_and_old_graph(
+    app,
+    monkeypatch,
+    failure,
+):
+    original_member = _user(f'original-{failure}')
+    original_member_id = original_member.scim_resource.id
+    group = _managed_group(f'member-failure-{failure}')
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[original_member_id],
+        external_destinations=['original@outside.test'],
+    )
+    models.db.session.commit()
+    group_id = group.id
+
+    if failure == 'wrong-case':
+        exact_id = 'abcdef01-2345-6789-abcd-ef0123456789'
+        monkeypatch.setattr(models, 'new_scim_id', lambda: exact_id)
+        _user('wrong-case-candidate')
+        bad_id = exact_id.upper()
+    else:
+        candidate = _user('tombstoned-candidate')
+        bad_id = candidate.scim_resource.id
+        models.tombstone_scim_resource(candidate.scim_resource)
+        models.db.session.commit()
+
+    before = _group_graph_snapshot(group_id)
+    group = models.db.session.get(models.ScimResource, group_id)
+    later_missing_id = 'later-missing-member-id'
+    with pytest.raises(
+        models.ScimGraphError,
+        match=re.escape(
+            f'SCIM member {bad_id!r} is not an active resource'
+        ),
+    ):
+        models.replace_scim_group_graph(
+            group,
+            member_ids=[original_member_id, bad_id, later_missing_id],
+            external_destinations=['replacement@outside.test'],
+        )
+    models.db.session.rollback()
+
+    assert _group_graph_snapshot(group_id) == before
+
+
+def test_graph_batch_local_conflict_uses_sorted_request_order_and_rolls_back(app):
+    original_member = _user('local-conflict-original')
+    group = _managed_group('local-conflict-group')
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[original_member.scim_resource.id],
+        external_destinations=['original@outside.test'],
+    )
+    models.db.session.commit()
+    group_id = group.id
+    _user('z-local-conflict')
+    _user('m-local-conflict')
+    before = _group_graph_snapshot(group_id)
+    first_conflict = 'm-local-conflict@example.com'
+
+    with pytest.raises(
+        models.ScimExternalDestinationError,
+        match=re.escape(
+            f'External destination {first_conflict!r} is locally owned'
+        ),
+    ):
+        models.replace_scim_group_graph(
+            models.db.session.get(models.ScimResource, group_id),
+            member_ids=[],
+            external_destinations=[
+                'z-local-conflict@example.com',
+                'a-harmless@outside.test',
+                first_conflict,
+            ],
+        )
+    models.db.session.rollback()
+
+    assert _group_graph_snapshot(group_id) == before
+
+
+def test_mysql_batch_destination_conflict_preserves_routing_collation(app):
+    if models.db.engine.dialect.name not in {'mysql', 'mariadb'}:
+        pytest.skip('requires MySQL/MariaDB routing collation')
+
+    stored_first = _user('café-collation')
+    stored_second = _user('résumé-collation')
+    requested_first = 'cafe-collation@example.com'
+    requested_second = 'resume-collation@example.com'
+    assert models.db.session.execute(
+        sa.select(models.MailAddress.email)
+        .where(models.MailAddress.email == requested_first)
+    ).scalar_one() == stored_first.email
+    assert models.db.session.execute(
+        sa.select(models.MailAddress.email)
+        .where(models.MailAddress.email == requested_second)
+    ).scalar_one() == stored_second.email
+    group = _managed_group('collation-conflict-group')
+
+    with pytest.raises(
+        models.ScimExternalDestinationError,
+        match=re.escape(
+            f'External destination {requested_first!r} is locally owned'
+        ),
+    ):
+        models.replace_scim_group_graph(
+            group,
+            member_ids=[],
+            external_destinations=[
+                requested_second,
+                requested_first,
+                'a-harmless@outside.test',
+            ],
+        )
+    models.db.session.rollback()
+
+
+def test_graph_replace_rolls_back_after_staging_failure(app, monkeypatch):
+    original_member = _user('staging-original')
+    replacement_member = _user('staging-replacement')
+    group = _managed_group('staging-failure-group')
+    group.external_id = 'original-external-id'
+    models.permit_scim_managed_alias_edit(group.alias)
+    group.alias.comment = 'Original comment'
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[original_member.scim_resource.id],
+        external_destinations=['original@outside.test'],
+    )
+    models.db.session.commit()
+    group_id = group.id
+    before = _group_graph_snapshot(group_id)
+
+    def fail_materialization(failing_group):
+        models.permit_scim_managed_alias_edit(failing_group.alias)
+        raise models.ScimGraphError('injected post-staging failure')
+
+    monkeypatch.setattr(models, 'materialize_scim_group', fail_materialization)
+    group = models.db.session.get(models.ScimResource, group_id)
+    models.permit_scim_managed_alias_edit(group.alias)
+    group.alias.comment = 'Replacement comment'
+    group.external_id = 'replacement-external-id'
+    with pytest.raises(
+        models.ScimGraphError,
+        match='injected post-staging failure',
+    ):
+        models.replace_scim_group_graph(
+            group,
+            member_ids=[replacement_member.scim_resource.id],
+            external_destinations=['replacement@outside.test'],
+        )
+    models.db.session.rollback()
+
+    assert _group_graph_snapshot(group_id) == before
+    alias = models.db.session.get(models.ScimResource, group_id).alias
+    alias.comment = 'Unpermitted edit after rollback'
     with pytest.raises(models.ScimManagedAliasError):
         models.db.session.commit()
     models.db.session.rollback()

--- a/tests/scim_identity_model_test.py
+++ b/tests/scim_identity_model_test.py
@@ -11,6 +11,8 @@ import re
 import threading
 import unicodedata
 from contextlib import contextmanager
+from datetime import date, datetime
+from types import SimpleNamespace
 
 import pytest
 import sqlalchemy as sa
@@ -93,6 +95,51 @@ def _captured_sql():
         yield statements
     finally:
         sa.event.remove(models.db.engine, 'before_cursor_execute', capture)
+
+
+def _seed_cycle_probe_graph(edge_rows, extra_ids=()):
+    resource_ids = sorted({
+        resource_id
+        for edge in edge_rows
+        for resource_id in edge
+    }.union(extra_ids))
+    models.db.session.execute(
+        models.ScimResource.__table__.insert(),
+        [
+            {
+                'id': resource_id,
+                'resource_type': 'Group',
+                'external_id_bytes': None,
+                'user_email': None,
+                'alias_email': None,
+                'subject_address': (
+                    f'fixture-{index:05d}@cycle.invalid'
+                ),
+                'deleted_at': datetime(2000, 1, 1),
+                'created_at': date(2000, 1, 1),
+                'updated_at': None,
+                'comment': 'cycle fixture',
+            }
+            for index, resource_id in enumerate(resource_ids)
+        ],
+    )
+    if edge_rows:
+        models.db.session.execute(
+            models.ScimGroupMember.__table__.insert(),
+            [
+                {'group_id': group_id, 'member_id': member_id}
+                for group_id, member_id in edge_rows
+            ],
+        )
+    models.db.session.commit()
+
+
+def _cycle_statements(statements):
+    return [
+        (statement, bound_strings)
+        for statement, bound_strings in statements
+        if ' from scim_group_member' in statement
+    ]
 
 
 def _group_graph_snapshot(group_id):
@@ -1018,25 +1065,231 @@ def test_mysql_local_claim_sees_external_delete_after_prior_read(app):
     ).count() == 0
 
 
-def test_group_cycle_is_rejected_before_materialization(app):
+def test_cycle_frontier_preserves_cycle_semantics_and_exact_ids(app):
+    edges = [
+        ('two:parent', 'two:target'),
+        ('diamond:left', 'diamond:target'),
+        ('diamond:right', 'diamond:target'),
+        ('diamond:top', 'diamond:left'),
+        ('diamond:top', 'diamond:right'),
+        ('Exact:Parent', 'exact:target'),
+        ('Exact:Positive', 'Exact:Target'),
+        ('replace:target', 'replace:old'),
+        ('disconnected:a', 'disconnected:b'),
+        ('disconnected:b', 'disconnected:a'),
+    ]
+    _seed_cycle_probe_graph(
+        edges,
+        extra_ids={
+            'diamond:safe',
+            'disconnected:target',
+            'empty:target',
+            'self:target',
+        },
+    )
+    cycle_error = re.escape('SCIM Group membership would create a cycle')
+
+    with _captured_sql() as statements:
+        with pytest.raises(models.ScimGraphError, match=cycle_error):
+            models._validate_scim_cycle(
+                SimpleNamespace(id='self:target'),
+                ['self:target'],
+            )
+        models._validate_scim_cycle(
+            SimpleNamespace(id='empty:target'),
+            [],
+        )
+    assert _cycle_statements(statements) == []
+
+    with pytest.raises(models.ScimGraphError, match=cycle_error):
+        models._validate_scim_cycle(
+            SimpleNamespace(id='two:target'),
+            ['two:parent'],
+        )
+    with pytest.raises(models.ScimGraphError, match=cycle_error):
+        models._validate_scim_cycle(
+            SimpleNamespace(id='diamond:target'),
+            ['diamond:top'],
+        )
+    with pytest.raises(models.ScimGraphError, match=cycle_error):
+        models._validate_scim_cycle(
+            SimpleNamespace(id='diamond:target'),
+            ['diamond:safe', 'diamond:top'],
+        )
+
+    models._validate_scim_cycle(
+        SimpleNamespace(id='Exact:Target'),
+        ['Exact:Parent'],
+    )
+    with pytest.raises(models.ScimGraphError, match=cycle_error):
+        models._validate_scim_cycle(
+            SimpleNamespace(id='Exact:Target'),
+            ['Exact:Positive'],
+        )
+    models._validate_scim_cycle(
+        SimpleNamespace(id='replace:target'),
+        ['replace:old'],
+    )
+    models._validate_scim_cycle(
+        SimpleNamespace(id='disconnected:target'),
+        ['disconnected:a'],
+    )
+
+
+def test_cycle_frontier_shallow_sql_ignores_unrelated_edges(app):
+    unrelated_ids = [
+        f'unrelated:{index:04d}'
+        for index in range(1025)
+    ]
+    edges = [
+        ('parent:0', 'shallow:target'),
+        ('parent:1', 'parent:0'),
+        *[
+            (unrelated_ids[index + 1], unrelated_ids[index])
+            for index in range(1024)
+        ],
+    ]
+    _seed_cycle_probe_graph(edges, extra_ids={'shallow:outside'})
+
+    with _captured_sql() as statements:
+        models._validate_scim_cycle(
+            SimpleNamespace(id='shallow:target'),
+            ['shallow:outside'],
+        )
+
+    cycle_statements = _cycle_statements(statements)
+    assert len(cycle_statements) == 3
+    assert all(
+        ' where scim_group_member.member_id in ' in statement
+        and 'scim_group_member.group_id !=' in statement
+        for statement, _bound_strings in cycle_statements
+    )
+    assert all(
+        set(bound_strings).isdisjoint(unrelated_ids)
+        for _statement, bound_strings in cycle_statements
+    )
+
+
+def test_cycle_frontier_chunks_wide_fan_in_at_500_values(app):
+    parent_ids = [
+        f'wide:parent:{index:04d}'
+        for index in range(1201)
+    ]
+    _seed_cycle_probe_graph(
+        [(parent_id, 'wide:target') for parent_id in parent_ids],
+        extra_ids={'wide:outside'},
+    )
+
+    with _captured_sql() as statements:
+        models._validate_scim_cycle(
+            SimpleNamespace(id='wide:target'),
+            ['wide:outside'],
+        )
+
+    cycle_statements = _cycle_statements(statements)
+    assert len(cycle_statements) == 4
+    assert all(
+        ' where scim_group_member.member_id in ' in statement
+        and 'scim_group_member.group_id !=' in statement
+        for statement, _bound_strings in cycle_statements
+    )
+    parent_id_set = set(parent_ids)
+    chunk_sizes = [
+        len(parent_id_set.intersection(bound_strings))
+        for _statement, bound_strings in cycle_statements[1:]
+    ]
+    assert chunk_sizes == [500, 500, 201]
+    assert all(
+        size <= models._SCIM_GRAPH_PROBE_CHUNK_SIZE
+        for size in chunk_sizes
+    )
+
+
+def test_cycle_frontier_fallback_is_iterative_correct_and_capped(app):
+    parent_ids = [
+        f'deep:parent:{index:04d}'
+        for index in range(1105)
+    ]
+    edges = [
+        (parent_ids[0], 'deep:target'),
+        ('deep:target', 'deep:old'),
+    ]
+    edges.extend(
+        (parent_ids[index], parent_ids[index - 1])
+        for index in range(1, len(parent_ids))
+    )
+    _seed_cycle_probe_graph(edges, extra_ids={'deep:outside'})
+    cycle_error = re.escape('SCIM Group membership would create a cycle')
+
+    with _captured_sql() as cyclic_statements:
+        with pytest.raises(models.ScimGraphError, match=cycle_error):
+            models._validate_scim_cycle(
+                SimpleNamespace(id='deep:target'),
+                [parent_ids[-1]],
+            )
+    models.db.session.rollback()
+
+    with _captured_sql() as acyclic_statements:
+        models._validate_scim_cycle(
+            SimpleNamespace(id='deep:target'),
+            ['deep:outside'],
+        )
+
+    for statements in (cyclic_statements, acyclic_statements):
+        cycle_statements = _cycle_statements(statements)
+        probes = [
+            entry
+            for entry in cycle_statements
+            if ' where scim_group_member.member_id in ' in entry[0]
+            and 'scim_group_member.group_id !=' in entry[0]
+        ]
+        fallback = [
+            entry
+            for entry in cycle_statements
+            if ' where ' not in entry[0]
+        ]
+        assert len(probes) == 64
+        assert len(fallback) == 1
+        assert len(cycle_statements) == 65
+        assert cycle_statements[-1] == fallback[0]
+
+
+def test_cycle_frontier_rejection_preserves_old_graph_and_projection(app):
+    original_member = _user('cycle-original')
     first = _managed_group('cycle-a')
     second = _managed_group('cycle-b')
-    original_projection = list(first.alias.destination)
+    first.external_id = 'original-external-id'
+    models.permit_scim_managed_alias_edit(first.alias)
+    first.alias.comment = 'Original comment'
+    models.replace_scim_group_graph(
+        first,
+        member_ids=[original_member.scim_resource.id],
+        external_destinations=['original@outside.test'],
+    )
     models.replace_scim_group_graph(
         second,
         member_ids=[first.id],
         external_destinations=[],
     )
     models.db.session.commit()
+    first_id = first.id
+    before = _group_graph_snapshot(first_id)
 
-    with pytest.raises(models.ScimGraphError):
+    first = models.db.session.get(models.ScimResource, first_id)
+    first.external_id = 'replacement-external-id'
+    models.permit_scim_managed_alias_edit(first.alias)
+    first.alias.comment = 'Replacement comment'
+    with pytest.raises(
+        models.ScimGraphError,
+        match=re.escape('SCIM Group membership would create a cycle'),
+    ):
         models.replace_scim_group_graph(
             first,
             member_ids=[second.id],
-            external_destinations=[],
+            external_destinations=['replacement@outside.test'],
         )
     models.db.session.rollback()
-    assert first.alias.destination == original_projection
+    assert _group_graph_snapshot(first_id) == before
 
 
 def test_hard_deleted_member_is_tombstoned_and_removed_from_group(app):

--- a/tests/scim_identity_model_test.py
+++ b/tests/scim_identity_model_test.py
@@ -86,6 +86,16 @@ def test_address_conflict_preserves_integrity_error_contract():
     assert issubclass(models.AddressConflict, IntegrityError)
 
 
+def test_fetch_protocol_enum_matches_migration_name():
+    assert models.Fetch.__table__.c.protocol.type.name == 'enum_protocol'
+
+
+def test_scim_group_member_reverse_index_is_declared():
+    assert 'scim_group_member_member_id_idx' in {
+        index.name for index in models.ScimGroupMember.__table__.indexes
+    }
+
+
 def test_new_orm_user_gets_random_generation_and_uuid_mapping(app):
     user = _user('new-identity')
     mapping = models.ScimResource.query.filter_by(
@@ -444,6 +454,36 @@ def test_mysql_engine_uses_read_committed(app):
     )
 
 
+def test_mysql_scim_id_columns_use_binary_collation(app):
+    if models.db.engine.dialect.name not in {'mysql', 'mariadb'}:
+        pytest.skip('requires MySQL/MariaDB')
+
+    rows = models.db.session.execute(sa.text(
+        """
+        SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME, COLLATION_NAME
+          FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE()
+           AND (
+             (TABLE_NAME = 'scim_resource' AND COLUMN_NAME = 'id') OR
+             (TABLE_NAME = 'scim_group_member' AND COLUMN_NAME IN
+               ('group_id', 'member_id')) OR
+             (TABLE_NAME = 'scim_group_destination' AND COLUMN_NAME = 'group_id')
+           )
+        """
+    )).all()
+    assert len(rows) == 4
+    character_sets = {
+        character_set
+        for _table, _column, character_set, _collation in rows
+    }
+    assert character_sets == {'utf8mb4'}
+    collations = {
+        collation
+        for _table, _column, _character_set, collation in rows
+    }
+    assert collations == {'utf8mb4_bin'}
+
+
 def test_mysql_external_reservation_sees_local_commit_after_prior_read(app):
     if models.db.engine.dialect.name not in {'mysql', 'mariadb'}:
         pytest.skip('requires MySQL/MariaDB')
@@ -787,6 +827,10 @@ def test_identity_migration_backfills_users_only_and_gates_downgrade():
     assert 'auth_generation' in {
         column['name'] for column in inspector.get_columns('user')
     }
+    assert 'scim_group_member_member_id_idx' in {
+        index['name']
+        for index in inspector.get_indexes('scim_group_member')
+    }
 
     with engine.connect() as connection:
         assert connection.exec_driver_sql(
@@ -886,10 +930,11 @@ def test_address_preflight_uses_native_database_collation():
         'address_native_collation_preflight',
     )
     with engine.connect() as connection:
-        collisions = migration._cross_table_collisions(connection)
+        collisions, truncated = migration._cross_table_collisions(connection)
     assert collisions == [
         ('cafe@example.com', 'cafe@example.com', 'café@example.com')
     ]
+    assert truncated is False
     engine.dispose()
 
 

--- a/tests/scim_identity_model_test.py
+++ b/tests/scim_identity_model_test.py
@@ -938,6 +938,56 @@ def test_address_preflight_uses_native_database_collation():
     engine.dispose()
 
 
+def test_address_preflight_lowercase_probe_work_is_population_bounded():
+    population_size = 32
+    lower_calls = 0
+    engine = sa.create_engine('sqlite://')
+
+    @sa.event.listens_for(engine, 'connect')
+    def count_lower_calls(connection, _record):
+        def counted_lower(value):
+            nonlocal lower_calls
+            lower_calls += 1
+            return value.lower()
+
+        connection.create_function('lower', 1, counted_lower)
+
+    metadata = sa.MetaData()
+    user_table = sa.Table(
+        'user',
+        metadata,
+        sa.Column('email', sa.String(255), primary_key=True),
+    )
+    alias_table = sa.Table(
+        'alias',
+        metadata,
+        sa.Column('email', sa.String(255), primary_key=True),
+    )
+    metadata.create_all(engine)
+    with engine.begin() as connection:
+        connection.execute(user_table.insert(), [
+            {'email': f'user-{index:03d}@example.com'}
+            for index in range(population_size)
+        ])
+        connection.execute(alias_table.insert(), [
+            {'email': f'alias-{index:03d}@example.net'}
+            for index in range(population_size)
+        ])
+
+    migration = _load_migration(
+        ADDRESS_MIGRATION,
+        'address_population_bounded_preflight',
+    )
+    lower_calls = 0
+    with engine.connect() as connection:
+        collisions, truncated = migration._cross_table_collisions(connection)
+
+    assert collisions == []
+    assert truncated is False
+    assert lower_calls <= population_size * 8
+    engine.dispose()
+
+
 def test_address_migration_rebuilds_inbound_user_fks_only_on_sqlite():
     migration = _load_migration(
         ADDRESS_MIGRATION,

--- a/tests/scim_identity_test.py
+++ b/tests/scim_identity_test.py
@@ -1,0 +1,757 @@
+import re
+
+import pytest
+
+from mailu import models
+
+
+USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User'
+GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group'
+PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'
+BULK_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest'
+GROUP_EXTENSION = 'https://mailu.io/schemas/scim/2.0/Group'
+UUID_PATTERN = re.compile(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-'
+    r'[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+)
+
+
+def auth_headers(app):
+    return {
+        'Authorization': f'Bearer {app.config["API_TOKEN"]}',
+        'Content-Type': 'application/scim+json',
+    }
+
+
+def create_domain(name='example.com'):
+    domain = models.Domain(name=name)
+    models.db.session.add(domain)
+    models.db.session.commit()
+    return domain
+
+
+def create_local_user(localpart='local-user'):
+    domain = models.db.session.get(models.Domain, 'example.com') or create_domain()
+    user = models.User(localpart=localpart, domain=domain)
+    user.set_password('secret', keep_sessions=True)
+    models.db.session.add(user)
+    models.db.session.commit()
+    return user
+
+
+def provision_user(client, app, localpart, *, external_id=None, supplied_id=None):
+    payload = {
+        'schemas': [USER_SCHEMA],
+        'userName': f'{localpart}@example.com',
+        'password': 'secret',
+        'active': True,
+    }
+    if external_id is not None:
+        payload['externalId'] = external_id
+    if supplied_id is not None:
+        payload['id'] = supplied_id
+    return client.post(
+        '/api/scim/v2/Users',
+        json=payload,
+        headers=auth_headers(app),
+    )
+
+
+def provision_group(
+    client,
+    app,
+    *,
+    alias_address,
+    display_name='Operations',
+    members=None,
+    external_destinations=None,
+    supplied_id=None,
+):
+    extension = {
+        'aliasAddress': alias_address,
+        'externalDestinations': external_destinations or [],
+    }
+    payload = {
+        'schemas': [GROUP_SCHEMA, GROUP_EXTENSION],
+        'displayName': display_name,
+        'members': [{'value': value} for value in (members or [])],
+        GROUP_EXTENSION: extension,
+    }
+    if supplied_id is not None:
+        payload['id'] = supplied_id
+    return client.post(
+        '/api/scim/v2/Groups',
+        json=payload,
+        headers=auth_headers(app),
+    )
+
+
+def test_new_local_user_gets_provider_uuid_mapping(app, client):
+    with app.app_context():
+        user = create_local_user()
+        mapping = models.ScimResource.query.filter_by(
+            resource_type='User',
+            user_email=user.email,
+            deleted_at=None,
+        ).one()
+        resource_id = mapping.id
+
+    assert UUID_PATTERN.fullmatch(resource_id)
+    response = client.get(
+        f'/api/scim/v2/Users/{resource_id}',
+        headers=auth_headers(app),
+    )
+    assert response.status_code == 200
+    assert response.get_json()['id'] == resource_id
+    assert client.get(
+        '/api/scim/v2/Users/local-user@example.com',
+        headers=auth_headers(app),
+    ).status_code == 404
+
+
+def test_user_create_ignores_client_id_and_persists_external_id(app, client):
+    with app.app_context():
+        create_domain()
+
+    response = provision_user(
+        client,
+        app,
+        'provisioned',
+        external_id='directory-object-7',
+        supplied_id='client-controlled-id',
+    )
+
+    assert response.status_code == 201
+    resource = response.get_json()
+    assert UUID_PATTERN.fullmatch(resource['id'])
+    assert resource['id'] != 'client-controlled-id'
+    assert resource['externalId'] == 'directory-object-7'
+    assert response.headers['Location'].endswith(f"/Users/{resource['id']}")
+
+    fetched = client.get(
+        f"/api/scim/v2/Users/{resource['id']}",
+        headers=auth_headers(app),
+    )
+    assert fetched.status_code == 200
+    assert fetched.get_json()['externalId'] == 'directory-object-7'
+
+
+@pytest.mark.parametrize(
+    'user_name',
+    [
+        'not-an-email',
+        'foo bar@example.com',
+        'user@exa mple.com',
+        'double@@example.com',
+    ],
+)
+def test_user_create_rejects_malformed_username_without_mutation(
+    app,
+    client,
+    user_name,
+):
+    with app.app_context():
+        create_domain()
+
+    response = client.post(
+        '/api/scim/v2/Users',
+        json={
+            'schemas': [USER_SCHEMA],
+            'userName': user_name,
+            'active': True,
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+    with app.app_context():
+        assert models.User.query.count() == 0
+        assert models.ScimResource.query.count() == 0
+
+
+def test_bulk_user_create_rejects_malformed_username_without_mutation(
+    app,
+    client,
+):
+    with app.app_context():
+        create_domain()
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'POST',
+                'path': '/Users',
+                'bulkId': 'invalid-user',
+                'data': {
+                    'schemas': [USER_SCHEMA],
+                    'userName': 'not-an-email',
+                },
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 200
+    operation = response.get_json()['Operations'][0]
+    assert operation['status'] == '400'
+    assert operation['response']['scimType'] == 'invalidValue'
+    with app.app_context():
+        assert models.User.query.count() == 0
+        assert models.ScimResource.query.count() == 0
+
+
+def test_user_create_accepts_valid_idna_domain(app, client):
+    with app.app_context():
+        create_domain('bücher.example')
+
+    response = client.post(
+        '/api/scim/v2/Users',
+        json={
+            'schemas': [USER_SCHEMA],
+            'userName': 'unicode@bücher.example',
+            'active': True,
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 201
+    assert response.get_json()['userName'] == 'unicode@bücher.example'
+
+
+def test_user_patch_rejects_partial_immutable_and_missing_value(app, client):
+    with app.app_context():
+        create_domain()
+    created = provision_user(
+        client,
+        app,
+        'patch-contract',
+        external_id='keep-me',
+    ).get_json()
+    resource_url = f"/api/scim/v2/Users/{created['id']}"
+
+    partial = client.patch(
+        resource_url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'value': {
+                    'userName': 'changed@example.com',
+                    'active': False,
+                },
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert partial.status_code == 400
+    assert partial.get_json()['scimType'] == 'mutability'
+
+    missing = client.patch(
+        resource_url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'externalId',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert missing.status_code == 400
+    assert missing.get_json()['scimType'] == 'invalidValue'
+
+    unchanged = client.get(resource_url, headers=auth_headers(app)).get_json()
+    assert unchanged['active'] is True
+    assert unchanged['externalId'] == 'keep-me'
+
+
+def test_user_patch_applies_final_active_value_once(app, client):
+    with app.app_context():
+        create_domain()
+    created = provision_user(client, app, 'final-active').get_json()
+    with app.app_context():
+        user = models.db.session.get(models.User, 'final-active@example.com')
+        generation = user.auth_generation
+
+    response = client.patch(
+        f"/api/scim/v2/Users/{created['id']}",
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [
+                {'op': 'replace', 'path': 'active', 'value': False},
+                {'op': 'replace', 'path': 'active', 'value': True},
+            ],
+        },
+        headers=auth_headers(app),
+    )
+    assert response.status_code == 200
+    assert response.get_json()['active'] is True
+    with app.app_context():
+        user = models.db.session.get(models.User, 'final-active@example.com')
+        assert user.auth_generation == generation
+
+
+def test_group_request_types_and_pathless_immutable_noop(app, client):
+    with app.app_context():
+        create_domain()
+    invalid = client.post(
+        '/api/scim/v2/Groups',
+        json={
+            'schemas': [GROUP_SCHEMA, GROUP_EXTENSION],
+            'displayName': 'Invalid destination type',
+            GROUP_EXTENSION: {
+                'aliasAddress': 'invalid-type@example.com',
+                'externalDestinations': '',
+            },
+        },
+        headers=auth_headers(app),
+    )
+    assert invalid.status_code == 400
+    assert invalid.get_json()['scimType'] == 'invalidValue'
+
+    created = provision_group(
+        client,
+        app,
+        alias_address='pathless-noop@example.com',
+    ).get_json()
+    patched = client.patch(
+        f"/api/scim/v2/Groups/{created['id']}",
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'value': {
+                    GROUP_EXTENSION: {
+                        'aliasAddress': 'pathless-noop@example.com',
+                        'externalDestinations': ['outside@example.net'],
+                    },
+                },
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert patched.status_code == 200
+    assert patched.get_json()[GROUP_EXTENSION][
+        'externalDestinations'
+    ] == ['outside@example.net']
+
+
+@pytest.mark.parametrize(
+    'extra',
+    [
+        {'failOnErrors': 1.5},
+        {'operation_bulk_id': 'not-a-create'},
+    ],
+)
+def test_bulk_rejects_non_integer_limit_and_non_post_bulk_id(
+    app,
+    client,
+    extra,
+):
+    request = {
+        'schemas': [BULK_SCHEMA],
+        'Operations': [{
+            'method': 'PATCH',
+            'path': '/Users/missing',
+            'data': {
+                'schemas': [PATCH_SCHEMA],
+                'Operations': [{
+                    'op': 'replace',
+                    'path': 'active',
+                    'value': False,
+                }],
+            },
+        }],
+    }
+    if 'failOnErrors' in extra:
+        request['failOnErrors'] = extra['failOnErrors']
+    if 'operation_bulk_id' in extra:
+        request['Operations'][0]['bulkId'] = extra['operation_bulk_id']
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json=request,
+        headers=auth_headers(app),
+    )
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+
+
+def test_user_delete_tombstones_id_and_reserves_subject_address(app, client):
+    with app.app_context():
+        create_domain()
+    created = provision_user(client, app, 'deleted-user')
+    assert created.status_code == 201
+    old_id = created.get_json()['id']
+
+    deleted = client.delete(
+        f'/api/scim/v2/Users/{old_id}',
+        headers=auth_headers(app),
+    )
+    assert deleted.status_code == 204
+
+    for method in ('get', 'delete'):
+        response = getattr(client, method)(
+            f'/api/scim/v2/Users/{old_id}',
+            headers=auth_headers(app),
+        )
+        assert response.status_code == 404
+
+    listing = client.get('/api/scim/v2/Users', headers=auth_headers(app))
+    assert old_id not in {
+        resource['id'] for resource in listing.get_json()['Resources']
+    }
+
+    with app.app_context():
+        retained = models.db.session.get(models.User, 'deleted-user@example.com')
+        tombstone = models.db.session.get(models.ScimResource, old_id)
+        assert retained is not None
+        assert retained.enabled is False
+        assert tombstone.deleted_at is not None
+        assert tombstone.user_email is None
+
+    recreated = provision_user(client, app, 'deleted-user')
+    assert recreated.status_code == 409
+    assert recreated.get_json()['scimType'] == 'uniqueness'
+    assert client.get(
+        f'/api/scim/v2/Users/{old_id}',
+        headers=auth_headers(app),
+    ).status_code == 404
+
+
+def test_user_delete_scrubs_authority_and_rejects_reprovision(app, client):
+    with app.app_context():
+        create_domain()
+    created = provision_user(client, app, 'prior-authority')
+    assert created.status_code == 201
+    old_id = created.get_json()['id']
+
+    with app.app_context():
+        user = models.db.session.get(
+            models.User,
+            'prior-authority@example.com',
+        )
+        example_domain = models.db.session.get(models.Domain, 'example.com')
+        managed_domain = models.Domain(name='managed.example')
+        user.global_admin = True
+        user.allow_spoofing = True
+        user.forward_enabled = True
+        user.forward_destination = ['old-owner@outside.example']
+        user.reply_enabled = True
+        user.manager_of.append(managed_domain)
+
+        token = models.Token(user=user)
+        token.set_password('a' * 32)
+        fetch = models.Fetch(
+            user=user,
+            protocol='imap',
+            host='imap.outside.example',
+            port=993,
+            tls=True,
+            username='old-owner',
+            password='old-remote-secret',
+        )
+        access = models.DomainAccess(
+            domain=managed_domain,
+            user=user,
+        )
+        owned_alias = models.Alias(
+            localpart='old-private-alias',
+            domain=example_domain,
+            destination=[user.email],
+            owner=user,
+        )
+        models.db.session.add_all([
+            managed_domain,
+            token,
+            fetch,
+            access,
+            owned_alias,
+        ])
+        models.db.session.commit()
+
+    deleted = client.delete(
+        f'/api/scim/v2/Users/{old_id}',
+        headers=auth_headers(app),
+    )
+    assert deleted.status_code == 204
+
+    with app.app_context():
+        user = models.db.session.get(
+            models.User,
+            'prior-authority@example.com',
+        )
+        assert user is not None
+        assert user.enabled is False
+        assert user.global_admin is False
+        assert user.allow_spoofing is False
+        assert user.forward_enabled is False
+        assert user.forward_destination == []
+        assert user.reply_enabled is False
+        assert user.tokens == []
+        assert user.fetches == []
+        assert user.manager_of == []
+        assert user.domain_accesses == []
+        assert models.db.session.get(
+            models.Alias,
+            'old-private-alias@example.com',
+        ) is None
+
+    recreated = provision_user(client, app, 'prior-authority')
+    assert recreated.status_code == 409
+    assert recreated.get_json()['scimType'] == 'uniqueness'
+
+    with app.app_context():
+        user = models.db.session.get(
+            models.User,
+            'prior-authority@example.com',
+        )
+        assert user.enabled is False
+        assert user.global_admin is False
+        assert user.allow_spoofing is False
+        assert user.forward_enabled is False
+        assert user.forward_destination == []
+        assert user.reply_enabled is False
+        assert user.tokens == []
+        assert user.fetches == []
+        assert user.manager_of == []
+        assert user.domain_accesses == []
+
+
+def test_unmanaged_alias_is_not_a_scim_group(app, client):
+    with app.app_context():
+        domain = create_domain()
+        alias = models.Alias(
+            localpart='ordinary',
+            domain=domain,
+            destination=['outside@example.net'],
+        )
+        models.db.session.add(alias)
+        models.db.session.commit()
+
+    listing = client.get('/api/scim/v2/Groups', headers=auth_headers(app))
+    assert listing.status_code == 200
+    assert listing.get_json()['totalResults'] == 0
+    assert client.get(
+        '/api/scim/v2/Groups/ordinary@example.com',
+        headers=auth_headers(app),
+    ).status_code == 404
+
+
+def test_group_separates_member_ids_from_external_destinations(app, client):
+    with app.app_context():
+        create_domain()
+    member_response = provision_user(client, app, 'member')
+    assert member_response.status_code == 201
+    member_id = member_response.get_json()['id']
+
+    response = provision_group(
+        client,
+        app,
+        alias_address='operations@example.com',
+        display_name='Human operations label',
+        members=[member_id],
+        external_destinations=['pager@example.net'],
+        supplied_id='client-group-id',
+    )
+
+    assert response.status_code == 201
+    resource = response.get_json()
+    assert UUID_PATTERN.fullmatch(resource['id'])
+    assert resource['id'] != 'client-group-id'
+    assert resource['displayName'] == 'Human operations label'
+    assert resource['schemas'] == [GROUP_SCHEMA, GROUP_EXTENSION]
+    assert resource['members'] == [{
+        'value': member_id,
+        '$ref': resource['members'][0]['$ref'],
+        'display': resource['members'][0]['display'],
+        'type': 'User',
+    }]
+    assert resource['members'][0]['$ref'].endswith(f'/Users/{member_id}')
+    assert resource[GROUP_EXTENSION] == {
+        'aliasAddress': 'operations@example.com',
+        'externalDestinations': ['pager@example.net'],
+    }
+
+    with app.app_context():
+        alias = models.db.session.get(models.Alias, 'operations@example.com')
+        assert alias.destination == [
+            'member@example.com',
+            'pager@example.net',
+        ]
+
+
+def test_group_rejects_unknown_or_tombstoned_member_without_mutation(app, client):
+    with app.app_context():
+        create_domain()
+    response = provision_group(
+        client,
+        app,
+        alias_address='invalid-members@example.com',
+        members=['00000000-0000-4000-8000-000000000000'],
+    )
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+    assert 'member' in response.get_json()['detail'].lower()
+    assert 'active' in response.get_json()['detail'].lower()
+    with app.app_context():
+        assert models.db.session.get(
+            models.Alias,
+            'invalid-members@example.com',
+        ) is None
+
+
+def test_group_cycle_is_rejected_atomically(app, client):
+    with app.app_context():
+        create_domain()
+    group_a = provision_group(
+        client,
+        app,
+        alias_address='a@example.com',
+        display_name='A',
+    ).get_json()
+    group_b = provision_group(
+        client,
+        app,
+        alias_address='b@example.com',
+        display_name='B',
+        members=[group_a['id']],
+    ).get_json()
+
+    response = client.patch(
+        f"/api/scim/v2/Groups/{group_a['id']}",
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'add',
+                'path': 'members',
+                'value': [{'value': group_b['id']}],
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+
+    unchanged = client.get(
+        f"/api/scim/v2/Groups/{group_a['id']}",
+        headers=auth_headers(app),
+    )
+    assert unchanged.get_json()['members'] == []
+
+
+def test_group_extension_patch_and_projection(app, client):
+    with app.app_context():
+        create_domain()
+    created = provision_group(
+        client,
+        app,
+        alias_address='projected@example.com',
+        display_name='Projected',
+        external_destinations=['one@example.net'],
+    ).get_json()
+
+    patched = client.patch(
+        f"/api/scim/v2/Groups/{created['id']}",
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'add',
+                'path': f'{GROUP_EXTENSION}:externalDestinations',
+                'value': ['two@example.net'],
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert patched.status_code == 200
+    assert patched.get_json()[GROUP_EXTENSION]['externalDestinations'] == [
+        'one@example.net',
+        'two@example.net',
+    ]
+
+    projected = client.get(
+        f"/api/scim/v2/Groups/{created['id']}",
+        query_string={
+            'attributes': f'{GROUP_EXTENSION}:externalDestinations',
+        },
+        headers=auth_headers(app),
+    )
+    assert projected.status_code == 200
+    assert projected.get_json() == {
+        'schemas': [GROUP_SCHEMA, GROUP_EXTENSION],
+        'id': created['id'],
+        'displayName': 'Projected',
+        GROUP_EXTENSION: {
+            'externalDestinations': [
+                'one@example.net',
+                'two@example.net',
+            ],
+        },
+    }
+
+
+def test_group_alias_address_is_immutable(app, client):
+    with app.app_context():
+        create_domain()
+    created = provision_group(
+        client,
+        app,
+        alias_address='immutable@example.com',
+    ).get_json()
+
+    response = client.patch(
+        f"/api/scim/v2/Groups/{created['id']}",
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': f'{GROUP_EXTENSION}:aliasAddress',
+                'value': 'changed@example.com',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'mutability'
+
+
+@pytest.mark.parametrize('extra_length', [0, 1])
+def test_group_materialized_destination_boundary_is_portable(
+    app,
+    client,
+    extra_length,
+):
+    with app.app_context():
+        create_domain()
+    # One address whose serialized length is exactly the routing column limit,
+    # then one character over. Domain syntax is not the point of this test, so
+    # use many individually valid short addresses instead.
+    addresses = []
+    serialized = ''
+    index = 0
+    while len(serialized) < 1023 + extra_length:
+        candidate = f'd{index}@x.example'
+        next_value = ','.join(addresses + [candidate])
+        if len(next_value) > 1023 + extra_length:
+            break
+        addresses.append(candidate)
+        serialized = next_value
+        index += 1
+    if extra_length:
+        addresses.append('overflow@x.example')
+
+    response = provision_group(
+        client,
+        app,
+        alias_address=f'boundary-{extra_length}@example.com',
+        external_destinations=addresses,
+    )
+    if len(','.join(sorted(set(addresses)))) <= 1023:
+        assert response.status_code == 201
+    else:
+        assert response.status_code == 400
+        assert response.get_json()['scimType'] == 'invalidValue'
+        assert '1023' in response.get_json()['detail']

--- a/tests/scim_managed_alias_surface_test.py
+++ b/tests/scim_managed_alias_surface_test.py
@@ -1,0 +1,312 @@
+"""User-facing contracts for ordinary writes to SCIM-managed Aliases."""
+
+import pytest
+
+from mailu import models
+
+
+def _setup_managed_alias():
+    domain = models.Domain(name='example.com')
+    admin = models.User(
+        localpart='admin',
+        domain=domain,
+        global_admin=True,
+    )
+    admin.set_password('not-a-real-password')
+    alias = models.Alias(
+        localpart='managed',
+        domain=domain,
+        destination=['kept@outside.example'],
+        comment='Managed group',
+    )
+    models.db.session.add_all([domain, admin, alias])
+    models.db.session.commit()
+    group = models.create_scim_group_mapping(alias)
+    models.replace_scim_group_graph(
+        group,
+        member_ids=[],
+        external_destinations=['kept@outside.example'],
+    )
+    models.db.session.commit()
+    return admin.email, alias.email, group.id
+
+
+def _assert_graph_unchanged(alias_email, group_id):
+    alias = models.db.session.get(models.Alias, alias_email)
+    group = models.ScimResource.get_exact(group_id, resource_type='Group')
+    assert alias is not None
+    assert group is not None
+    assert alias.scim_resource is group
+    assert alias.comment == 'Managed group'
+    assert alias.destination == ['kept@outside.example']
+    assert [edge.destination for edge in group.destinations] == [
+        'kept@outside.example'
+    ]
+
+
+def _bearer(app):
+    return {'Authorization': f'Bearer {app.config["API_TOKEN"]}'}
+
+
+def _add_removable_domain(name='removable.example'):
+    domain = models.Domain(name=name)
+    models.db.session.add(domain)
+    models.db.session.commit()
+    return domain
+
+
+def _login(client, user):
+    with client.session_transaction() as session:
+        session['_user_id'] = user.email
+        session['_auth_generation'] = user.auth_generation
+        session['_fresh'] = True
+
+
+@pytest.mark.parametrize('method', ['patch', 'delete'])
+def test_v1_managed_alias_write_returns_conflict(app, client, method):
+    with app.app_context():
+        admin_email, alias_email, group_id = _setup_managed_alias()
+
+    if method == 'patch':
+        response = client.patch(
+            f'/api/v1/alias/{alias_email}',
+            json={
+                'comment': 'ordinary edit',
+                'destination': [admin_email],
+            },
+            headers=_bearer(app),
+        )
+    else:
+        response = client.delete(
+            f'/api/v1/alias/{alias_email}',
+            headers=_bearer(app),
+        )
+    assert response.status_code == 409
+    assert response.get_json() == {
+        'code': 409,
+        'message': f'Alias {alias_email} is exclusively SCIM managed',
+    }
+
+    assert client.get(
+        f'/api/v1/alias/{alias_email}',
+        headers=_bearer(app),
+    ).status_code == 200
+    with app.app_context():
+        _assert_graph_unchanged(alias_email, group_id)
+
+
+def test_v1_managed_alias_blocks_domain_cascade_and_rolls_back(app, client):
+    with app.app_context():
+        _admin_email, alias_email, group_id = _setup_managed_alias()
+        _add_removable_domain()
+
+    response = client.delete(
+        '/api/v1/domain/example.com',
+        headers=_bearer(app),
+    )
+    assert response.status_code == 409
+    assert response.get_json() == {
+        'code': 409,
+        'message': f'Alias {alias_email} is exclusively SCIM managed',
+    }
+
+    follow_up = client.delete(
+        '/api/v1/domain/removable.example',
+        headers=_bearer(app),
+    )
+    assert follow_up.status_code == 200, follow_up.get_json()
+    with app.app_context():
+        assert models.db.session.get(models.Domain, 'example.com') is not None
+        assert models.db.session.get(
+            models.Domain,
+            'removable.example',
+        ) is None
+        _assert_graph_unchanged(alias_email, group_id)
+
+
+@pytest.mark.parametrize('operation', ['edit', 'delete'])
+def test_ui_managed_alias_write_flashes_error(app, client, operation):
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        admin_email, alias_email, group_id = _setup_managed_alias()
+        _login(client, models.db.session.get(models.User, admin_email))
+
+    prefix = app.config['WEB_ADMIN']
+    if operation == 'edit':
+        response = client.post(
+            f'{prefix}/alias/edit/{alias_email}',
+            data={
+                'localpart': 'managed',
+                'destination': [admin_email],
+                'comment': 'ordinary edit',
+                'submit': 'Save',
+            },
+            follow_redirects=True,
+        )
+    else:
+        response = client.post(
+            f'{prefix}/alias/delete/{alias_email}',
+            data={'submit': 'Confirm'},
+            follow_redirects=True,
+        )
+    assert response.status_code == 200
+    assert b'exclusively SCIM managed' in response.data
+
+    with app.app_context():
+        _assert_graph_unchanged(alias_email, group_id)
+
+
+def test_ui_managed_alias_blocks_domain_cascade_and_rolls_back(app, client):
+    app.config['WTF_CSRF_ENABLED'] = False
+    with app.app_context():
+        admin_email, alias_email, group_id = _setup_managed_alias()
+        _add_removable_domain()
+        _login(client, models.db.session.get(models.User, admin_email))
+
+    prefix = app.config['WEB_ADMIN']
+    response = client.post(
+        f'{prefix}/domain/delete/example.com',
+        data={'submit': 'Confirm'},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b'exclusively SCIM managed' in response.data
+
+    follow_up = client.post(
+        f'{prefix}/domain/delete/removable.example',
+        data={'submit': 'Confirm'},
+        follow_redirects=True,
+    )
+    assert follow_up.status_code == 200
+    with app.app_context():
+        assert models.db.session.get(models.Domain, 'example.com') is not None
+        assert models.db.session.get(
+            models.Domain,
+            'removable.example',
+        ) is None
+        _assert_graph_unchanged(alias_email, group_id)
+
+
+def test_cli_managed_alias_delete_is_a_clean_error_and_rolls_back(app):
+    with app.app_context():
+        _admin_email, alias_email, group_id = _setup_managed_alias()
+        removable = models.Alias(
+            localpart='removable',
+            domain=models.db.session.get(models.Domain, 'example.com'),
+            destination=['outside@example.net'],
+        )
+        models.db.session.add(removable)
+        models.db.session.commit()
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(args=['mailu', 'alias-delete', alias_email])
+    assert result.exit_code != 0
+    assert 'exclusively SCIM managed' in result.output
+
+    follow_up = runner.invoke(
+        args=['mailu', 'alias-delete', 'removable@example.com'],
+    )
+    assert follow_up.exit_code == 0, follow_up.output
+
+    with app.app_context():
+        _assert_graph_unchanged(alias_email, group_id)
+        assert models.db.session.get(
+            models.Alias,
+            'removable@example.com',
+        ) is None
+
+
+def test_cli_config_update_is_a_clean_error_and_rolls_back(app):
+    with app.app_context():
+        _admin_email, alias_email, group_id = _setup_managed_alias()
+        removable = models.Alias(
+            localpart='removable',
+            domain=models.db.session.get(models.Domain, 'example.com'),
+            destination=['outside@example.net'],
+        )
+        models.db.session.add(removable)
+        models.db.session.commit()
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        args=['mailu', 'config-update'],
+        input='''
+domains:
+  - name: example.com
+    max_users: 99
+aliases:
+  - localpart: managed
+    domain: example.com
+    destination: changed@outside.example
+''',
+    )
+    assert result.exit_code != 0
+    assert 'exclusively SCIM managed' in result.output
+
+    follow_up = runner.invoke(
+        args=['mailu', 'alias-delete', 'removable@example.com'],
+    )
+    assert follow_up.exit_code == 0, follow_up.output
+
+    with app.app_context():
+        assert models.db.session.get(models.Domain, 'example.com').max_users == -1
+        _assert_graph_unchanged(alias_email, group_id)
+        assert models.db.session.get(
+            models.Alias,
+            'removable@example.com',
+        ) is None
+
+
+@pytest.mark.parametrize('retain_managed_domain', [True, False])
+def test_cli_config_update_delete_objects_is_atomic_for_managed_alias(
+    app,
+    retain_managed_domain,
+):
+    with app.app_context():
+        admin_email, alias_email, group_id = _setup_managed_alias()
+        ordinary_domain = _add_removable_domain('ordinary.example')
+        removable = models.Alias(
+            localpart='removable',
+            domain=ordinary_domain,
+            destination=['outside@example.net'],
+        )
+        models.db.session.add(removable)
+        models.db.session.commit()
+
+    config = [
+        'domains:',
+        '  - name: ordinary.example',
+        '    max_users: 99',
+    ]
+    if retain_managed_domain:
+        config.extend([
+            '  - name: example.com',
+            '    max_users: 99',
+        ])
+    config.extend(['aliases: []', ''])
+
+    runner = app.test_cli_runner()
+    result = runner.invoke(
+        args=['mailu', 'config-update', '--delete-objects', 'true'],
+        input='\n'.join(config),
+    )
+    assert result.exit_code != 0
+    assert 'exclusively SCIM managed' in result.output
+
+    follow_up = runner.invoke(
+        args=['mailu', 'alias-delete', 'removable@ordinary.example'],
+    )
+    assert follow_up.exit_code == 0, follow_up.output
+
+    with app.app_context():
+        assert models.db.session.get(
+            models.Domain,
+            'ordinary.example',
+        ).max_users == -1
+        assert models.db.session.get(models.Domain, 'example.com') is not None
+        assert models.db.session.get(models.User, admin_email) is not None
+        _assert_graph_unchanged(alias_email, group_id)
+        assert models.db.session.get(
+            models.Alias,
+            'removable@ordinary.example',
+        ) is None

--- a/tests/scim_native_migration_test.py
+++ b/tests/scim_native_migration_test.py
@@ -884,6 +884,60 @@ def test_mysql_registry_storage_preflight_is_before_ddl(
     _assert_table_snapshots(engine, snapshots)
 
 
+def test_address_collision_preflight_retries_without_native_ddl(
+    native_migration_app,
+):
+    engine = models.db.engine
+    _upgrade(BASE_REVISION)
+    snapshots = _seed_populated_legacy_database(engine)
+    changed_default = _change_mysql_database_default(engine)
+    with engine.begin() as connection:
+        table = _tables(connection, 'alias')
+        connection.execute(
+            table['alias'].update()
+            .where(table['alias'].c.email == 'list@example.com')
+            .values(email='admin@example.com')
+        )
+        collision_snapshot = _snapshot_tables(
+            connection,
+            _tables(connection, *snapshots),
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match='admin@example.com: User=admin@example.com, '
+        'Alias=admin@example.com',
+    ):
+        _upgrade(ADDRESS_REVISION)
+
+    inspector = sa.inspect(engine)
+    table_names = set(inspector.get_table_names())
+    assert 'mail_address' not in table_names
+    assert not {name for name in table_names if name.startswith('scim_')}
+    assert 'address_type' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    assert 'address_type' not in {
+        column['name'] for column in inspector.get_columns('alias')
+    }
+    with engine.connect() as connection:
+        assert connection.scalar(sa.text(
+            'SELECT version_num FROM alembic_version'
+        )) == BASE_REVISION
+    _assert_table_snapshots(engine, collision_snapshot)
+
+    with engine.begin() as connection:
+        table = _tables(connection, 'alias')
+        connection.execute(
+            table['alias'].update()
+            .where(table['alias'].c.email == 'admin@example.com')
+            .values(email='list@example.com')
+        )
+
+    _upgrade('head')
+    _assert_populated_upgrade(engine, changed_default, snapshots)
+
+
 def test_invalid_legacy_identity_fails_before_identity_ddl_and_retries(
     native_migration_app,
 ):
@@ -1061,20 +1115,11 @@ def test_user_migration_reads_and_writes_are_bounded(
         get_final_froms = getattr(statement, 'get_final_froms', None)
         limit_clause = getattr(statement, '_limit_clause', None)
         if get_final_froms is not None and limit_clause is not None:
-            def table_names(from_clause):
-                name = getattr(from_clause, 'name', None)
-                if name is not None:
-                    return {name}
-                names = set()
-                for side in ('left', 'right'):
-                    nested = getattr(from_clause, side, None)
-                    if nested is not None:
-                        names.update(table_names(nested))
-                return names
-
-            from_names = set()
-            for from_clause in get_final_froms():
-                from_names.update(table_names(from_clause))
+            from_names = {
+                element.name
+                for element in sa.sql.visitors.iterate(statement)
+                if isinstance(element, sa.Table)
+            }
             if from_names == {'alias', 'user'}:
                 collision_probe_limits.append(limit_clause.value)
             if from_names == {'user'}:

--- a/tests/scim_native_migration_test.py
+++ b/tests/scim_native_migration_test.py
@@ -1,0 +1,1101 @@
+"""Real populated Alembic upgrade coverage for native SQL backends."""
+
+from datetime import date, datetime
+import os
+import pathlib
+import re
+
+from alembic import command
+from flask import current_app
+import pytest
+import sqlalchemy as sa
+
+from mailu import configuration, create_app_from_config, models
+
+
+BASE_REVISION = '9a5866105f5a'
+ADDRESS_REVISION = 'd4a6f2b8c901'
+HEAD_REVISION = 'e7c9a4f2b631'
+MIGRATIONS = pathlib.Path(models.__file__).resolve().parent.parent / 'migrations'
+INITIAL_AUTH_GENERATION = '0' * 32
+MYSQL_FAMILY = {'mysql', 'mariadb'}
+SAFE_DATABASE = 'mailu_scim_test'
+SAFE_HOSTS = {'127.0.0.1', 'localhost'}
+SAFE_IDENTIFIER = re.compile(r'^[A-Za-z0-9_]+$')
+EXPECTED_BACKFILL_BATCH_SIZE = 128
+EXPECTED_COLLISION_PROBE_LIMIT = 21
+
+
+def _assert_safe_target(engine):
+    url = engine.url
+    if (
+        engine.dialect.name not in MYSQL_FAMILY | {'postgresql'}
+        or url.host not in SAFE_HOSTS
+        or url.database != SAFE_DATABASE
+    ):
+        raise AssertionError(
+            'refusing destructive native migration test against '
+            f'{url.render_as_string(hide_password=True)}'
+        )
+
+
+def _mysql_database_default(engine):
+    if engine.dialect.name not in MYSQL_FAMILY:
+        return None
+    with engine.connect() as connection:
+        database_name, character_set, collation = connection.execute(sa.text(
+            """
+            SELECT SCHEMA_NAME, DEFAULT_CHARACTER_SET_NAME,
+                   DEFAULT_COLLATION_NAME
+              FROM information_schema.SCHEMATA
+             WHERE SCHEMA_NAME = DATABASE()
+            """
+        )).one()
+    return database_name, character_set, collation
+
+
+def _restore_mysql_database_default(engine, storage):
+    if storage is None:
+        return
+    database_name, character_set, collation = storage
+    if not all(
+        SAFE_IDENTIFIER.fullmatch(value)
+        for value in storage
+    ):
+        raise AssertionError('database returned an unsafe identifier')
+    with engine.connect() as connection:
+        quote = connection.dialect.identifier_preparer.quote
+        connection.exec_driver_sql(
+            f'ALTER DATABASE {quote(database_name)} '
+            f'CHARACTER SET {character_set} COLLATE {collation}'
+        )
+        connection.commit()
+
+
+def _set_mysql_database_default(engine, character_set, collation):
+    if engine.dialect.name not in MYSQL_FAMILY:
+        raise AssertionError('requires MariaDB/MySQL')
+    with engine.connect() as connection:
+        database_name = connection.scalar(sa.text('SELECT DATABASE()'))
+        available = connection.scalar(sa.text(
+            """
+            SELECT COUNT(*)
+              FROM information_schema.COLLATIONS
+             WHERE CHARACTER_SET_NAME = :character_set
+               AND COLLATION_NAME = :collation
+            """
+        ), {
+            'character_set': character_set,
+            'collation': collation,
+        })
+    if available != 1:
+        raise AssertionError(
+            f'collation {collation!r} is not available for {character_set!r}'
+        )
+    _restore_mysql_database_default(
+        engine,
+        (database_name, character_set, collation),
+    )
+
+
+def _reset_database(engine):
+    models.db.session.remove()
+    if engine.dialect.name == 'postgresql':
+        with engine.begin() as connection:
+            connection.exec_driver_sql('DROP SCHEMA IF EXISTS public CASCADE')
+            connection.exec_driver_sql('CREATE SCHEMA public')
+        return
+
+    if engine.dialect.name in MYSQL_FAMILY:
+        with engine.connect() as connection:
+            try:
+                connection.exec_driver_sql('SET FOREIGN_KEY_CHECKS=0')
+                inspector = sa.inspect(connection)
+                quote = connection.dialect.identifier_preparer.quote
+                for table_name in inspector.get_table_names():
+                    connection.exec_driver_sql(
+                        f'DROP TABLE IF EXISTS {quote(table_name)}'
+                    )
+            finally:
+                connection.exec_driver_sql('SET FOREIGN_KEY_CHECKS=1')
+                connection.commit()
+        return
+
+    raise AssertionError(f'unsupported native test dialect {engine.dialect.name}')
+
+
+@pytest.fixture
+def native_migration_app(env_setup):
+    if os.environ.get('MAILU_NATIVE_MIGRATION_TEST') != '1':
+        pytest.skip('native migration test is destructive and explicitly gated')
+
+    app = create_app_from_config(configuration.ConfigManager())
+    app.config['TESTING'] = True
+    with app.app_context():
+        engine = models.db.engine
+        _assert_safe_target(engine)
+        original_mysql_default = _mysql_database_default(engine)
+        _reset_database(engine)
+        try:
+            yield app
+        finally:
+            try:
+                _reset_database(engine)
+            finally:
+                _restore_mysql_database_default(
+                    engine,
+                    original_mysql_default,
+                )
+                models.db.session.remove()
+                engine.dispose()
+
+
+def _upgrade(revision):
+    config = current_app.extensions['migrate'].migrate.get_config(
+        str(MIGRATIONS)
+    )
+    command.upgrade(config, revision)
+
+
+def _tables(connection, *names):
+    metadata = sa.MetaData()
+    return {
+        name: sa.Table(name, metadata, autoload_with=connection)
+        for name in names
+    }
+
+
+def _snapshot_tables(connection, tables):
+    snapshots = {}
+    for name, table in tables.items():
+        column_names = tuple(column.name for column in table.columns)
+        order_by = list(table.primary_key.columns) or list(table.columns)
+        rows = connection.execute(
+            sa.select(*(table.c[column] for column in column_names)).order_by(
+                *order_by
+            )
+        ).all()
+        snapshots[name] = (column_names, rows)
+    return snapshots
+
+
+def _assert_table_snapshots(engine, snapshots):
+    with engine.connect() as connection:
+        tables = _tables(connection, *snapshots)
+        for name, (column_names, expected_rows) in snapshots.items():
+            table = tables[name]
+            order_by = list(table.primary_key.columns) or [
+                table.c[column] for column in column_names
+            ]
+            actual_rows = connection.execute(
+                sa.select(*(
+                    table.c[column] for column in column_names
+                )).order_by(*order_by)
+            ).all()
+            assert actual_rows == expected_rows
+
+
+def _legacy_user(email, domain_name, *, global_admin=False):
+    localpart = email.rsplit('@', 1)[0]
+    return {
+        'created_at': date(2024, 1, 2),
+        'updated_at': date(2024, 1, 3),
+        'comment': f'legacy {localpart}',
+        'localpart': localpart,
+        'password': 'not-a-real-password-hash',
+        'quota_bytes': 1_000_000,
+        'global_admin': global_admin,
+        'enable_imap': True,
+        'enable_pop': False,
+        'forward_enabled': True,
+        'forward_destination': 'archive@outside.example',
+        'reply_enabled': False,
+        'reply_subject': None,
+        'reply_body': None,
+        'displayed_name': f'Legacy {localpart}',
+        'spam_enabled': True,
+        'domain_name': domain_name,
+        'email': email,
+        'spam_threshold': 75,
+        'forward_keep': True,
+        'reply_enddate': date(2999, 12, 31),
+        'enabled': True,
+        'quota_bytes_used': 123,
+        'reply_startdate': date(1900, 1, 1),
+        'spam_mark_as_read': False,
+        'allow_spoofing': True,
+        'change_pw_next_login': False,
+    }
+
+
+def _seed_populated_legacy_database(engine):
+    with engine.begin() as connection:
+        table = _tables(
+            connection,
+            'domain',
+            'user',
+            'alias',
+            'fetch',
+            'token',
+            'manager',
+            'domain_access',
+        )
+        connection.execute(table['domain'].insert(), [
+            {
+                'created_at': date(2024, 1, 1),
+                'updated_at': None,
+                'comment': 'ASCII domain',
+                'name': 'example.com',
+                'max_users': -1,
+                'max_aliases': -1,
+                'max_quota_bytes': 0,
+                'signup_enabled': False,
+                'anonmail_enabled': True,
+            },
+            {
+                'created_at': date(2024, 1, 1),
+                'updated_at': None,
+                'comment': 'IDNA domain',
+                'name': 'xn--bcher-kva.example',
+                'max_users': -1,
+                'max_aliases': -1,
+                'max_quota_bytes': 0,
+                'signup_enabled': False,
+                'anonmail_enabled': False,
+            },
+        ])
+        connection.execute(table['user'].insert(), [
+            _legacy_user(
+                'admin@example.com',
+                'example.com',
+                global_admin=True,
+            ),
+            _legacy_user(
+                'member@xn--bcher-kva.example',
+                'xn--bcher-kva.example',
+            ),
+        ])
+        connection.execute(table['alias'].insert().values(
+            created_at=date(2024, 1, 4),
+            updated_at=date(2024, 1, 5),
+            comment='Legacy list',
+            localpart='list',
+            destination='admin@example.com,pager@outside.example',
+            domain_name='example.com',
+            email='list@example.com',
+            wildcard=False,
+            hostname='list.example.com',
+            owner_email='admin@example.com',
+            disabled=False,
+        ))
+        connection.execute(table['fetch'].insert().values(
+            id=41,
+            created_at=date(2024, 1, 6),
+            updated_at=None,
+            comment='Legacy fetch',
+            user_email='admin@example.com',
+            protocol='imap',
+            host='imap.outside.example',
+            port=993,
+            tls=True,
+            username='remote-user',
+            password='remote-password',
+            error=None,
+            last_check=None,
+            keep=True,
+            scan=True,
+            folders='INBOX',
+            invisible=False,
+        ))
+        connection.execute(table['token'].insert().values(
+            id=42,
+            created_at=date(2024, 1, 7),
+            updated_at=None,
+            comment='Legacy token',
+            user_email='admin@example.com',
+            password='a' * 32,
+            ip='127.0.0.1',
+        ))
+        connection.execute(table['manager'].insert().values(
+            domain_name='example.com',
+            user_email='admin@example.com',
+        ))
+        connection.execute(table['domain_access'].insert().values(
+            id=43,
+            domain_name='example.com',
+            user_email='admin@example.com',
+            created_at=date(2024, 1, 8),
+            updated_at=None,
+            comment='Legacy grant',
+        ))
+        return _snapshot_tables(connection, table)
+
+
+def _seed_invalid_identity(engine):
+    with engine.begin() as connection:
+        table = _tables(connection, 'domain', 'user')
+        connection.execute(table['domain'].insert().values(
+            created_at=date(2024, 1, 1),
+            updated_at=None,
+            comment='Invalid IDNA domain',
+            name='xn--',
+            max_users=-1,
+            max_aliases=-1,
+            max_quota_bytes=0,
+            signup_enabled=False,
+            anonmail_enabled=False,
+        ))
+        connection.execute(
+            table['user'].insert().values(
+                **_legacy_user('invalid@xn--', 'xn--')
+            )
+        )
+
+
+def _seed_duplicate_published_identity(engine):
+    domains = ('xn--bcher-kva.example', 'bücher.example')
+    with engine.begin() as connection:
+        table = _tables(connection, 'domain', 'user')
+        connection.execute(table['domain'].insert(), [
+            {
+                'created_at': date(2024, 1, 1),
+                'updated_at': None,
+                'comment': 'Duplicate published SCIM ID',
+                'name': domain_name,
+                'max_users': -1,
+                'max_aliases': -1,
+                'max_quota_bytes': 0,
+                'signup_enabled': False,
+                'anonmail_enabled': False,
+            }
+            for domain_name in domains
+        ])
+        connection.execute(table['user'].insert(), [
+            _legacy_user(f'member@{domain_name}', domain_name)
+            for domain_name in domains
+        ])
+
+
+def _seed_non_latin_idna_identity(engine):
+    domain_name = 'xn--e1afmkfd.xn--p1ai'
+    email = f'member@{domain_name}'
+    with engine.begin() as connection:
+        table = _tables(connection, 'domain', 'user')
+        connection.execute(table['domain'].insert().values(
+            created_at=date(2024, 1, 1),
+            updated_at=None,
+            comment='Cyrillic IDNA domain',
+            name=domain_name,
+            max_users=-1,
+            max_aliases=-1,
+            max_quota_bytes=0,
+            signup_enabled=False,
+            anonmail_enabled=False,
+        ))
+        connection.execute(
+            table['user'].insert().values(
+                **_legacy_user(email, domain_name)
+            )
+        )
+    return email, 'member@\u043f\u0440\u0438\u043c\u0435\u0440.\u0440\u0444'
+
+
+def _seed_backfill_population(engine, count, *, alias_count=0):
+    domain_name = 'batch.example'
+    with engine.begin() as connection:
+        table = _tables(connection, 'domain', 'user', 'alias')
+        connection.execute(table['domain'].insert().values(
+            created_at=date(2024, 1, 1),
+            updated_at=None,
+            comment='Backfill batch domain',
+            name=domain_name,
+            max_users=-1,
+            max_aliases=-1,
+            max_quota_bytes=0,
+            signup_enabled=False,
+            anonmail_enabled=False,
+        ))
+        connection.execute(table['user'].insert(), [
+            _legacy_user(f'batch{index:04d}@{domain_name}', domain_name)
+            for index in range(count)
+        ])
+        if alias_count:
+            connection.execute(table['alias'].insert(), [
+                {
+                    'created_at': date(2024, 1, 1),
+                    'updated_at': None,
+                    'comment': 'Backfill batch Alias',
+                    'localpart': f'route{index:04d}',
+                    'destination': 'outside@example.net',
+                    'domain_name': domain_name,
+                    'email': f'route{index:04d}@{domain_name}',
+                    'wildcard': False,
+                    'hostname': None,
+                    'owner_email': None,
+                    'disabled': False,
+                }
+                for index in range(alias_count)
+            ])
+
+
+def _mysql_column_storage(connection, table_name, column_name):
+    return connection.execute(sa.text(
+        """
+        SELECT CHARACTER_SET_NAME, COLLATION_NAME
+          FROM information_schema.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE()
+           AND TABLE_NAME = :table_name
+           AND COLUMN_NAME = :column_name
+        """
+    ), {
+        'table_name': table_name,
+        'column_name': column_name,
+    }).one()
+
+
+def _alternate_mysql_collation(connection, character_set, current):
+    candidates = connection.execute(sa.text(
+        """
+        SELECT COLLATION_NAME
+          FROM information_schema.COLLATIONS
+         WHERE CHARACTER_SET_NAME = :character_set
+           AND COLLATION_NAME <> :current
+           AND COLLATION_NAME NOT LIKE '%\\_bin'
+         ORDER BY COLLATION_NAME
+        """
+    ), {
+        'character_set': character_set,
+        'current': current,
+    }).scalars().all()
+    if not candidates:
+        raise AssertionError('no alternate database collation is available')
+    preferred = [
+        f'{character_set}_unicode_ci',
+        f'{character_set}_general_ci',
+    ]
+    return next(
+        (name for name in preferred if name in candidates),
+        candidates[0],
+    )
+
+
+def _change_mysql_database_default(engine):
+    if engine.dialect.name not in MYSQL_FAMILY:
+        return None
+
+    with engine.connect() as connection:
+        database_name = connection.scalar(sa.text('SELECT DATABASE()'))
+        character_set, legacy_collation = _mysql_column_storage(
+            connection,
+            'user',
+            'email',
+        )
+        target = _alternate_mysql_collation(
+            connection,
+            character_set,
+            legacy_collation,
+        )
+        if not all(
+            SAFE_IDENTIFIER.fullmatch(value)
+            for value in (database_name, character_set, target)
+        ):
+            raise AssertionError('database returned an unsafe identifier')
+        quote = connection.dialect.identifier_preparer.quote
+        connection.exec_driver_sql(
+            f'ALTER DATABASE {quote(database_name)} '
+            f'CHARACTER SET {character_set} COLLATE {target}'
+        )
+        connection.commit()
+    return legacy_collation, target
+
+
+def _force_alias_email_collation_mismatch(engine):
+    with engine.connect() as connection:
+        character_set, current = _mysql_column_storage(
+            connection,
+            'alias',
+            'email',
+        )
+        target = _alternate_mysql_collation(
+            connection,
+            character_set,
+            current,
+        )
+        if not all(
+            SAFE_IDENTIFIER.fullmatch(value)
+            for value in (character_set, target)
+        ):
+            raise AssertionError('database returned an unsafe identifier')
+        quote = connection.dialect.identifier_preparer.quote
+        connection.exec_driver_sql(
+            f'ALTER TABLE {quote("alias")} MODIFY {quote("email")} '
+            f'VARCHAR(255) CHARACTER SET {character_set} COLLATE {target} '
+            'NOT NULL'
+        )
+        connection.commit()
+    return current, target
+
+
+def _assert_foreign_key(
+    inspector,
+    table_name,
+    constraint_name,
+    constrained_columns,
+    referred_table,
+    referred_columns,
+):
+    constraint = next(
+        foreign_key
+        for foreign_key in inspector.get_foreign_keys(table_name)
+        if foreign_key['name'] == constraint_name
+    )
+    assert constraint['constrained_columns'] == constrained_columns
+    assert constraint['referred_table'] == referred_table
+    assert constraint['referred_columns'] == referred_columns
+
+
+def _assert_member_index(inspector):
+    index = next(
+        index
+        for index in inspector.get_indexes('scim_group_member')
+        if index['name'] == 'scim_group_member_member_id_idx'
+    )
+    assert index['column_names'] == ['member_id']
+    assert index['unique'] is False
+
+    model_index = next(
+        index
+        for index in models.ScimGroupMember.__table__.indexes
+        if index.name == 'scim_group_member_member_id_idx'
+    )
+    assert [column.name for column in model_index.columns] == ['member_id']
+    assert model_index.unique is False
+
+
+def _assert_native_constraints(inspector):
+    expected_foreign_keys = (
+        (
+            'user',
+            'user_mail_address_fkey',
+            ['email', 'address_type'],
+            'mail_address',
+            ['email', 'address_type'],
+        ),
+        (
+            'alias',
+            'alias_mail_address_fkey',
+            ['email', 'address_type'],
+            'mail_address',
+            ['email', 'address_type'],
+        ),
+        (
+            'scim_resource',
+            'scim_resource_user_email_fkey',
+            ['user_email'],
+            'user',
+            ['email'],
+        ),
+        (
+            'scim_resource',
+            'scim_resource_alias_email_fkey',
+            ['alias_email'],
+            'alias',
+            ['email'],
+        ),
+        (
+            'scim_group_member',
+            'scim_group_member_group_id_fkey',
+            ['group_id'],
+            'scim_resource',
+            ['id'],
+        ),
+        (
+            'scim_group_member',
+            'scim_group_member_member_id_fkey',
+            ['member_id'],
+            'scim_resource',
+            ['id'],
+        ),
+        (
+            'scim_group_destination',
+            'scim_group_destination_group_id_fkey',
+            ['group_id'],
+            'scim_resource',
+            ['id'],
+        ),
+    )
+    for expected in expected_foreign_keys:
+        _assert_foreign_key(inspector, *expected)
+
+    expected_checks = {
+        'mail_address': {'mail_address_type_check'},
+        'user': {'user_address_type_check'},
+        'alias': {'alias_address_type_check'},
+        'scim_state': {'scim_state_singleton_check'},
+        'scim_resource': {
+            'scim_resource_type_check',
+            'scim_resource_lifecycle_check',
+        },
+    }
+    for table_name, names in expected_checks.items():
+        assert names <= {
+            constraint['name']
+            for constraint in inspector.get_check_constraints(table_name)
+        }
+    _assert_member_index(inspector)
+
+
+def _assert_populated_upgrade(engine, changed_default, snapshots):
+    inspector = sa.inspect(engine)
+    assert {
+        'mail_address',
+        'scim_state',
+        'scim_resource',
+        'scim_group_member',
+        'scim_group_destination',
+    } <= set(inspector.get_table_names())
+    _assert_native_constraints(inspector)
+    _assert_table_snapshots(engine, snapshots)
+    auth_generation = next(
+        column
+        for column in inspector.get_columns('user')
+        if column['name'] == 'auth_generation'
+    )
+    assert auth_generation['nullable'] is False
+    assert auth_generation['default'] is None
+
+    with engine.begin() as connection:
+        table = _tables(
+            connection,
+            'alembic_version',
+            'user',
+            'alias',
+            'fetch',
+            'token',
+            'manager',
+            'domain_access',
+            'mail_address',
+            'scim_resource',
+            'scim_state',
+            'scim_group_member',
+            'scim_group_destination',
+        )
+        assert connection.scalar(
+            sa.select(table['alembic_version'].c.version_num)
+        ) == HEAD_REVISION
+        assert set(connection.execute(sa.select(
+            table['user'].c.email,
+            table['user'].c.auth_generation,
+        ))) == {
+            ('admin@example.com', INITIAL_AUTH_GENERATION),
+            ('member@xn--bcher-kva.example', INITIAL_AUTH_GENERATION),
+        }
+        assert connection.execute(sa.select(
+            table['alias'].c.email,
+            table['alias'].c.destination,
+            table['alias'].c.owner_email,
+        )).all() == [(
+            'list@example.com',
+            'admin@example.com,pager@outside.example',
+            'admin@example.com',
+        )]
+        assert connection.execute(sa.select(
+            table['fetch'].c.id,
+            table['fetch'].c.user_email,
+            table['fetch'].c.protocol,
+            table['fetch'].c.folders,
+        )).all() == [(41, 'admin@example.com', 'imap', 'INBOX')]
+        assert connection.execute(sa.select(
+            table['token'].c.id,
+            table['token'].c.user_email,
+            table['token'].c.comment,
+        )).all() == [(42, 'admin@example.com', 'Legacy token')]
+        assert connection.execute(sa.select(table['manager'])).all() == [
+            ('example.com', 'admin@example.com'),
+        ]
+        assert connection.execute(sa.select(
+            table['domain_access'].c.id,
+            table['domain_access'].c.domain_name,
+            table['domain_access'].c.user_email,
+        )).all() == [(43, 'example.com', 'admin@example.com')]
+        assert set(connection.execute(sa.select(
+            table['mail_address'].c.email,
+            table['mail_address'].c.address_type,
+        ))) == {
+            ('admin@example.com', 'user'),
+            ('member@xn--bcher-kva.example', 'user'),
+            ('list@example.com', 'alias'),
+        }
+        assert connection.execute(sa.select(
+            table['scim_resource'].c.id,
+            table['scim_resource'].c.resource_type,
+            table['scim_resource'].c.user_email,
+            table['scim_resource'].c.alias_email,
+        ).order_by(table['scim_resource'].c.id)).all() == [
+            ('admin@example.com', 'User', 'admin@example.com', None),
+            (
+                'member@b\u00fccher.example',
+                'User',
+                'member@xn--bcher-kva.example',
+                None,
+            ),
+        ]
+        assert connection.execute(sa.select(table['scim_state'])).all() == [
+            (1, 0),
+        ]
+        assert connection.scalar(sa.select(sa.func.count()).select_from(
+            table['scim_group_member']
+        )) == 0
+        assert connection.scalar(sa.select(sa.func.count()).select_from(
+            table['scim_group_destination']
+        )) == 0
+
+        tombstones = [
+            {
+                'id': resource_id,
+                'resource_type': 'Group',
+                'external_id_bytes': None,
+                'user_email': None,
+                'alias_email': None,
+                'subject_address': f'{resource_id}@outside.example',
+                'deleted_at': datetime(2024, 1, 9),
+                'created_at': date(2024, 1, 9),
+                'updated_at': None,
+                'comment': '',
+            }
+            for resource_id in ('Case-ID', 'case-id')
+        ]
+        connection.execute(table['scim_resource'].insert(), tombstones)
+        assert set(connection.execute(
+            sa.select(table['scim_resource'].c.id).where(
+                table['scim_resource'].c.id.in_(['Case-ID', 'case-id'])
+            )
+        ).scalars()) == {'Case-ID', 'case-id'}
+
+        if engine.dialect.name in MYSQL_FAMILY:
+            rows = connection.execute(sa.text(
+                """
+                SELECT TABLE_NAME, COLUMN_NAME, CHARACTER_SET_NAME,
+                       COLLATION_NAME
+                  FROM information_schema.COLUMNS
+                 WHERE TABLE_SCHEMA = DATABASE()
+                   AND (
+                     (TABLE_NAME = 'user' AND COLUMN_NAME IN
+                       ('email', 'address_type')) OR
+                     (TABLE_NAME = 'alias' AND COLUMN_NAME IN
+                       ('email', 'address_type')) OR
+                     (TABLE_NAME = 'mail_address' AND COLUMN_NAME IN
+                       ('email', 'address_type')) OR
+                     (TABLE_NAME = 'scim_resource' AND COLUMN_NAME IN
+                       ('user_email', 'alias_email', 'subject_address', 'id')) OR
+                     (TABLE_NAME = 'scim_group_member' AND COLUMN_NAME IN
+                       ('group_id', 'member_id')) OR
+                     (TABLE_NAME = 'scim_group_destination' AND COLUMN_NAME IN
+                       ('group_id', 'destination'))
+                   )
+                """
+            )).all()
+            storage = {
+                (table_name, column_name): (character_set, collation)
+                for table_name, column_name, character_set, collation in rows
+            }
+            routing_columns = {
+                ('user', 'email'),
+                ('alias', 'email'),
+                ('mail_address', 'email'),
+                ('scim_resource', 'user_email'),
+                ('scim_resource', 'alias_email'),
+                ('scim_resource', 'subject_address'),
+                ('scim_group_destination', 'destination'),
+            }
+            address_type_columns = {
+                ('user', 'address_type'),
+                ('alias', 'address_type'),
+                ('mail_address', 'address_type'),
+            }
+            exact_columns = {
+                ('scim_resource', 'id'),
+                ('scim_group_member', 'group_id'),
+                ('scim_group_member', 'member_id'),
+                ('scim_group_destination', 'group_id'),
+            }
+            assert len({storage[column] for column in routing_columns}) == 1
+            assert len({storage[column] for column in address_type_columns}) == 1
+            exact_storage = {storage[column] for column in exact_columns}
+            assert len(exact_storage) == 1
+            _character_set, exact_collation = next(iter(exact_storage))
+            assert exact_collation.endswith('_bin')
+            model_type = models.ScimResource.__table__.c.id.type.dialect_impl(
+                engine.dialect
+            )
+            assert model_type.charset == _character_set
+            assert model_type.collation == exact_collation
+            assert changed_default is not None
+            legacy_collation, database_default = changed_default
+            assert legacy_collation != database_default
+            assert storage[('user', 'email')][1] == legacy_collation
+
+
+def test_real_populated_upgrade_preserves_data_and_native_constraints(
+    native_migration_app,
+):
+    engine = models.db.engine
+    _upgrade(BASE_REVISION)
+    snapshots = _seed_populated_legacy_database(engine)
+    changed_default = _change_mysql_database_default(engine)
+    _upgrade('head')
+    _assert_populated_upgrade(engine, changed_default, snapshots)
+
+
+def test_mysql_registry_storage_preflight_is_before_ddl(
+    native_migration_app,
+):
+    engine = models.db.engine
+    if engine.dialect.name not in MYSQL_FAMILY:
+        pytest.skip('requires MariaDB/MySQL non-transactional DDL')
+
+    _upgrade(BASE_REVISION)
+    snapshots = _seed_populated_legacy_database(engine)
+    original_collation, changed_collation = (
+        _force_alias_email_collation_mismatch(engine)
+    )
+    assert original_collation != changed_collation
+
+    with pytest.raises(RuntimeError, match='different email storage semantics'):
+        _upgrade('head')
+
+    inspector = sa.inspect(engine)
+    table_names = set(inspector.get_table_names())
+    assert 'mail_address' not in table_names
+    assert not {name for name in table_names if name.startswith('scim_')}
+    assert 'address_type' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    assert 'address_type' not in {
+        column['name'] for column in inspector.get_columns('alias')
+    }
+    assert 'auth_generation' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    with engine.connect() as connection:
+        assert connection.scalar(sa.text(
+            'SELECT version_num FROM alembic_version'
+        )) == BASE_REVISION
+    _assert_table_snapshots(engine, snapshots)
+
+
+def test_invalid_legacy_identity_fails_before_identity_ddl_and_retries(
+    native_migration_app,
+):
+    engine = models.db.engine
+    _upgrade(BASE_REVISION)
+    _seed_invalid_identity(engine)
+    _upgrade(ADDRESS_REVISION)
+
+    with pytest.raises(RuntimeError, match='invalid@xn--'):
+        _upgrade('head')
+
+    inspector = sa.inspect(engine)
+    assert 'mail_address' in set(inspector.get_table_names())
+    assert 'address_type' in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    assert 'auth_generation' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    assert not {
+        'scim_state',
+        'scim_resource',
+        'scim_group_member',
+        'scim_group_destination',
+    } & set(inspector.get_table_names())
+    with engine.begin() as connection:
+        table = _tables(
+            connection,
+            'alembic_version',
+            'user',
+            'mail_address',
+        )
+        assert connection.scalar(
+            sa.select(table['alembic_version'].c.version_num)
+        ) == ADDRESS_REVISION
+        connection.execute(
+            table['user'].delete().where(
+                table['user'].c.email == 'invalid@xn--'
+            )
+        )
+        connection.execute(
+            table['mail_address'].delete().where(
+                table['mail_address'].c.email == 'invalid@xn--'
+            )
+        )
+
+    _upgrade('head')
+    inspector = sa.inspect(engine)
+    assert 'auth_generation' in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    _assert_member_index(inspector)
+    with engine.connect() as connection:
+        assert connection.scalar(sa.text(
+            'SELECT COUNT(*) FROM scim_resource'
+        )) == 0
+        assert connection.scalar(sa.text(
+            'SELECT version_num FROM alembic_version'
+        )) == HEAD_REVISION
+
+
+def test_postgresql_staging_sql_error_preserves_collision_diagnostic(
+    native_migration_app,
+):
+    engine = models.db.engine
+    if engine.dialect.name != 'postgresql':
+        pytest.skip('requires PostgreSQL aborted-transaction behavior')
+
+    _upgrade(BASE_REVISION)
+    _seed_duplicate_published_identity(engine)
+    _upgrade(ADDRESS_REVISION)
+
+    with pytest.raises(
+        RuntimeError,
+        match='Cannot stage every legacy SCIM ID without loss or collision',
+    ):
+        _upgrade('head')
+
+    inspector = sa.inspect(engine)
+    assert 'auth_generation' not in {
+        column['name'] for column in inspector.get_columns('user')
+    }
+    assert not {
+        'scim_state',
+        'scim_resource',
+        'scim_group_member',
+        'scim_group_destination',
+    } & set(inspector.get_table_names())
+    with engine.connect() as connection:
+        assert connection.scalar(sa.text(
+            'SELECT version_num FROM alembic_version'
+        )) == ADDRESS_REVISION
+
+
+def test_mysql_non_utf8mb4_legacy_schema_preserves_non_latin_scim_id(
+    native_migration_app,
+):
+    engine = models.db.engine
+    if engine.dialect.name not in MYSQL_FAMILY:
+        pytest.skip('requires MariaDB/MySQL legacy charset storage')
+
+    _set_mysql_database_default(engine, 'latin1', 'latin1_swedish_ci')
+    _upgrade(BASE_REVISION)
+    stored_email, published_id = _seed_non_latin_idna_identity(engine)
+    _upgrade('head')
+
+    with engine.connect() as connection:
+        table = _tables(connection, 'scim_resource')
+        assert connection.execute(sa.select(
+            table['scim_resource'].c.id,
+            table['scim_resource'].c.user_email,
+        )).one() == (published_id, stored_email)
+        assert _mysql_column_storage(
+            connection,
+            'user',
+            'email',
+        ) == ('latin1', 'latin1_swedish_ci')
+        for table_name, column_name in (
+            ('scim_resource', 'id'),
+            ('scim_group_member', 'group_id'),
+            ('scim_group_member', 'member_id'),
+            ('scim_group_destination', 'group_id'),
+        ):
+            assert _mysql_column_storage(
+                connection,
+                table_name,
+                column_name,
+            ) == ('utf8mb4', 'utf8mb4_bin')
+
+    model_type = models.ScimResource.__table__.c.id.type.dialect_impl(
+        engine.dialect
+    )
+    assert model_type.charset == 'utf8mb4'
+    assert model_type.collation == 'utf8mb4_bin'
+
+
+def test_user_migration_reads_and_writes_are_bounded(
+    native_migration_app,
+    monkeypatch,
+):
+    engine = models.db.engine
+
+    user_count = EXPECTED_BACKFILL_BATCH_SIZE + 1
+    _upgrade(BASE_REVISION)
+    _seed_backfill_population(
+        engine,
+        user_count,
+        alias_count=user_count,
+    )
+
+    collision_probe_limits = []
+    source_read_limits = []
+    staged_batch_sizes = []
+    copied_batch_sizes = []
+    original_execute = sa.engine.Connection.execute
+
+    def record_execute(
+        connection,
+        statement,
+        parameters=None,
+        *args,
+        **kwargs,
+    ):
+        table = getattr(statement, 'table', None)
+        table_name = getattr(table, 'name', None)
+        if table_name == '_mailu_scim_resource_stage':
+            staged_batch_sizes.append(
+                len(parameters) if isinstance(parameters, list) else 1
+            )
+        elif table_name == 'scim_resource':
+            copied_batch_sizes.append(
+                len(parameters) if isinstance(parameters, list) else 1
+            )
+
+        get_final_froms = getattr(statement, 'get_final_froms', None)
+        limit_clause = getattr(statement, '_limit_clause', None)
+        if get_final_froms is not None and limit_clause is not None:
+            def table_names(from_clause):
+                name = getattr(from_clause, 'name', None)
+                if name is not None:
+                    return {name}
+                names = set()
+                for side in ('left', 'right'):
+                    nested = getattr(from_clause, side, None)
+                    if nested is not None:
+                        names.update(table_names(nested))
+                return names
+
+            from_names = set()
+            for from_clause in get_final_froms():
+                from_names.update(table_names(from_clause))
+            if from_names == {'alias', 'user'}:
+                collision_probe_limits.append(limit_clause.value)
+            if from_names == {'user'}:
+                source_read_limits.append(limit_clause.value)
+        return original_execute(
+            connection,
+            statement,
+            parameters,
+            *args,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(sa.engine.Connection, 'execute', record_execute)
+    _upgrade(ADDRESS_REVISION)
+    _upgrade('head')
+
+    assert collision_probe_limits == [EXPECTED_COLLISION_PROBE_LIMIT] * 2
+    assert source_read_limits == [EXPECTED_BACKFILL_BATCH_SIZE] * 3
+    assert staged_batch_sizes == [EXPECTED_BACKFILL_BATCH_SIZE, 1]
+    assert copied_batch_sizes == [EXPECTED_BACKFILL_BATCH_SIZE, 1]
+    with engine.connect() as connection:
+        assert connection.scalar(sa.text(
+            'SELECT COUNT(*) FROM scim_resource'
+        )) == user_count

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -277,3 +277,38 @@ def test_scim_patch_rejects_unknown_path(app, client):
 
     assert rv.status_code == 400
     assert rv.get_json()['scimType'] == 'invalidPath'
+
+
+def test_scim_list_caps_count_to_advertised_max_results(app, client):
+    with app.app_context():
+        domain = create_domain()
+        for localpart in ('kate', 'louis'):
+            user = models.User(localpart=localpart, domain=domain)
+            user.set_password('secret')
+            models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.get('/api/scim/v2/Users?count=999999', headers=auth_headers(app))
+
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data['itemsPerPage'] == 2
+    assert data['totalResults'] == 2
+
+
+def test_scim_patch_rejects_empty_operations(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='mallory', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.patch(
+        '/api/scim/v2/Users/mallory@example.com',
+        json={'Operations': []},
+        headers=auth_headers(app),
+    )
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'invalidValue'

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -133,3 +133,76 @@ def test_scim_delete_disables_user_without_removing_mailbox(app, client):
         user = models.db.session.get(models.User, 'dave@example.com')
         assert user is not None
         assert user.enabled is False
+
+
+def test_scim_list_rejects_invalid_pagination(app, client):
+    rv = client.get('/api/scim/v2/Users?startIndex=nope', headers=auth_headers(app))
+
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data['schemas'] == ['urn:ietf:params:scim:api:messages:2.0:Error']
+    assert data['scimType'] == 'invalidValue'
+
+
+def test_scim_create_rejects_non_object_payload(app, client):
+    rv = client.post('/api/scim/v2/Users', json=[], headers=auth_headers(app))
+
+    assert rv.status_code == 400
+    data = rv.get_json()
+    assert data['scimType'] == 'invalidSyntax'
+
+
+def test_scim_create_parses_string_false_active(app, client):
+    with app.app_context():
+        create_domain()
+
+    payload = {
+        'userName': 'erin@example.com',
+        'active': 'false',
+    }
+    rv = client.post('/api/scim/v2/Users', json=payload, headers=auth_headers(app))
+
+    assert rv.status_code == 201
+    assert rv.get_json()['active'] is False
+    with app.app_context():
+        user = models.db.session.get(models.User, 'erin@example.com')
+        assert user.enabled is False
+
+
+def test_scim_patch_rejects_invalid_active_value(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='frank', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    payload = {
+        'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        'Operations': [{'op': 'replace', 'path': 'active', 'value': 'maybe'}],
+    }
+    rv = client.patch('/api/scim/v2/Users/frank@example.com', json=payload, headers=auth_headers(app))
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'invalidValue'
+    with app.app_context():
+        user = models.db.session.get(models.User, 'frank@example.com')
+        assert user.enabled is True
+
+
+def test_scim_patch_rejects_non_object_operations(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='grace', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.patch(
+        '/api/scim/v2/Users/grace@example.com',
+        json={'Operations': ['not-an-object']},
+        headers=auth_headers(app),
+    )
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'invalidSyntax'

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -1,4 +1,16 @@
+import urllib.parse
+
+import pytest
+from sqlalchemy.orm import Session
+
 from mailu import models
+from mailu.api import scim
+
+
+USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User'
+GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group'
+PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'
+BULK_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest'
 
 
 def auth_headers(app):
@@ -15,6 +27,38 @@ def create_domain(name='example.com'):
     return domain
 
 
+def create_user(localpart='conditional-user', *, displayed_name='Original user'):
+    domain = models.db.session.get(models.Domain, 'example.com') or create_domain()
+    user = models.User(localpart=localpart, domain=domain, displayed_name=displayed_name)
+    user.set_password('secret')
+    models.db.session.add(user)
+    models.db.session.commit()
+    return user
+
+
+def create_group(localpart='conditional-group', *, comment='Original group'):
+    domain = models.db.session.get(models.Domain, 'example.com') or create_domain()
+    group = models.Alias(
+        localpart=localpart,
+        domain=domain,
+        comment=comment,
+        destination=['original@example.net'],
+    )
+    models.db.session.add(group)
+    models.db.session.commit()
+    return group
+
+
+def assert_precondition_failed(response):
+    assert response.status_code == 412
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json() == {
+        'schemas': ['urn:ietf:params:scim:api:messages:2.0:Error'],
+        'status': '412',
+        'detail': 'If-Match does not match the current resource version',
+    }
+
+
 def test_scim_service_provider_config(app, client):
     rv = client.get('/api/scim/v2/ServiceProviderConfig', headers=auth_headers(app))
 
@@ -23,6 +67,8 @@ def test_scim_service_provider_config(app, client):
     assert data['patch']['supported'] is True
     assert data['bulk']['supported'] is True
     assert data['etag']['supported'] is True
+    assert data['filter']['supported'] is False
+    assert data['changePassword']['supported'] is False
     assert data['authenticationSchemes'][0]['type'] == 'oauthbearertoken'
 
 
@@ -48,7 +94,11 @@ def test_scim_groups_are_backed_by_aliases(app, client):
     assert data['displayName'] == 'admins@example.com'
     assert data['members'][0]['value'] == 'alice@example.com'
     assert data['meta']['resourceType'] == 'Group'
-    assert data['meta']['version'].startswith('W/"')
+    assert data['meta']['version'].startswith('"')
+    assert data['meta']['version'].endswith('"')
+    assert rv.headers['ETag'] == data['meta']['version']
+    assert rv.headers['Location'] == data['meta']['location']
+    assert rv.headers['Content-Location'] == data['meta']['location']
 
     with app.app_context():
         alias = models.db.session.get(models.Alias, 'admins@example.com')
@@ -83,6 +133,108 @@ def test_scim_group_patch_updates_alias_members(app, client):
         assert alias.destination == ['bob@example.com']
 
 
+def test_scim_group_patch_supports_filtered_and_remove_all_members(app, client):
+    with app.app_context():
+        domain = create_domain()
+        group = models.Alias(
+            localpart='filtered',
+            domain=domain,
+            destination=['alice@example.com', 'bob@example.com'],
+        )
+        models.db.session.add(group)
+        models.db.session.commit()
+
+    filtered = client.patch(
+        '/api/scim/v2/Groups/filtered@example.com',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'remove',
+                'path': 'members[value eq "alice@example.com"]',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert filtered.status_code == 200
+    assert [member['value'] for member in filtered.get_json()['members']] == ['bob@example.com']
+
+    no_target = client.patch(
+        '/api/scim/v2/Groups/filtered@example.com',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'remove',
+                'path': 'members[value eq "missing@example.com"]',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert no_target.status_code == 200
+    assert [member['value'] for member in no_target.get_json()['members']] == ['bob@example.com']
+
+    remove_all = client.patch(
+        '/api/scim/v2/Groups/filtered@example.com',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{'op': 'remove', 'path': 'members'}],
+        },
+        headers=auth_headers(app),
+    )
+    assert remove_all.status_code == 200
+    assert remove_all.get_json()['members'] == []
+
+    required = client.patch(
+        '/api/scim/v2/Groups/filtered@example.com',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{'op': 'remove', 'path': 'displayName'}],
+        },
+        headers=auth_headers(app),
+    )
+    assert required.status_code == 400
+    assert required.get_json()['scimType'] == 'mutability'
+
+
+def test_scim_group_pathless_patch_applies_all_attributes_atomically(app, client):
+    with app.app_context():
+        group_id = create_group(localpart='pathless').email
+
+    response = client.patch(
+        f'/api/scim/v2/Groups/{group_id}',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'value': {
+                    'displayName': 'Pathless group',
+                    'members': [{'value': 'member@example.net'}],
+                },
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert response.status_code == 200
+    assert response.get_json()['displayName'] == 'Pathless group'
+    assert [member['value'] for member in response.get_json()['members']] == ['member@example.net']
+
+    rejected = client.patch(
+        f'/api/scim/v2/Groups/{group_id}',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [
+                {'op': 'replace', 'path': 'displayName', 'value': 'Leaked change'},
+                {'op': 'replace', 'path': 'unsupported', 'value': 'reject'},
+            ],
+        },
+        headers=auth_headers(app),
+    )
+    assert rejected.status_code == 400
+    with app.app_context():
+        group = models.db.session.get(models.Alias, group_id)
+        assert group.comment == 'Pathless group'
+        assert group.destination == ['member@example.net']
+
+
 
 def test_scim_user_resources_include_etag_metadata(app, client):
     with app.app_context():
@@ -97,8 +249,595 @@ def test_scim_user_resources_include_etag_metadata(app, client):
     assert rv.status_code == 200
     meta = rv.get_json()['meta']
     assert meta['resourceType'] == 'User'
-    assert meta['version'].startswith('W/"')
-    assert meta['created']
+    assert meta['version'].startswith('"')
+    assert meta['version'].endswith('"')
+    assert 'created' not in meta
+    assert 'lastModified' not in meta
+    assert rv.headers['ETag'] == meta['version']
+    assert rv.headers['Content-Location'] == meta['location']
+
+
+def test_scim_resource_locations_percent_encode_reserved_id_characters(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='hash#tag').email
+
+    response = client.get(
+        f'/api/scim/v2/Users/{urllib.parse.quote(user_id, safe="@")}',
+        headers=auth_headers(app),
+    )
+    location = response.get_json()['meta']['location']
+
+    assert response.status_code == 200
+    assert '#tag' not in location
+    assert '%23tag' in location
+    followed = client.get(
+        urllib.parse.urlsplit(location).path,
+        headers=auth_headers(app),
+    )
+    assert followed.status_code == 200
+    assert followed.get_json()['id'] == user_id
+
+
+@pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
+def test_scim_conditional_get_uses_http_entity_tag_rules(app, client, resource_type):
+    with app.app_context():
+        resource = create_user() if resource_type == 'Users' else create_group()
+        resource_id = resource.email
+
+    url = f'/api/scim/v2/{resource_type}/{resource_id}'
+    current = client.get(url, headers=auth_headers(app))
+    version = current.headers['ETag']
+
+    not_modified = client.get(
+        url,
+        headers={**auth_headers(app), 'If-None-Match': f'"other", W/{version}'},
+    )
+    assert not_modified.status_code == 304
+    assert not_modified.data == b''
+    assert not_modified.headers['ETag'] == version
+
+    matched = client.get(
+        url,
+        headers={**auth_headers(app), 'If-Match': f'"other", {version}'},
+    )
+    assert matched.status_code == 200
+
+    stale = client.get(
+        url,
+        headers={**auth_headers(app), 'If-Match': '"stale"'},
+    )
+    assert_precondition_failed(stale)
+
+
+@pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
+def test_scim_if_none_match_rejects_unsafe_change(app, client, resource_type):
+    with app.app_context():
+        resource = create_user() if resource_type == 'Users' else create_group()
+        resource_id = resource.email
+
+    url = f'/api/scim/v2/{resource_type}/{resource_id}'
+    version = client.get(url, headers=auth_headers(app)).headers['ETag']
+    if resource_type == 'Users':
+        payload = {
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [
+                {'op': 'replace', 'path': 'displayName', 'value': 'Must not change'},
+            ],
+        }
+    else:
+        payload = {
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [
+                {
+                    'op': 'replace',
+                    'path': 'members',
+                    'value': [{'value': 'must-not-change@example.net'}],
+                },
+            ],
+        }
+
+    response = client.patch(
+        url,
+        json=payload,
+        headers={
+            **auth_headers(app),
+            'If-Match': version,
+            'If-None-Match': f'W/{version}',
+        },
+    )
+
+    assert response.status_code == 412
+    assert response.get_json()['detail'] == 'If-None-Match matches the current resource version'
+    with app.app_context():
+        if resource_type == 'Users':
+            user = models.db.session.get(models.User, resource_id)
+            assert user.displayed_name == 'Original user'
+        else:
+            group = models.db.session.get(models.Alias, resource_id)
+            assert group.destination == ['original@example.net']
+
+
+def test_scim_if_match_supports_lists_and_wildcard_but_rejects_weak_tags(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='entity-tags').email
+    url = f'/api/scim/v2/Users/{user_id}'
+    version = client.get(url, headers=auth_headers(app)).headers['ETag']
+    payload = {
+        'schemas': [PATCH_SCHEMA],
+        'Operations': [
+            {'op': 'replace', 'path': 'displayName', 'value': 'List match'},
+        ],
+    }
+
+    weak = client.patch(
+        url,
+        json=payload,
+        headers={**auth_headers(app), 'If-Match': f'W/{version}'},
+    )
+    assert_precondition_failed(weak)
+
+    listed = client.patch(
+        url,
+        json=payload,
+        headers={**auth_headers(app), 'If-Match': f'"other", {version}'},
+    )
+    assert listed.status_code == 200
+    assert listed.get_json()['displayName'] == 'List match'
+
+    wildcard = client.patch(
+        url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [
+                {'op': 'replace', 'path': 'displayName', 'value': 'Wildcard match'},
+            ],
+        },
+        headers={**auth_headers(app), 'If-Match': '*'},
+    )
+    assert wildcard.status_code == 200
+    assert wildcard.get_json()['displayName'] == 'Wildcard match'
+
+
+@pytest.mark.parametrize('method', ['PUT', 'PATCH', 'DELETE'])
+def test_scim_user_if_match_rejects_stale_without_changes(app, client, method):
+    with app.app_context():
+        user = create_user()
+        user_id = user.email
+
+    initial = client.get(f'/api/scim/v2/Users/{user_id}', headers=auth_headers(app))
+    stale_version = initial.get_json()['meta']['version']
+
+    with app.app_context():
+        user = models.db.session.get(models.User, user_id)
+        user.displayed_name = 'Concurrent user update'
+        models.db.session.commit()
+        expected_password = user.password
+
+    current = client.get(f'/api/scim/v2/Users/{user_id}', headers=auth_headers(app))
+    current_version = current.get_json()['meta']['version']
+    assert current_version != stale_version
+
+    headers = {**auth_headers(app), 'If-Match': stale_version}
+    if method == 'PUT':
+        response = client.put(
+            f'/api/scim/v2/Users/{user_id}',
+            json={
+                'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
+                'id': user_id,
+                'userName': user_id,
+                'active': False,
+                'displayName': 'Rejected stale replacement',
+            },
+            headers=headers,
+        )
+    elif method == 'PATCH':
+        response = client.patch(
+            f'/api/scim/v2/Users/{user_id}',
+            json={
+                'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                'Operations': [
+                    {'op': 'replace', 'path': 'active', 'value': False},
+                    {'op': 'replace', 'path': 'displayName', 'value': 'Rejected stale patch'},
+                ],
+            },
+            headers=headers,
+        )
+    else:
+        response = client.delete(f'/api/scim/v2/Users/{user_id}', headers=headers)
+
+    assert_precondition_failed(response)
+    with app.app_context():
+        user = models.db.session.get(models.User, user_id)
+        assert user.enabled is True
+        assert user.displayed_name == 'Concurrent user update'
+        assert user.password == expected_password
+
+    current_headers = {**auth_headers(app), 'If-Match': current_version}
+    if method == 'PUT':
+        response = client.put(
+            f'/api/scim/v2/Users/{user_id}',
+            json={
+                'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
+                'id': user_id,
+                'userName': user_id,
+                'active': False,
+                'displayName': 'Accepted replacement',
+            },
+            headers=current_headers,
+        )
+        assert response.status_code == 200
+        assert response.get_json()['displayName'] == 'Accepted replacement'
+    elif method == 'PATCH':
+        response = client.patch(
+            f'/api/scim/v2/Users/{user_id}',
+            json={
+                'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                'Operations': [{'op': 'replace', 'path': 'displayName', 'value': 'Accepted patch'}],
+            },
+            headers=current_headers,
+        )
+        assert response.status_code == 200
+        assert response.get_json()['displayName'] == 'Accepted patch'
+    else:
+        response = client.delete(f'/api/scim/v2/Users/{user_id}', headers=current_headers)
+        assert response.status_code == 204
+
+
+@pytest.mark.parametrize('method', ['PUT', 'PATCH', 'DELETE'])
+def test_scim_group_if_match_rejects_stale_without_changes(app, client, method):
+    with app.app_context():
+        group = create_group()
+        group_id = group.email
+
+    initial = client.get(f'/api/scim/v2/Groups/{group_id}', headers=auth_headers(app))
+    stale_version = initial.get_json()['meta']['version']
+
+    with app.app_context():
+        group = models.db.session.get(models.Alias, group_id)
+        group.comment = 'Concurrent group update'
+        group.destination = ['current@example.net']
+        models.db.session.commit()
+
+    current = client.get(f'/api/scim/v2/Groups/{group_id}', headers=auth_headers(app))
+    current_version = current.get_json()['meta']['version']
+    assert current_version != stale_version
+
+    headers = {**auth_headers(app), 'If-Match': stale_version}
+    if method == 'PUT':
+        response = client.put(
+            f'/api/scim/v2/Groups/{group_id}',
+            json={
+                'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+                'id': group_id,
+                'displayName': 'Rejected stale replacement',
+                'members': [{'value': 'rejected@example.net'}],
+            },
+            headers=headers,
+        )
+    elif method == 'PATCH':
+        response = client.patch(
+            f'/api/scim/v2/Groups/{group_id}',
+            json={
+                'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                'Operations': [
+                    {
+                        'op': 'replace',
+                        'path': 'members',
+                        'value': [{'value': 'rejected@example.net'}],
+                    }
+                ],
+            },
+            headers=headers,
+        )
+    else:
+        response = client.delete(f'/api/scim/v2/Groups/{group_id}', headers=headers)
+
+    assert_precondition_failed(response)
+    with app.app_context():
+        group = models.db.session.get(models.Alias, group_id)
+        assert group.comment == 'Concurrent group update'
+        assert group.destination == ['current@example.net']
+
+    current_headers = {**auth_headers(app), 'If-Match': current_version}
+    if method == 'PUT':
+        response = client.put(
+            f'/api/scim/v2/Groups/{group_id}',
+            json={
+                'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+                'id': group_id,
+                'displayName': 'Accepted replacement',
+                'members': [{'value': 'accepted@example.net'}],
+            },
+            headers=current_headers,
+        )
+        assert response.status_code == 200
+        assert response.get_json()['displayName'] == 'Accepted replacement'
+    elif method == 'PATCH':
+        response = client.patch(
+            f'/api/scim/v2/Groups/{group_id}',
+            json={
+                'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+                'Operations': [
+                    {
+                        'op': 'replace',
+                        'path': 'members',
+                        'value': [{'value': 'accepted@example.net'}],
+                    }
+                ],
+            },
+            headers=current_headers,
+        )
+        assert response.status_code == 200
+        assert [member['value'] for member in response.get_json()['members']] == ['accepted@example.net']
+    else:
+        response = client.delete(f'/api/scim/v2/Groups/{group_id}', headers=current_headers)
+        assert response.status_code == 204
+
+
+def test_scim_user_patch_rejects_password_change_without_side_effects(app, client, monkeypatch):
+    with app.app_context():
+        user = create_user(localpart='patch-password')
+        user_id = user.email
+        original_password = user.password
+
+    pruned_users = []
+    monkeypatch.setattr(
+        models.utils.MailuSessionExtension,
+        'prune_sessions',
+        lambda uid=None, keep=None, app=None: pruned_users.append(uid),
+    )
+    response = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'Operations': [
+                {'op': 'replace', 'path': 'password', 'value': 'replacement-secret'},
+                {'op': 'replace', 'path': 'unsupported', 'value': 'reject the request'},
+            ],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'mutability'
+    assert pruned_users == []
+    with app.app_context():
+        user = models.db.session.get(models.User, user_id)
+        assert user.password == original_password
+
+
+@pytest.mark.parametrize('method', ['PUT', 'PATCH', 'DELETE'])
+def test_scim_deprovisioning_prunes_existing_sessions_after_commit(
+    app,
+    client,
+    monkeypatch,
+    method,
+):
+    with app.app_context():
+        user_id = create_user(localpart=f'deprovision-{method.lower()}').email
+
+    pruned_users = []
+    monkeypatch.setattr(
+        models.utils.MailuSessionExtension,
+        'prune_sessions',
+        lambda uid=None, keep=None, app=None: pruned_users.append(uid),
+    )
+    url = f'/api/scim/v2/Users/{user_id}'
+    if method == 'PUT':
+        response = client.put(
+            url,
+            json={
+                'schemas': [USER_SCHEMA],
+                'userName': user_id,
+                'active': False,
+            },
+            headers=auth_headers(app),
+        )
+    elif method == 'PATCH':
+        response = client.patch(
+            url,
+            json={
+                'schemas': [PATCH_SCHEMA],
+                'Operations': [{
+                    'op': 'replace',
+                    'path': 'active',
+                    'value': False,
+                }],
+            },
+            headers=auth_headers(app),
+        )
+    else:
+        response = client.delete(url, headers=auth_headers(app))
+
+    assert response.status_code == (204 if method == 'DELETE' else 200)
+    assert pruned_users == [user_id]
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is False
+
+
+def test_scim_stale_deprovision_precondition_does_not_prune_sessions(
+    app,
+    client,
+    monkeypatch,
+):
+    with app.app_context():
+        user_id = create_user(localpart='stale-deprovision').email
+    url = f'/api/scim/v2/Users/{user_id}'
+    stale_version = client.get(url, headers=auth_headers(app)).headers['ETag']
+    with app.app_context():
+        user = models.db.session.get(models.User, user_id)
+        user.displayed_name = 'Concurrent change'
+        models.db.session.commit()
+
+    pruned_users = []
+    monkeypatch.setattr(
+        models.utils.MailuSessionExtension,
+        'prune_sessions',
+        lambda uid=None, keep=None, app=None: pruned_users.append(uid),
+    )
+    response = client.patch(
+        url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'active',
+                'value': False,
+            }],
+        },
+        headers={**auth_headers(app), 'If-Match': stale_version},
+    )
+
+    assert_precondition_failed(response)
+    assert pruned_users == []
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is True
+
+
+def test_scim_session_revocation_failure_rolls_back_user_change(
+    app,
+    client,
+    monkeypatch,
+):
+    with app.app_context():
+        user_id = create_user(localpart='revoke-failure').email
+
+    def fail_revocation(**_kwargs):
+        raise RuntimeError('session store unavailable')
+
+    monkeypatch.setattr(
+        models.utils.MailuSessionExtension,
+        'prune_sessions',
+        fail_revocation,
+    )
+    response = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'active',
+                'value': False,
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 500
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['detail'] == 'Existing sessions could not be revoked'
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is True
+
+
+def test_scim_lock_failure_returns_scim_error_without_mutation(
+    app,
+    client,
+    monkeypatch,
+):
+    with app.app_context():
+        user_id = create_user(localpart='lock-failure').email
+    original_get_for_update = scim._get_for_update
+
+    def fail_user_lock(model, resource_id):
+        if model is models.User and resource_id == user_id:
+            raise scim.SQLAlchemyError('lock unavailable')
+        return original_get_for_update(model, resource_id)
+
+    monkeypatch.setattr(scim, '_get_for_update', fail_user_lock)
+    response = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'active',
+                'value': False,
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 500
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['detail'] == 'The SCIM resource could not be locked'
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is True
+
+
+def test_scim_sqlite_lock_refreshes_an_unexpired_identity(app):
+    with app.app_context():
+        user_id = create_user(localpart='stale-identity').email
+        session = models.db.session()
+        cached = session.get(models.User, user_id)
+        session.commit()
+        assert cached.displayed_name == 'Original user'
+
+        concurrent_session = Session(models.db.engine)
+        try:
+            concurrent = concurrent_session.get(models.User, user_id)
+            concurrent.displayed_name = 'Concurrent user'
+            concurrent_session.commit()
+        finally:
+            concurrent_session.close()
+
+        locked = scim._get_for_update(models.User, user_id)
+        assert locked is cached
+        assert locked.displayed_name == 'Concurrent user'
+        models.db.session.rollback()
+
+
+def test_scim_bulk_continues_after_session_revocation_failure(
+    app,
+    client,
+    monkeypatch,
+):
+    with app.app_context():
+        user_id = create_user(localpart='bulk-revoke-failure').email
+
+    def fail_revocation(**_kwargs):
+        raise RuntimeError('session store unavailable')
+
+    monkeypatch.setattr(
+        models.utils.MailuSessionExtension,
+        'prune_sessions',
+        fail_revocation,
+    )
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [
+                {
+                    'method': 'PATCH',
+                    'path': f'/Users/{user_id}',
+                    'data': {
+                        'schemas': [PATCH_SCHEMA],
+                        'Operations': [{
+                            'op': 'replace',
+                            'path': 'active',
+                            'value': False,
+                        }],
+                    },
+                },
+                {
+                    'method': 'POST',
+                    'path': '/Users',
+                    'bulkId': 'created-after-revocation-error',
+                    'data': {
+                        'schemas': [USER_SCHEMA],
+                        'userName': 'after-revocation-error@example.com',
+                    },
+                },
+            ],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert [item['status'] for item in response.get_json()['Operations']] == ['500', '201']
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is True
+        assert models.db.session.get(models.User, 'after-revocation-error@example.com') is not None
 
 
 def test_scim_create_and_get_user(app, client):
@@ -133,7 +872,10 @@ def test_scim_create_and_get_user(app, client):
 
 
 def test_scim_create_requires_existing_domain(app, client):
-    payload = {'userName': 'missing@example.com'}
+    payload = {
+        'schemas': [USER_SCHEMA],
+        'userName': 'missing@example.com',
+    }
     rv = client.post('/api/scim/v2/Users', json=payload, headers=auth_headers(app))
 
     assert rv.status_code == 404
@@ -184,6 +926,50 @@ def test_scim_patch_active_and_display_name(app, client):
         assert user.displayed_name == 'Carol Disabled'
 
 
+def test_scim_patch_accepts_schema_qualified_core_path(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='qualified-path').email
+
+    response = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': (
+                    'urn:ietf:params:scim:schemas:core:2.0:User:displayName'
+                ),
+                'value': 'Qualified path',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()['displayName'] == 'Qualified path'
+
+
+def test_scim_resource_attribute_names_are_case_insensitive(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='attribute-case').email
+
+    response = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'SCHEMAS': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+            'operations': [{
+                'OP': 'replace',
+                'PATH': 'DISPLAYNAME',
+                'VALUE': 'Case insensitive',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()['displayName'] == 'Case insensitive'
+
+
 def test_scim_delete_disables_user_without_removing_mailbox(app, client):
     with app.app_context():
         domain = create_domain()
@@ -199,6 +985,30 @@ def test_scim_delete_disables_user_without_removing_mailbox(app, client):
         user = models.db.session.get(models.User, 'dave@example.com')
         assert user is not None
         assert user.enabled is False
+
+
+@pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
+def test_scim_delete_missing_resource_returns_scim_404(app, client, resource_type):
+    response = client.delete(
+        f'/api/scim/v2/{resource_type}/missing@example.com',
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 404
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['status'] == '404'
+
+
+def test_scim_repeated_group_delete_returns_scim_404(app, client):
+    with app.app_context():
+        group_id = create_group(localpart='delete-twice').email
+    url = f'/api/scim/v2/Groups/{group_id}'
+
+    assert client.delete(url, headers=auth_headers(app)).status_code == 204
+    repeated = client.delete(url, headers=auth_headers(app))
+
+    assert repeated.status_code == 404
+    assert repeated.get_json()['status'] == '404'
 
 
 def test_scim_list_rejects_invalid_pagination(app, client):
@@ -223,6 +1033,7 @@ def test_scim_create_parses_string_false_active(app, client):
         create_domain()
 
     payload = {
+        'schemas': [USER_SCHEMA],
         'userName': 'erin@example.com',
         'active': 'false',
     }
@@ -266,7 +1077,10 @@ def test_scim_patch_rejects_non_object_operations(app, client):
 
     rv = client.patch(
         '/api/scim/v2/Users/grace@example.com',
-        json={'Operations': ['not-an-object']},
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': ['not-an-object'],
+        },
         headers=auth_headers(app),
     )
 
@@ -280,7 +1094,11 @@ def test_scim_create_handles_non_string_username_and_name(app, client):
 
     rv = client.post(
         '/api/scim/v2/Users',
-        json={'userName': 123, 'name': 'not-an-object'},
+        json={
+            'schemas': [USER_SCHEMA],
+            'userName': 123,
+            'name': 'not-an-object',
+        },
         headers=auth_headers(app),
     )
 
@@ -298,18 +1116,21 @@ def test_scim_patch_rejects_non_string_op_and_path(app, client):
 
     rv = client.patch(
         '/api/scim/v2/Users/heidi@example.com',
-        json={'Operations': [{'op': 7, 'path': 9, 'value': 'ignored'}]},
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{'op': 7, 'path': 9, 'value': 'ignored'}],
+        },
         headers=auth_headers(app),
     )
 
     assert rv.status_code == 400
-    assert rv.get_json()['scimType'] == 'mutability'
+    assert rv.get_json()['scimType'] == 'invalidSyntax'
     with app.app_context():
         user = models.db.session.get(models.User, 'heidi@example.com')
         assert user.enabled is True
 
 
-def test_scim_patch_rejects_remove_operation(app, client):
+def test_scim_patch_remove_clears_optional_display_name(app, client):
     with app.app_context():
         domain = create_domain()
         user = models.User(localpart='ivan', domain=domain)
@@ -319,12 +1140,17 @@ def test_scim_patch_rejects_remove_operation(app, client):
 
     rv = client.patch(
         '/api/scim/v2/Users/ivan@example.com',
-        json={'Operations': [{'op': 'remove', 'path': 'displayName'}]},
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{'op': 'remove', 'path': 'displayName'}],
+        },
         headers=auth_headers(app),
     )
 
-    assert rv.status_code == 400
-    assert rv.get_json()['scimType'] == 'mutability'
+    assert rv.status_code == 200
+    assert rv.get_json()['displayName'] == 'ivan@example.com'
+    with app.app_context():
+        assert models.db.session.get(models.User, 'ivan@example.com').displayed_name == ''
 
 
 def test_scim_patch_rejects_unknown_path(app, client):
@@ -337,7 +1163,14 @@ def test_scim_patch_rejects_unknown_path(app, client):
 
     rv = client.patch(
         '/api/scim/v2/Users/judy@example.com',
-        json={'Operations': [{'op': 'replace', 'path': 'title', 'value': 'Boss'}]},
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'title',
+                'value': 'Boss',
+            }],
+        },
         headers=auth_headers(app),
     )
 
@@ -372,7 +1205,7 @@ def test_scim_patch_rejects_empty_operations(app, client):
 
     rv = client.patch(
         '/api/scim/v2/Users/mallory@example.com',
-        json={'Operations': []},
+        json={'schemas': [PATCH_SCHEMA], 'Operations': []},
         headers=auth_headers(app),
     )
 
@@ -386,7 +1219,11 @@ def test_scim_create_rejects_non_string_password(app, client):
 
     rv = client.post(
         '/api/scim/v2/Users',
-        json={'userName': 'nick@example.com', 'password': {'cleartext': 'nope'}},
+        json={
+            'schemas': [USER_SCHEMA],
+            'userName': 'nick@example.com',
+            'password': {'cleartext': 'nope'},
+        },
         headers=auth_headers(app),
     )
 
@@ -396,7 +1233,7 @@ def test_scim_create_rejects_non_string_password(app, client):
         assert models.db.session.get(models.User, 'nick@example.com') is None
 
 
-def test_scim_patch_rejects_non_string_password(app, client):
+def test_scim_patch_rejects_existing_password_changes(app, client):
     with app.app_context():
         domain = create_domain()
         user = models.User(localpart='olivia', domain=domain)
@@ -406,12 +1243,19 @@ def test_scim_patch_rejects_non_string_password(app, client):
 
     rv = client.patch(
         '/api/scim/v2/Users/olivia@example.com',
-        json={'Operations': [{'op': 'replace', 'path': 'password', 'value': ['bad']}]},
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'password',
+                'value': ['bad'],
+            }],
+        },
         headers=auth_headers(app),
     )
 
     assert rv.status_code == 400
-    assert rv.get_json()['scimType'] == 'invalidValue'
+    assert rv.get_json()['scimType'] == 'mutability'
 
 
 def test_scim_create_rejects_malformed_json(app, client):
@@ -437,15 +1281,20 @@ def test_scim_bulk_creates_user_and_group(app, client):
                 'method': 'POST',
                 'path': '/Users',
                 'bulkId': 'user1',
-                'data': {'userName': 'bulkuser@example.com', 'active': True},
+                'data': {
+                    'schemas': [USER_SCHEMA],
+                    'userName': 'bulkuser@example.com',
+                    'active': True,
+                },
             },
             {
                 'method': 'POST',
                 'path': '/Groups',
                 'bulkId': 'group1',
                 'data': {
+                    'schemas': [GROUP_SCHEMA],
                     'displayName': 'bulkgroup@example.com',
-                    'members': [{'value': 'bulkuser@example.com'}],
+                    'members': [{'value': 'bulkId:user1'}],
                 },
             },
         ],
@@ -456,6 +1305,8 @@ def test_scim_bulk_creates_user_and_group(app, client):
     data = rv.get_json()
     assert data['schemas'] == ['urn:ietf:params:scim:api:messages:2.0:BulkResponse']
     assert [operation['status'] for operation in data['Operations']] == ['201', '201']
+    assert [operation['method'] for operation in data['Operations']] == ['POST', 'POST']
+    assert all(operation['version'] for operation in data['Operations'])
     with app.app_context():
         assert models.db.session.get(models.User, 'bulkuser@example.com') is not None
         alias = models.db.session.get(models.Alias, 'bulkgroup@example.com')
@@ -463,12 +1314,117 @@ def test_scim_bulk_creates_user_and_group(app, client):
         assert alias.destination == ['bulkuser@example.com']
 
 
+def test_scim_bulk_resolves_forward_bulk_id_dependencies(app, client):
+    with app.app_context():
+        create_domain()
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [
+                {
+                    'method': 'POST',
+                    'path': '/Groups',
+                    'bulkId': 'group-first',
+                    'data': {
+                        'schemas': [GROUP_SCHEMA],
+                        'displayName': 'forward-group@example.com',
+                        'members': [{'value': 'bulkId:user-later'}],
+                    },
+                },
+                {
+                    'method': 'POST',
+                    'path': '/Users',
+                    'bulkId': 'user-later',
+                    'data': {
+                        'schemas': [USER_SCHEMA],
+                        'userName': 'forward-user@example.com',
+                    },
+                },
+            ],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert [item['status'] for item in response.get_json()['Operations']] == ['201', '201']
+    with app.app_context():
+        group = models.db.session.get(models.Alias, 'forward-group@example.com')
+        assert group.destination == ['forward-user@example.com']
+
+
+def test_scim_bulk_rejects_circular_bulk_id_dependencies_without_partial_commit(
+    app,
+    client,
+):
+    with app.app_context():
+        create_domain()
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'failOnErrors': 0,
+            'Operations': [
+                {
+                    'method': 'POST',
+                    'path': '/Groups',
+                    'bulkId': 'group-a',
+                    'data': {
+                        'schemas': [GROUP_SCHEMA],
+                        'displayName': 'group-a@example.com',
+                        'members': [{'value': 'bulkId:group-b'}],
+                    },
+                },
+                {
+                    'method': 'POST',
+                    'path': '/Groups',
+                    'bulkId': 'group-b',
+                    'data': {
+                        'schemas': [GROUP_SCHEMA],
+                        'displayName': 'group-b@example.com',
+                        'members': [
+                            {'value': 'bulkId:group-a'},
+                            {'value': 'not-an-email'},
+                        ],
+                    },
+                },
+            ],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert [item['status'] for item in response.get_json()['Operations']] == ['409', '409']
+    with app.app_context():
+        group_a = models.db.session.get(models.Alias, 'group-a@example.com')
+        group_b = models.db.session.get(models.Alias, 'group-b@example.com')
+        assert group_a is None
+        assert group_b is None
+
+
 def test_scim_bulk_stops_after_fail_on_errors(app, client):
     payload = {
+        'schemas': [BULK_SCHEMA],
         'failOnErrors': 1,
         'Operations': [
-            {'method': 'POST', 'path': '/Users', 'data': {'userName': 'missing@example.com'}},
-            {'method': 'POST', 'path': '/Users', 'data': {'userName': 'never@example.com'}},
+            {
+                'method': 'POST',
+                'path': '/Users',
+                'bulkId': 'missing',
+                'data': {
+                    'schemas': [USER_SCHEMA],
+                    'userName': 'missing@example.com',
+                },
+            },
+            {
+                'method': 'POST',
+                'path': '/Users',
+                'bulkId': 'never',
+                'data': {
+                    'schemas': [USER_SCHEMA],
+                    'userName': 'never@example.com',
+                },
+            },
         ],
     }
     rv = client.post('/api/scim/v2/Bulk', json=payload, headers=auth_headers(app))
@@ -477,3 +1433,888 @@ def test_scim_bulk_stops_after_fail_on_errors(app, client):
     operations = rv.get_json()['Operations']
     assert len(operations) == 1
     assert operations[0]['status'] == '404'
+
+
+@pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
+def test_scim_bulk_version_rejects_stale_resource_without_changes(app, client, resource_type):
+    with app.app_context():
+        resource = create_user() if resource_type == 'Users' else create_group()
+        resource_id = resource.email
+    url = f'/api/scim/v2/{resource_type}/{resource_id}'
+    stale_version = client.get(url, headers=auth_headers(app)).headers['ETag']
+
+    with app.app_context():
+        if resource_type == 'Users':
+            resource = models.db.session.get(models.User, resource_id)
+            resource.displayed_name = 'Concurrent user'
+        else:
+            resource = models.db.session.get(models.Alias, resource_id)
+            resource.comment = 'Concurrent group'
+        models.db.session.commit()
+
+    if resource_type == 'Users':
+        patch = {
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'displayName',
+                'value': 'Rejected',
+            }],
+        }
+    else:
+        patch = {
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'members',
+                'value': [{'value': 'rejected@example.net'}],
+            }],
+        }
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'PATCH',
+                'path': f'/{resource_type}/{resource_id}',
+                'version': stale_version,
+                'data': patch,
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 200
+    operation = response.get_json()['Operations'][0]
+    assert operation['method'] == 'PATCH'
+    assert operation['status'] == '412'
+    assert operation['response']['status'] == '412'
+    assert operation['location'].endswith(f'/{resource_type}/{resource_id}')
+    with app.app_context():
+        if resource_type == 'Users':
+            assert models.db.session.get(models.User, resource_id).displayed_name == 'Concurrent user'
+        else:
+            group = models.db.session.get(models.Alias, resource_id)
+            assert group.comment == 'Concurrent group'
+            assert group.destination == ['original@example.net']
+
+
+def test_scim_bulk_delete_response_includes_resource_location(app, client):
+    with app.app_context():
+        group_id = create_group(localpart='bulk-delete-location').email
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'DELETE',
+                'path': f'/Groups/{group_id}',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    operation = response.get_json()['Operations'][0]
+    assert operation['status'] == '204'
+    assert operation['location'].endswith(f'/Groups/{group_id}')
+    with app.app_context():
+        assert models.db.session.get(models.Alias, group_id) is None
+
+
+def test_scim_bulk_does_not_leak_failed_operation_state_into_later_commit(app, client):
+    with app.app_context():
+        group_id = create_group(localpart='bulk-rollback').email
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [
+                {
+                    'method': 'PUT',
+                    'path': f'/Groups/{group_id}',
+                    'data': {
+                        'schemas': [GROUP_SCHEMA],
+                        'id': group_id,
+                        'displayName': 'Must roll back',
+                        'members': [{}],
+                    },
+                },
+                {
+                    'method': 'POST',
+                    'path': '/Users',
+                    'bulkId': 'commit-after-error',
+                    'data': {
+                        'schemas': [USER_SCHEMA],
+                        'userName': 'committed@example.com',
+                    },
+                },
+            ],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert [item['status'] for item in response.get_json()['Operations']] == ['400', '201']
+    with app.app_context():
+        group = models.db.session.get(models.Alias, group_id)
+        assert group.comment == 'Original group'
+        assert group.destination == ['original@example.net']
+        assert models.db.session.get(models.User, 'committed@example.com') is not None
+
+
+def test_scim_bulk_ignores_outer_if_match_and_preserves_absent_version_behavior(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='bulk-outer-header').email
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'PATCH',
+                'path': f'/Users/{user_id}',
+                'data': {
+                    'schemas': [PATCH_SCHEMA],
+                    'Operations': [{
+                        'op': 'replace',
+                        'path': 'displayName',
+                        'value': 'Bulk update',
+                    }],
+                },
+            }],
+        },
+        headers={**auth_headers(app), 'If-Match': '"outer-request-tag"'},
+    )
+
+    operation = response.get_json()['Operations'][0]
+    assert operation['status'] == '200'
+    assert operation['version'] == operation['response']['meta']['version']
+    assert operation['response']['displayName'] == 'Bulk update'
+
+
+@pytest.mark.parametrize(
+    ('payload', 'detail'),
+    [
+        (
+            {
+                'schemas': [BULK_SCHEMA],
+                'Operations': [{
+                    'method': 'POST',
+                    'path': '/Users',
+                    'data': {'userName': 'x@example.com'},
+                }],
+            },
+            'POST bulk operations require a non-empty bulkId',
+        ),
+        (
+            {
+                'schemas': [BULK_SCHEMA],
+                'Operations': [
+                    {'method': 'POST', 'path': '/Users', 'bulkId': 'duplicate', 'data': {}},
+                    {'method': 'POST', 'path': '/Groups', 'bulkId': 'duplicate', 'data': {}},
+                ],
+            },
+            "Duplicate bulkId 'duplicate'",
+        ),
+        (
+            {
+                'schemas': [BULK_SCHEMA],
+                'failOnErrors': 'not-an-integer',
+                'Operations': [{
+                    'method': 'DELETE',
+                    'path': '/Users/a@example.com',
+                }],
+            },
+            'failOnErrors must be a non-negative integer',
+        ),
+        (
+            {
+                'schemas': [BULK_SCHEMA],
+                'failOnErrors': -1,
+                'Operations': [{
+                    'method': 'DELETE',
+                    'path': '/Users/a@example.com',
+                }],
+            },
+            'failOnErrors must be a non-negative integer',
+        ),
+    ],
+)
+def test_scim_bulk_rejects_invalid_request_contract(app, client, payload, detail):
+    response = client.post('/api/scim/v2/Bulk', json=payload, headers=auth_headers(app))
+
+    assert response.status_code == 400
+    assert response.get_json()['detail'] == detail
+
+
+def test_scim_bulk_enforces_advertised_payload_limit_before_json_parsing(app, client):
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        data=b'x' * (1048576 + 1),
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 413
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['detail'] == 'Bulk request exceeds maxPayloadSize'
+
+
+def test_scim_bulk_validation_error_includes_non_post_resource_location(app, client):
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'PATCH',
+                'path': '/Users/invalid-data@example.com',
+                'data': [],
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    operation = response.get_json()['Operations'][0]
+    assert operation['status'] == '400'
+    assert operation['location'].endswith('/Users/invalid-data@example.com')
+
+
+@pytest.mark.parametrize('method', ['PUT', 'PATCH', 'DELETE'])
+def test_scim_bulk_accepts_canonical_percent_encoded_resource_paths(
+    app,
+    client,
+    method,
+):
+    with app.app_context():
+        user_id = create_user(localpart=f'bulk-{method.lower()}#question?percent%').email
+    direct_path = f'/api/scim/v2/Users/{urllib.parse.quote(user_id, safe="@")}'
+    direct = client.get(direct_path, headers=auth_headers(app))
+    location = direct.get_json()['meta']['location']
+    bulk_path = urllib.parse.urlsplit(location).path.split('/scim/v2', 1)[1]
+    if method == 'PUT':
+        data = {
+            'schemas': [USER_SCHEMA],
+            'userName': user_id,
+            'displayName': 'Bulk encoded PUT',
+        }
+    elif method == 'PATCH':
+        data = {
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'displayName',
+                'value': 'Bulk encoded PATCH',
+            }],
+        }
+    else:
+        data = None
+    operation = {
+        'method': method,
+        'path': bulk_path,
+    }
+    if data is not None:
+        operation['data'] = data
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [operation],
+        },
+        headers=auth_headers(app),
+    )
+
+    result = response.get_json()['Operations'][0]
+    assert result['status'] == ('204' if method == 'DELETE' else '200')
+    assert result['location'] == location
+    with app.app_context():
+        user = models.db.session.get(models.User, user_id)
+        if method == 'DELETE':
+            assert user.enabled is False
+        else:
+            assert user.displayed_name == f'Bulk encoded {method}'
+
+
+@pytest.mark.parametrize('path', [
+    'https://evil.example/Users/alice@example.com',
+    '//[',
+    '/Users/alice@example.com?active=false',
+    '/Users/alice@example.com#fragment',
+])
+def test_scim_bulk_rejects_non_relative_resource_paths(app, client, path):
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'DELETE',
+                'path': path,
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    operation = response.get_json()['Operations'][0]
+    assert operation['status'] == '400'
+    assert operation['response']['scimType'] == 'invalidPath'
+
+
+@pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
+def test_scim_malformed_resource_id_returns_scim_error(app, client, resource_type):
+    response = client.get(
+        f'/api/scim/v2/{resource_type}/not-an-email',
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['scimType'] == 'invalidValue'
+
+
+def test_scim_filters_validate_syntax_and_group_display_name_semantics(app, client):
+    with app.app_context():
+        create_group(localpart='filter-label', comment='Operations Team')
+        create_group(localpart='filter-address', comment='')
+
+    label = client.get(
+        '/api/scim/v2/Groups?filter=displayName%20eq%20%22operations%20team%22',
+        headers=auth_headers(app),
+    )
+    assert label.status_code == 200
+    assert [group['id'] for group in label.get_json()['Resources']] == ['filter-label@example.com']
+
+    address = client.get(
+        '/api/scim/v2/Groups?filter=displayName%20eq%20%22filter-address@example.com%22',
+        headers=auth_headers(app),
+    )
+    assert address.status_code == 200
+    assert [group['id'] for group in address.get_json()['Resources']] == ['filter-address@example.com']
+
+    malformed = client.get(
+        '/api/scim/v2/Users?filter=userName%20eq%20not-an-email',
+        headers=auth_headers(app),
+    )
+    assert malformed.status_code == 400
+    assert malformed.get_json()['scimType'] == 'invalidFilter'
+
+
+def test_scim_rejects_user_alias_address_collisions(app, client):
+    with app.app_context():
+        create_user(localpart='user-first')
+
+    group_collision = client.post(
+        '/api/scim/v2/Groups',
+        json={
+            'schemas': [GROUP_SCHEMA],
+            'displayName': 'user-first@example.com',
+        },
+        headers=auth_headers(app),
+    )
+    assert group_collision.status_code == 409
+    assert group_collision.get_json()['scimType'] == 'uniqueness'
+
+    with app.app_context():
+        create_group(localpart='group-first')
+
+    user_collision = client.post(
+        '/api/scim/v2/Users',
+        json={
+            'schemas': [USER_SCHEMA],
+            'userName': 'group-first@example.com',
+        },
+        headers=auth_headers(app),
+    )
+    assert user_collision.status_code == 409
+    assert user_collision.get_json()['scimType'] == 'uniqueness'
+    with app.app_context():
+        assert models.db.session.get(models.Alias, 'user-first@example.com') is None
+        assert models.db.session.get(models.User, 'group-first@example.com') is None
+
+
+def test_scim_external_group_destination_has_no_dangling_user_reference(app, client):
+    with app.app_context():
+        group_id = create_group(localpart='external-member').email
+
+    response = client.get(
+        f'/api/scim/v2/Groups/{group_id}',
+        headers=auth_headers(app),
+    )
+    member = response.get_json()['members'][0]
+    assert member == {
+        'value': 'original@example.net',
+        'display': 'original@example.net',
+    }
+
+
+@pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
+def test_scim_put_requires_complete_identity_fields_without_mutation(app, client, resource_type):
+    with app.app_context():
+        resource = create_user() if resource_type == 'Users' else create_group()
+        resource_id = resource.email
+
+    response = client.put(
+        f'/api/scim/v2/{resource_type}/{resource_id}',
+        json={
+            'schemas': [
+                USER_SCHEMA if resource_type == 'Users' else GROUP_SCHEMA
+            ],
+        },
+        headers=auth_headers(app),
+    )
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+    with app.app_context():
+        if resource_type == 'Users':
+            user = models.db.session.get(models.User, resource_id)
+            assert user.displayed_name == 'Original user'
+            assert user.enabled is True
+        else:
+            group = models.db.session.get(models.Alias, resource_id)
+            assert group.comment == 'Original group'
+            assert group.destination == ['original@example.net']
+
+
+def test_scim_user_put_rejects_conflicting_immutable_email_identity(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='identity-conflict').email
+
+    response = client.put(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'schemas': [USER_SCHEMA],
+            'userName': user_id,
+            'emails': [{'value': 'different@example.com'}],
+            'active': False,
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'mutability'
+    with app.app_context():
+        user = models.db.session.get(models.User, user_id)
+        assert user.enabled is True
+        assert user.displayed_name == 'Original user'
+
+
+@pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
+def test_scim_patch_requires_explicit_operation(app, client, resource_type):
+    with app.app_context():
+        resource = create_user() if resource_type == 'Users' else create_group()
+        resource_id = resource.email
+
+    response = client.patch(
+        f'/api/scim/v2/{resource_type}/{resource_id}',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'path': 'displayName',
+                'value': 'Must not change',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidSyntax'
+
+
+def test_scim_rejects_incorrect_schema_envelope_without_mutation(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='wrong-schema').email
+
+    response = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'active',
+                'value': False,
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is True
+
+
+def test_scim_discovery_self_links_are_retrievable_and_schemas_are_not_empty(app, client):
+    resource_type = client.get(
+        '/api/scim/v2/ResourceTypes/User',
+        headers=auth_headers(app),
+    )
+    assert resource_type.status_code == 200
+    assert resource_type.get_json()['endpoint'] == '/Users'
+
+    schema_id = 'urn:ietf:params:scim:schemas:core:2.0:Group'
+    schema = client.get(
+        f'/api/scim/v2/Schemas/{schema_id}',
+        headers=auth_headers(app),
+    )
+    assert schema.status_code == 200
+    assert schema.get_json()['schemas'] == ['urn:ietf:params:scim:schemas:core:2.0:Schema']
+    assert {attribute['name'] for attribute in schema.get_json()['attributes']} == {
+        'displayName',
+        'members',
+    }
+    members = next(
+        attribute
+        for attribute in schema.get_json()['attributes']
+        if attribute['name'] == 'members'
+    )
+    value = next(
+        attribute
+        for attribute in members['subAttributes']
+        if attribute['name'] == 'value'
+    )
+    assert value['mutability'] == 'immutable'
+    followed_schema = client.get(
+        urllib.parse.urlsplit(schema.get_json()['meta']['location']).path,
+        headers=auth_headers(app),
+    )
+    assert followed_schema.status_code == 200
+    assert followed_schema.get_json()['id'] == schema_id
+
+
+def test_scim_authentication_failure_uses_scim_error_envelope(app, client):
+    response = client.get('/api/scim/v2/Users')
+
+    assert response.status_code == 401
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['schemas'] == ['urn:ietf:params:scim:api:messages:2.0:Error']
+
+
+def test_scim_attributes_projection_applies_to_single_and_list_resources(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='project-user').email
+        group_id = create_group(localpart='project-group').email
+
+    user = client.get(
+        f'/api/scim/v2/Users/{user_id}?attributes=userName',
+        headers=auth_headers(app),
+    )
+    assert user.status_code == 200
+    assert set(user.get_json()) == {'schemas', 'id', 'userName'}
+    assert user.headers['ETag']
+
+    users = client.get(
+        '/api/scim/v2/Users?excludedAttributes=displayName,name,emails,active,meta',
+        headers=auth_headers(app),
+    )
+    projected_user = next(
+        resource for resource in users.get_json()['Resources']
+        if resource['id'] == user_id
+    )
+    assert set(projected_user) == {'schemas', 'id', 'userName'}
+
+    group = client.get(
+        f'/api/scim/v2/Groups/{group_id}?attributes=members.value',
+        headers=auth_headers(app),
+    )
+    group_payload = group.get_json()
+    assert group.status_code == 200
+    assert set(group_payload) == {'schemas', 'id', 'members'}, group_payload
+    assert group_payload['members'] == [{'value': 'original@example.net'}]
+    assert group.headers['ETag']
+
+    groups = client.get(
+        '/api/scim/v2/Groups?excludedAttributes=displayName,members,meta',
+        headers=auth_headers(app),
+    )
+    projected_group = next(
+        resource for resource in groups.get_json()['Resources']
+        if resource['id'] == group_id
+    )
+    assert set(projected_group) == {'schemas', 'id'}
+
+    id_only = client.get(
+        f'/api/scim/v2/Users/{user_id}?attributes=id',
+        headers=auth_headers(app),
+    )
+    assert set(id_only.get_json()) == {'schemas', 'id'}
+
+
+@pytest.mark.parametrize('query', [
+    'attributes=',
+    'excludedAttributes=',
+    'attributes=userName&excludedAttributes=displayName',
+    'attributes=name..formatted',
+    'attributes=unknownAttribute',
+    'attributes=name.unknownSubAttribute',
+    f'attributes={GROUP_SCHEMA}:displayName',
+])
+def test_scim_rejects_invalid_projection_queries(app, client, query):
+    response = client.get(
+        f'/api/scim/v2/Users?{query}',
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+
+
+def test_scim_projection_parent_dominates_children_and_never_returns_password(
+    app,
+    client,
+):
+    with app.app_context():
+        user_id = create_user(localpart='projection-tree').email
+
+    parent = client.get(
+        f'/api/scim/v2/Users/{user_id}?attributes=emails.value,emails',
+        headers=auth_headers(app),
+    )
+    assert parent.status_code == 200
+    assert parent.get_json()['emails'] == [{
+        'value': user_id,
+        'primary': True,
+        'type': 'work',
+    }]
+
+    password = client.get(
+        f'/api/scim/v2/Users/{user_id}?attributes=password',
+        headers=auth_headers(app),
+    )
+    assert set(password.get_json()) == {'schemas', 'id'}
+
+
+def test_scim_projection_applies_to_mutation_responses_but_not_discovery(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='project-mutation').email
+
+    replaced = client.put(
+        f'/api/scim/v2/Users/{user_id}?attributes=id',
+        json={
+            'schemas': [USER_SCHEMA],
+            'userName': user_id,
+            'displayName': 'Projected mutation',
+        },
+        headers=auth_headers(app),
+    )
+    assert replaced.status_code == 200
+    assert set(replaced.get_json()) == {'schemas', 'id'}
+    assert replaced.headers['ETag']
+    assert replaced.headers['Content-Location']
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).displayed_name == 'Projected mutation'
+
+    discovery = client.get(
+        '/api/scim/v2/Schemas?attributes=&excludedAttributes=id',
+        headers=auth_headers(app),
+    )
+    assert discovery.status_code == 200
+    assert discovery.get_json()['Resources']
+
+    user_schema = next(
+        resource
+        for resource in discovery.get_json()['Resources']
+        if resource['id'] == USER_SCHEMA
+    )
+    user_name = next(
+        attribute
+        for attribute in user_schema['attributes']
+        if attribute['name'] == 'userName'
+    )
+    assert user_name['returned'] == 'default'
+
+
+@pytest.mark.parametrize('schemas', [
+    None,
+    [],
+    USER_SCHEMA,
+    [USER_SCHEMA, USER_SCHEMA],
+    [USER_SCHEMA, USER_SCHEMA.upper()],
+    [USER_SCHEMA, GROUP_SCHEMA],
+    [GROUP_SCHEMA],
+])
+def test_scim_user_create_requires_exact_unique_schema_without_mutation(
+    app,
+    client,
+    schemas,
+):
+    payload = {'userName': 'schema-create@example.com'}
+    if schemas is not None:
+        payload['schemas'] = schemas
+
+    response = client.post(
+        '/api/scim/v2/Users',
+        json=payload,
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+    with app.app_context():
+        assert models.db.session.get(models.User, 'schema-create@example.com') is None
+
+
+def test_scim_schema_uri_matching_is_case_insensitive(app, client):
+    with app.app_context():
+        create_domain()
+
+    response = client.post(
+        '/api/scim/v2/Users',
+        json={
+            'schemas': [USER_SCHEMA.upper()],
+            'userName': 'case-schema@example.com',
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 201
+
+
+def test_scim_put_patch_and_bulk_require_their_schema_envelopes(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='schema-envelope').email
+
+    put_response = client.put(
+        f'/api/scim/v2/Users/{user_id}',
+        json={'userName': user_id, 'displayName': 'Must not change'},
+        headers=auth_headers(app),
+    )
+    patch_response = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'Operations': [{
+                'op': 'replace',
+                'path': 'displayName',
+                'value': 'Must not change',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    bulk_response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'Operations': [{
+                'method': 'PATCH',
+                'path': f'/Users/{user_id}',
+                'data': {
+                    'schemas': [PATCH_SCHEMA],
+                    'Operations': [{
+                        'op': 'replace',
+                        'path': 'displayName',
+                        'value': 'Must not change',
+                    }],
+                },
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert put_response.status_code == 400
+    assert patch_response.status_code == 400
+    assert bulk_response.status_code == 400
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).displayed_name == 'Original user'
+
+
+@pytest.mark.parametrize('method', ['post', 'put'])
+def test_scim_user_create_and_replace_require_explicit_username(app, client, method):
+    with app.app_context():
+        create_domain()
+        if method == 'put':
+            create_user(localpart='required-username')
+
+    user_id = 'required-username@example.com'
+    response = getattr(client, method)(
+        '/api/scim/v2/Users' if method == 'post' else f'/api/scim/v2/Users/{user_id}',
+        json={
+            'schemas': [USER_SCHEMA],
+            'emails': [{'value': user_id}],
+            'active': False,
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidValue'
+    with app.app_context():
+        if method == 'post':
+            assert models.db.session.get(models.User, user_id) is None
+        else:
+            user = models.db.session.get(models.User, user_id)
+            assert user.enabled is True
+            assert user.displayed_name == 'Original user'
+
+
+@pytest.mark.parametrize('payload', [
+    {
+        'schemas': [USER_SCHEMA],
+        'userName': 'ambiguous@example.com',
+        'USERNAME': 'other@example.com',
+    },
+    {
+        'schemas': [USER_SCHEMA],
+        'userName': 'ambiguous@example.com',
+        'name': {'formatted': 'First', 'FORMATTED': 'Second'},
+    },
+])
+def test_scim_rejects_case_equivalent_attribute_collisions_without_mutation(
+    app,
+    client,
+    payload,
+):
+    with app.app_context():
+        create_domain()
+
+    response = client.post(
+        '/api/scim/v2/Users',
+        json=payload,
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()['scimType'] == 'invalidSyntax'
+    with app.app_context():
+        assert models.db.session.get(models.User, 'ambiguous@example.com') is None
+
+
+def test_scim_rejects_case_equivalent_patch_and_bulk_keys_without_mutation(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='ambiguous-operation').email
+
+    patch_response = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'OP': 'remove',
+                'path': 'active',
+                'value': False,
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    bulk_response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'PATCH',
+                'METHOD': 'DELETE',
+                'path': f'/Users/{user_id}',
+                'data': {
+                    'schemas': [PATCH_SCHEMA],
+                    'Operations': [{
+                        'op': 'replace',
+                        'path': 'active',
+                        'value': False,
+                    }],
+                },
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert patch_response.status_code == 400
+    assert patch_response.get_json()['scimType'] == 'invalidSyntax'
+    assert bulk_response.status_code == 400
+    assert bulk_response.get_json()['scimType'] == 'invalidSyntax'
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is True

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -346,3 +346,15 @@ def test_scim_patch_rejects_non_string_password(app, client):
 
     assert rv.status_code == 400
     assert rv.get_json()['scimType'] == 'invalidValue'
+
+
+def test_scim_create_rejects_malformed_json(app, client):
+    rv = client.post(
+        '/api/scim/v2/Users',
+        data='{',
+        content_type='application/scim+json',
+        headers={'Authorization': f'Bearer {app.config["API_TOKEN"]}'},
+    )
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'invalidSyntax'

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -312,3 +312,37 @@ def test_scim_patch_rejects_empty_operations(app, client):
 
     assert rv.status_code == 400
     assert rv.get_json()['scimType'] == 'invalidValue'
+
+
+def test_scim_create_rejects_non_string_password(app, client):
+    with app.app_context():
+        create_domain()
+
+    rv = client.post(
+        '/api/scim/v2/Users',
+        json={'userName': 'nick@example.com', 'password': {'cleartext': 'nope'}},
+        headers=auth_headers(app),
+    )
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'invalidValue'
+    with app.app_context():
+        assert models.db.session.get(models.User, 'nick@example.com') is None
+
+
+def test_scim_patch_rejects_non_string_password(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='olivia', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.patch(
+        '/api/scim/v2/Users/olivia@example.com',
+        json={'Operations': [{'op': 'replace', 'path': 'password', 'value': ['bad']}]},
+        headers=auth_headers(app),
+    )
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'invalidValue'

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -1,3 +1,4 @@
+import time
 import urllib.parse
 
 import pytest
@@ -2318,3 +2319,292 @@ def test_scim_rejects_case_equivalent_patch_and_bulk_keys_without_mutation(app, 
     assert bulk_response.get_json()['scimType'] == 'invalidSyntax'
     with app.app_context():
         assert models.db.session.get(models.User, user_id).enabled is True
+
+
+@pytest.mark.parametrize('duplicate_name', ['userName', r'user\u004eame'])
+def test_scim_rejects_exact_duplicate_json_names_without_mutation(
+    app,
+    client,
+    duplicate_name,
+):
+    with app.app_context():
+        create_domain()
+
+    response = client.post(
+        '/api/scim/v2/Users',
+        data=(
+            '{"schemas":["' + USER_SCHEMA + '"],'
+            '"userName":"first-duplicate@example.com",'
+            '"' + duplicate_name + '":"second-duplicate@example.com"}'
+        ),
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['scimType'] == 'invalidSyntax'
+    with app.app_context():
+        assert models.db.session.get(models.User, 'first-duplicate@example.com') is None
+        assert models.db.session.get(models.User, 'second-duplicate@example.com') is None
+
+
+def test_scim_rejects_nested_exact_duplicate_json_names_without_mutation(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='nested-duplicate').email
+
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        data=(
+            '{"schemas":["' + BULK_SCHEMA + '"],"Operations":[{'
+            '"method":"PATCH","method":"DELETE",'
+            '"path":"/Users/' + user_id + '",'
+            '"data":{"schemas":["' + PATCH_SCHEMA + '"],"Operations":[{'
+            '"op":"replace","path":"active","value":false}]}}]}'
+        ),
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['scimType'] == 'invalidSyntax'
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is True
+
+
+@pytest.mark.parametrize(
+    'malformed',
+    [
+        'unquoted',
+        'lowercase-weak',
+        'wildcard-list',
+        'unterminated',
+        'space-in-opaque-tag',
+    ],
+)
+def test_scim_rejects_malformed_if_match_without_mutation(
+    app,
+    client,
+    malformed,
+):
+    with app.app_context():
+        user_id = create_user(localpart=f'malformed-{malformed}').email
+
+    url = f'/api/scim/v2/Users/{user_id}'
+    version = client.get(url, headers=auth_headers(app)).headers['ETag']
+    values = {
+        'unquoted': version[1:-1],
+        'lowercase-weak': f'w/{version}',
+        'wildcard-list': f'*, {version}',
+        'unterminated': version[:-1],
+        'space-in-opaque-tag': '"invalid entity tag"',
+    }
+    response = client.patch(
+        url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'displayName',
+                'value': 'Must not change',
+            }],
+        },
+        headers={**auth_headers(app), 'If-Match': values[malformed]},
+    )
+
+    assert response.status_code == 400
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['scimType'] == 'invalidValue'
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).displayed_name == 'Original user'
+
+
+def test_scim_rejects_malformed_if_none_match(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='malformed-if-none-match').email
+
+    url = f'/api/scim/v2/Users/{user_id}'
+    version = client.get(url, headers=auth_headers(app)).headers['ETag']
+    response = client.get(
+        url,
+        headers={**auth_headers(app), 'If-None-Match': version[1:-1]},
+    )
+
+    assert response.status_code == 400
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['scimType'] == 'invalidValue'
+
+
+def test_scim_accepts_empty_entity_tag_list_elements(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='empty-etag-elements').email
+
+    url = f'/api/scim/v2/Users/{user_id}'
+    version = client.get(url, headers=auth_headers(app)).headers['ETag']
+    empty_only = client.patch(
+        url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'displayName',
+                'value': 'Must not change',
+            }],
+        },
+        headers={**auth_headers(app), 'If-Match': ','},
+    )
+    assert_precondition_failed(empty_only)
+
+    comma_in_opaque_tag = client.patch(
+        url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'displayName',
+                'value': 'Must not change',
+            }],
+        },
+        headers={**auth_headers(app), 'If-Match': '"valid,opaque-tag"'},
+    )
+    assert_precondition_failed(comma_in_opaque_tag)
+
+    response = client.patch(
+        url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'displayName',
+                'value': 'Empty elements ignored',
+            }],
+        },
+        headers={**auth_headers(app), 'If-Match': f', {version},,'},
+    )
+
+    assert response.status_code == 200
+    assert response.get_json()['displayName'] == 'Empty elements ignored'
+
+
+def test_scim_accepts_ows_around_entity_tag_field_values(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='etag-ows').email
+
+    url = f'/api/scim/v2/Users/{user_id}'
+    version = client.get(url, headers=auth_headers(app)).headers['ETag']
+    changed = client.patch(
+        url,
+        json={
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'path': 'displayName',
+                'value': 'OWS accepted',
+            }],
+        },
+        headers={**auth_headers(app), 'If-Match': f' \t{version}\t '},
+    )
+
+    assert changed.status_code == 200
+    current_version = changed.headers['ETag']
+    not_modified = client.get(
+        url,
+        headers={
+            **auth_headers(app),
+            'If-None-Match': f' \tW/{current_version}\t ',
+        },
+    )
+    assert not_modified.status_code == 304
+
+
+def test_scim_rejects_large_malformed_bulk_version_in_linear_time(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='large-malformed-version').email
+
+    started = time.monotonic()
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'DELETE',
+                'path': f'/Users/{user_id}',
+                'version': (' ' * 24000) + 'x',
+            }],
+        },
+        headers=auth_headers(app),
+    )
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 1.0
+    assert response.status_code == 200
+    operation = response.get_json()['Operations'][0]
+    assert operation['status'] == '400'
+    assert operation['response']['scimType'] == 'invalidValue'
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).enabled is True
+
+
+def test_scim_validates_if_none_match_before_missing_resource(app, client):
+    response = client.put(
+        '/api/scim/v2/Users/missing@example.com',
+        json={
+            'schemas': [USER_SCHEMA],
+            'userName': 'missing@example.com',
+        },
+        headers={**auth_headers(app), 'If-None-Match': 'unquoted'},
+    )
+
+    assert response.status_code == 400
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['scimType'] == 'invalidValue'
+
+
+def test_scim_bulk_rejects_malformed_version_without_mutation(app, client):
+    with app.app_context():
+        user_id = create_user(localpart='malformed-bulk-version').email
+
+    url = f'/api/scim/v2/Users/{user_id}'
+    version = client.get(url, headers=auth_headers(app)).headers['ETag']
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [{
+                'method': 'PATCH',
+                'path': f'/Users/{user_id}',
+                'version': version[1:-1],
+                'data': {
+                    'schemas': [PATCH_SCHEMA],
+                    'Operations': [{
+                        'op': 'replace',
+                        'path': 'displayName',
+                        'value': 'Must not change',
+                    }],
+                },
+            }],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 200
+    operation = response.get_json()['Operations'][0]
+    assert operation['status'] == '400'
+    assert operation['response']['scimType'] == 'invalidValue'
+    with app.app_context():
+        assert models.db.session.get(models.User, user_id).displayed_name == 'Original user'
+
+
+def test_scim_bulk_rejects_empty_operations_with_invalid_value(app, client):
+    response = client.post(
+        '/api/scim/v2/Bulk',
+        json={
+            'schemas': [BULK_SCHEMA],
+            'Operations': [],
+        },
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 400
+    assert response.content_type == 'application/scim+json'
+    assert response.get_json()['scimType'] == 'invalidValue'
+    assert response.get_json()['detail'] == 'Operations must not be empty'

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -206,3 +206,37 @@ def test_scim_patch_rejects_non_object_operations(app, client):
 
     assert rv.status_code == 400
     assert rv.get_json()['scimType'] == 'invalidSyntax'
+
+
+def test_scim_create_handles_non_string_username_and_name(app, client):
+    with app.app_context():
+        create_domain('123.example')
+
+    rv = client.post(
+        '/api/scim/v2/Users',
+        json={'userName': 123, 'name': 'not-an-object'},
+        headers=auth_headers(app),
+    )
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'invalidValue'
+
+
+def test_scim_patch_handles_non_string_op_and_path(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='heidi', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.patch(
+        '/api/scim/v2/Users/heidi@example.com',
+        json={'Operations': [{'op': 7, 'path': 9, 'value': 'ignored'}]},
+        headers=auth_headers(app),
+    )
+
+    assert rv.status_code == 200
+    with app.app_context():
+        user = models.db.session.get(models.User, 'heidi@example.com')
+        assert user.enabled is True

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -21,18 +21,84 @@ def test_scim_service_provider_config(app, client):
     assert rv.status_code == 200
     data = rv.get_json()
     assert data['patch']['supported'] is True
-    assert data['bulk']['supported'] is False
+    assert data['bulk']['supported'] is True
+    assert data['etag']['supported'] is True
     assert data['authenticationSchemes'][0]['type'] == 'oauthbearertoken'
 
 
-def test_scim_groups_are_explicitly_unsupported(app, client):
-    rv = client.get('/api/scim/v2/Groups', headers=auth_headers(app))
+def test_scim_groups_are_backed_by_aliases(app, client):
+    with app.app_context():
+        create_domain()
+        domain = models.db.session.get(models.Domain, 'example.com')
+        user = models.User(localpart='alice', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    payload = {
+        'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
+        'displayName': 'admins@example.com',
+        'members': [{'value': 'alice@example.com'}],
+    }
+    rv = client.post('/api/scim/v2/Groups', json=payload, headers=auth_headers(app))
+
+    assert rv.status_code == 201
+    data = rv.get_json()
+    assert data['id'] == 'admins@example.com'
+    assert data['displayName'] == 'admins@example.com'
+    assert data['members'][0]['value'] == 'alice@example.com'
+    assert data['meta']['resourceType'] == 'Group'
+    assert data['meta']['version'].startswith('W/"')
+
+    with app.app_context():
+        alias = models.db.session.get(models.Alias, 'admins@example.com')
+        assert alias is not None
+        assert alias.destination == ['alice@example.com']
+
+    rv = client.get('/api/scim/v2/Groups/admins@example.com', headers=auth_headers(app))
+    assert rv.status_code == 200
+    assert rv.get_json()['members'][0]['value'] == 'alice@example.com'
+
+
+def test_scim_group_patch_updates_alias_members(app, client):
+    with app.app_context():
+        domain = create_domain()
+        alias = models.Alias(localpart='team', domain=domain, destination=['alice@example.com'])
+        models.db.session.add(alias)
+        models.db.session.commit()
+
+    payload = {
+        'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        'Operations': [
+            {'op': 'add', 'path': 'members', 'value': [{'value': 'bob@example.com'}]},
+            {'op': 'remove', 'path': 'members', 'value': [{'value': 'alice@example.com'}]},
+        ],
+    }
+    rv = client.patch('/api/scim/v2/Groups/team@example.com', json=payload, headers=auth_headers(app))
 
     assert rv.status_code == 200
-    assert rv.get_json()['Resources'] == []
+    assert [member['value'] for member in rv.get_json()['members']] == ['bob@example.com']
+    with app.app_context():
+        alias = models.db.session.get(models.Alias, 'team@example.com')
+        assert alias.destination == ['bob@example.com']
 
-    rv = client.post('/api/scim/v2/Groups', json={'displayName': 'admins'}, headers=auth_headers(app))
-    assert rv.status_code == 501
+
+
+def test_scim_user_resources_include_etag_metadata(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='etag', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.get('/api/scim/v2/Users/etag@example.com', headers=auth_headers(app))
+
+    assert rv.status_code == 200
+    meta = rv.get_json()['meta']
+    assert meta['resourceType'] == 'User'
+    assert meta['version'].startswith('W/"')
+    assert meta['created']
 
 
 def test_scim_create_and_get_user(app, client):
@@ -358,3 +424,56 @@ def test_scim_create_rejects_malformed_json(app, client):
 
     assert rv.status_code == 400
     assert rv.get_json()['scimType'] == 'invalidSyntax'
+
+
+def test_scim_bulk_creates_user_and_group(app, client):
+    with app.app_context():
+        create_domain()
+
+    payload = {
+        'schemas': ['urn:ietf:params:scim:api:messages:2.0:BulkRequest'],
+        'Operations': [
+            {
+                'method': 'POST',
+                'path': '/Users',
+                'bulkId': 'user1',
+                'data': {'userName': 'bulkuser@example.com', 'active': True},
+            },
+            {
+                'method': 'POST',
+                'path': '/Groups',
+                'bulkId': 'group1',
+                'data': {
+                    'displayName': 'bulkgroup@example.com',
+                    'members': [{'value': 'bulkuser@example.com'}],
+                },
+            },
+        ],
+    }
+    rv = client.post('/api/scim/v2/Bulk', json=payload, headers=auth_headers(app))
+
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data['schemas'] == ['urn:ietf:params:scim:api:messages:2.0:BulkResponse']
+    assert [operation['status'] for operation in data['Operations']] == ['201', '201']
+    with app.app_context():
+        assert models.db.session.get(models.User, 'bulkuser@example.com') is not None
+        alias = models.db.session.get(models.Alias, 'bulkgroup@example.com')
+        assert alias is not None
+        assert alias.destination == ['bulkuser@example.com']
+
+
+def test_scim_bulk_stops_after_fail_on_errors(app, client):
+    payload = {
+        'failOnErrors': 1,
+        'Operations': [
+            {'method': 'POST', 'path': '/Users', 'data': {'userName': 'missing@example.com'}},
+            {'method': 'POST', 'path': '/Users', 'data': {'userName': 'never@example.com'}},
+        ],
+    }
+    rv = client.post('/api/scim/v2/Bulk', json=payload, headers=auth_headers(app))
+
+    assert rv.status_code == 200
+    operations = rv.get_json()['Operations']
+    assert len(operations) == 1
+    assert operations[0]['status'] == '404'

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -1,0 +1,135 @@
+from mailu import models
+
+
+def auth_headers(app):
+    return {
+        'Authorization': f'Bearer {app.config["API_TOKEN"]}',
+        'Content-Type': 'application/scim+json',
+    }
+
+
+def create_domain(name='example.com'):
+    domain = models.Domain(name=name)
+    models.db.session.add(domain)
+    models.db.session.commit()
+    return domain
+
+
+def test_scim_service_provider_config(app, client):
+    rv = client.get('/api/scim/v2/ServiceProviderConfig', headers=auth_headers(app))
+
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data['patch']['supported'] is True
+    assert data['bulk']['supported'] is False
+    assert data['authenticationSchemes'][0]['type'] == 'oauthbearertoken'
+
+
+def test_scim_groups_are_explicitly_unsupported(app, client):
+    rv = client.get('/api/scim/v2/Groups', headers=auth_headers(app))
+
+    assert rv.status_code == 200
+    assert rv.get_json()['Resources'] == []
+
+    rv = client.post('/api/scim/v2/Groups', json={'displayName': 'admins'}, headers=auth_headers(app))
+    assert rv.status_code == 501
+
+
+def test_scim_create_and_get_user(app, client):
+    with app.app_context():
+        create_domain()
+
+    payload = {
+        'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
+        'userName': 'Alice@example.com',
+        'active': True,
+        'displayName': 'Alice Example',
+    }
+    rv = client.post('/api/scim/v2/Users', json=payload, headers=auth_headers(app))
+
+    assert rv.status_code == 201
+    data = rv.get_json()
+    assert data['id'] == 'alice@example.com'
+    assert data['userName'] == 'alice@example.com'
+    assert data['active'] is True
+    assert data['displayName'] == 'Alice Example'
+    assert data['emails'][0]['value'] == 'alice@example.com'
+
+    with app.app_context():
+        user = models.db.session.get(models.User, 'alice@example.com')
+        assert user is not None
+        assert user.enabled is True
+        assert user.displayed_name == 'Alice Example'
+
+    rv = client.get('/api/scim/v2/Users/alice@example.com', headers=auth_headers(app))
+    assert rv.status_code == 200
+    assert rv.get_json()['userName'] == 'alice@example.com'
+
+
+def test_scim_create_requires_existing_domain(app, client):
+    payload = {'userName': 'missing@example.com'}
+    rv = client.post('/api/scim/v2/Users', json=payload, headers=auth_headers(app))
+
+    assert rv.status_code == 404
+    assert rv.get_json()['schemas'] == ['urn:ietf:params:scim:api:messages:2.0:Error']
+
+
+def test_scim_filter_user_by_username(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='bob', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.get('/api/scim/v2/Users?filter=userName eq "bob@example.com"', headers=auth_headers(app))
+
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data['totalResults'] == 1
+    assert data['Resources'][0]['userName'] == 'bob@example.com'
+
+
+def test_scim_patch_active_and_display_name(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='carol', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    payload = {
+        'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
+        'Operations': [
+            {'op': 'replace', 'path': 'active', 'value': False},
+            {'op': 'replace', 'path': 'displayName', 'value': 'Carol Disabled'},
+        ],
+    }
+    rv = client.patch('/api/scim/v2/Users/carol@example.com', json=payload, headers=auth_headers(app))
+
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data['active'] is False
+    assert data['displayName'] == 'Carol Disabled'
+
+    with app.app_context():
+        user = models.db.session.get(models.User, 'carol@example.com')
+        assert user.enabled is False
+        assert user.displayed_name == 'Carol Disabled'
+
+
+def test_scim_delete_disables_user_without_removing_mailbox(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='dave', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.delete('/api/scim/v2/Users/dave@example.com', headers=auth_headers(app))
+
+    assert rv.status_code == 204
+    with app.app_context():
+        user = models.db.session.get(models.User, 'dave@example.com')
+        assert user is not None
+        assert user.enabled is False

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -10,6 +10,7 @@ from mailu.api import scim
 
 USER_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:User'
 GROUP_SCHEMA = 'urn:ietf:params:scim:schemas:core:2.0:Group'
+GROUP_EXTENSION = 'https://mailu.io/schemas/scim/2.0/Group'
 PATCH_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:PatchOp'
 BULK_SCHEMA = 'urn:ietf:params:scim:api:messages:2.0:BulkRequest'
 
@@ -43,11 +44,70 @@ def create_group(localpart='conditional-group', *, comment='Original group'):
         localpart=localpart,
         domain=domain,
         comment=comment,
-        destination=['original@example.net'],
+        destination=[],
     )
     models.db.session.add(group)
+    models.db.session.flush()
+    resource = models.create_scim_group_mapping(
+        group,
+        resource_id=models.new_scim_id(),
+    )
+    models.replace_scim_group_graph(
+        resource,
+        member_ids=[],
+        external_destinations=['original@example.net'],
+    )
     models.db.session.commit()
     return group
+
+
+def scim_id(subject):
+    if isinstance(subject, models.ScimResource):
+        return subject.id
+    return subject.scim_resource.id
+
+
+def scim_resource(resource_id):
+    return models.db.session.get(models.ScimResource, resource_id)
+
+
+def scim_user(resource_id):
+    resource = scim_resource(resource_id)
+    if resource is not None:
+        return (
+            resource.user
+            or models.db.session.get(models.User, resource.subject_address)
+        )
+    return models.db.session.get(models.User, resource_id)
+
+
+def scim_group(resource_id):
+    resource = scim_resource(resource_id)
+    if resource is not None:
+        return resource.alias
+    return models.db.session.get(models.Alias, resource_id)
+
+
+def group_payload(
+    alias_address,
+    *,
+    display_name='Group',
+    members=None,
+    external_destinations=None,
+    schemas=None,
+):
+    return {
+        'schemas': schemas or [GROUP_SCHEMA, GROUP_EXTENSION],
+        'displayName': display_name,
+        'members': [
+            {'value': member}
+            for member in (members or [])
+        ],
+        GROUP_EXTENSION: {
+            'aliasAddress': alias_address,
+            'externalDestinations': external_destinations or [],
+        },
+    }
 
 
 def assert_precondition_failed(response):
@@ -81,19 +141,25 @@ def test_scim_groups_are_backed_by_aliases(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
-    payload = {
-        'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
-        'displayName': 'admins@example.com',
-        'members': [{'value': 'alice@example.com'}],
-    }
+    payload = group_payload(
+        'admins@example.com',
+        display_name='Administrators',
+        members=[user_id],
+    )
     rv = client.post('/api/scim/v2/Groups', json=payload, headers=auth_headers(app))
 
     assert rv.status_code == 201
     data = rv.get_json()
-    assert data['id'] == 'admins@example.com'
-    assert data['displayName'] == 'admins@example.com'
-    assert data['members'][0]['value'] == 'alice@example.com'
+    assert data['id'] != 'admins@example.com'
+    assert data['displayName'] == 'Administrators'
+    assert data['members'][0]['value'] == user_id
+    assert data['members'][0]['type'] == 'User'
+    assert data[GROUP_EXTENSION] == {
+        'aliasAddress': 'admins@example.com',
+        'externalDestinations': [],
+    }
     assert data['meta']['resourceType'] == 'Group'
     assert data['meta']['version'].startswith('"')
     assert data['meta']['version'].endswith('"')
@@ -106,29 +172,45 @@ def test_scim_groups_are_backed_by_aliases(app, client):
         assert alias is not None
         assert alias.destination == ['alice@example.com']
 
-    rv = client.get('/api/scim/v2/Groups/admins@example.com', headers=auth_headers(app))
+    rv = client.get(
+        f'/api/scim/v2/Groups/{data["id"]}',
+        headers=auth_headers(app),
+    )
     assert rv.status_code == 200
-    assert rv.get_json()['members'][0]['value'] == 'alice@example.com'
+    assert rv.get_json()['members'][0]['value'] == user_id
 
 
 def test_scim_group_patch_updates_alias_members(app, client):
     with app.app_context():
-        domain = create_domain()
-        alias = models.Alias(localpart='team', domain=domain, destination=['alice@example.com'])
-        models.db.session.add(alias)
+        create_domain()
+        alice = create_user(localpart='alice')
+        bob = create_user(localpart='bob')
+        alias = create_group(localpart='team')
+        models.replace_scim_group_graph(
+            alias.scim_resource,
+            member_ids=[scim_id(alice)],
+            external_destinations=[],
+        )
         models.db.session.commit()
+        group_id = scim_id(alias)
+        alice_id = scim_id(alice)
+        bob_id = scim_id(bob)
 
     payload = {
         'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
         'Operations': [
-            {'op': 'add', 'path': 'members', 'value': [{'value': 'bob@example.com'}]},
-            {'op': 'remove', 'path': 'members', 'value': [{'value': 'alice@example.com'}]},
+            {'op': 'add', 'path': 'members', 'value': [{'value': bob_id}]},
+            {'op': 'remove', 'path': 'members', 'value': [{'value': alice_id}]},
         ],
     }
-    rv = client.patch('/api/scim/v2/Groups/team@example.com', json=payload, headers=auth_headers(app))
+    rv = client.patch(
+        f'/api/scim/v2/Groups/{group_id}',
+        json=payload,
+        headers=auth_headers(app),
+    )
 
     assert rv.status_code == 200
-    assert [member['value'] for member in rv.get_json()['members']] == ['bob@example.com']
+    assert [member['value'] for member in rv.get_json()['members']] == [bob_id]
     with app.app_context():
         alias = models.db.session.get(models.Alias, 'team@example.com')
         assert alias.destination == ['bob@example.com']
@@ -136,45 +218,50 @@ def test_scim_group_patch_updates_alias_members(app, client):
 
 def test_scim_group_patch_supports_filtered_and_remove_all_members(app, client):
     with app.app_context():
-        domain = create_domain()
-        group = models.Alias(
-            localpart='filtered',
-            domain=domain,
-            destination=['alice@example.com', 'bob@example.com'],
+        create_domain()
+        alice = create_user(localpart='alice')
+        bob = create_user(localpart='bob')
+        group = create_group(localpart='filtered')
+        models.replace_scim_group_graph(
+            group.scim_resource,
+            member_ids=[scim_id(alice), scim_id(bob)],
+            external_destinations=[],
         )
-        models.db.session.add(group)
         models.db.session.commit()
+        group_id = scim_id(group)
+        alice_id = scim_id(alice)
+        bob_id = scim_id(bob)
 
     filtered = client.patch(
-        '/api/scim/v2/Groups/filtered@example.com',
+        f'/api/scim/v2/Groups/{group_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': [{
                 'op': 'remove',
-                'path': 'members[value eq "alice@example.com"]',
+                'path': f'members[value eq "{alice_id}"]',
             }],
         },
         headers=auth_headers(app),
     )
     assert filtered.status_code == 200
-    assert [member['value'] for member in filtered.get_json()['members']] == ['bob@example.com']
+    assert [member['value'] for member in filtered.get_json()['members']] == [bob_id]
 
     no_target = client.patch(
-        '/api/scim/v2/Groups/filtered@example.com',
+        f'/api/scim/v2/Groups/{group_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': [{
                 'op': 'remove',
-                'path': 'members[value eq "missing@example.com"]',
+                'path': 'members[value eq "00000000-0000-4000-8000-000000000000"]',
             }],
         },
         headers=auth_headers(app),
     )
     assert no_target.status_code == 200
-    assert [member['value'] for member in no_target.get_json()['members']] == ['bob@example.com']
+    assert [member['value'] for member in no_target.get_json()['members']] == [bob_id]
 
     remove_all = client.patch(
-        '/api/scim/v2/Groups/filtered@example.com',
+        f'/api/scim/v2/Groups/{group_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': [{'op': 'remove', 'path': 'members'}],
@@ -185,7 +272,7 @@ def test_scim_group_patch_supports_filtered_and_remove_all_members(app, client):
     assert remove_all.get_json()['members'] == []
 
     required = client.patch(
-        '/api/scim/v2/Groups/filtered@example.com',
+        f'/api/scim/v2/Groups/{group_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': [{'op': 'remove', 'path': 'displayName'}],
@@ -198,7 +285,9 @@ def test_scim_group_patch_supports_filtered_and_remove_all_members(app, client):
 
 def test_scim_group_pathless_patch_applies_all_attributes_atomically(app, client):
     with app.app_context():
-        group_id = create_group(localpart='pathless').email
+        create_domain()
+        member_id = scim_id(create_user(localpart='pathless-member'))
+        group_id = scim_id(create_group(localpart='pathless'))
 
     response = client.patch(
         f'/api/scim/v2/Groups/{group_id}',
@@ -208,7 +297,10 @@ def test_scim_group_pathless_patch_applies_all_attributes_atomically(app, client
                 'op': 'replace',
                 'value': {
                     'displayName': 'Pathless group',
-                    'members': [{'value': 'member@example.net'}],
+                    'members': [{'value': member_id}],
+                    GROUP_EXTENSION: {
+                        'externalDestinations': ['pager@example.net'],
+                    },
                 },
             }],
         },
@@ -216,7 +308,10 @@ def test_scim_group_pathless_patch_applies_all_attributes_atomically(app, client
     )
     assert response.status_code == 200
     assert response.get_json()['displayName'] == 'Pathless group'
-    assert [member['value'] for member in response.get_json()['members']] == ['member@example.net']
+    assert [member['value'] for member in response.get_json()['members']] == [member_id]
+    assert response.get_json()[GROUP_EXTENSION]['externalDestinations'] == [
+        'pager@example.net',
+    ]
 
     rejected = client.patch(
         f'/api/scim/v2/Groups/{group_id}',
@@ -231,9 +326,12 @@ def test_scim_group_pathless_patch_applies_all_attributes_atomically(app, client
     )
     assert rejected.status_code == 400
     with app.app_context():
-        group = models.db.session.get(models.Alias, group_id)
+        group = scim_group(group_id)
         assert group.comment == 'Pathless group'
-        assert group.destination == ['member@example.net']
+        assert group.destination == [
+            'pager@example.net',
+            'pathless-member@example.com',
+        ]
 
 
 
@@ -244,8 +342,12 @@ def test_scim_user_resources_include_etag_metadata(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
-    rv = client.get('/api/scim/v2/Users/etag@example.com', headers=auth_headers(app))
+    rv = client.get(
+        f'/api/scim/v2/Users/{user_id}',
+        headers=auth_headers(app),
+    )
 
     assert rv.status_code == 200
     meta = rv.get_json()['meta']
@@ -259,31 +361,20 @@ def test_scim_user_resources_include_etag_metadata(app, client):
 
 
 def test_scim_resource_locations_percent_encode_reserved_id_characters(app, client):
-    with app.app_context():
-        user_id = create_user(localpart='hash#tag').email
-
-    response = client.get(
-        f'/api/scim/v2/Users/{urllib.parse.quote(user_id, safe="@")}',
-        headers=auth_headers(app),
-    )
-    location = response.get_json()['meta']['location']
-
-    assert response.status_code == 200
+    with app.test_request_context('/'):
+        location = scim._resource_location(
+            'Users',
+            'hash#tag@example.com',
+        )
     assert '#tag' not in location
     assert '%23tag' in location
-    followed = client.get(
-        urllib.parse.urlsplit(location).path,
-        headers=auth_headers(app),
-    )
-    assert followed.status_code == 200
-    assert followed.get_json()['id'] == user_id
 
 
 @pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
 def test_scim_conditional_get_uses_http_entity_tag_rules(app, client, resource_type):
     with app.app_context():
         resource = create_user() if resource_type == 'Users' else create_group()
-        resource_id = resource.email
+        resource_id = scim_id(resource)
 
     url = f'/api/scim/v2/{resource_type}/{resource_id}'
     current = client.get(url, headers=auth_headers(app))
@@ -314,7 +405,7 @@ def test_scim_conditional_get_uses_http_entity_tag_rules(app, client, resource_t
 def test_scim_if_none_match_rejects_unsafe_change(app, client, resource_type):
     with app.app_context():
         resource = create_user() if resource_type == 'Users' else create_group()
-        resource_id = resource.email
+        resource_id = scim_id(resource)
 
     url = f'/api/scim/v2/{resource_type}/{resource_id}'
     version = client.get(url, headers=auth_headers(app)).headers['ETag']
@@ -351,16 +442,16 @@ def test_scim_if_none_match_rejects_unsafe_change(app, client, resource_type):
     assert response.get_json()['detail'] == 'If-None-Match matches the current resource version'
     with app.app_context():
         if resource_type == 'Users':
-            user = models.db.session.get(models.User, resource_id)
+            user = scim_user(resource_id)
             assert user.displayed_name == 'Original user'
         else:
-            group = models.db.session.get(models.Alias, resource_id)
+            group = scim_group(resource_id)
             assert group.destination == ['original@example.net']
 
 
 def test_scim_if_match_supports_lists_and_wildcard_but_rejects_weak_tags(app, client):
     with app.app_context():
-        user_id = create_user(localpart='entity-tags').email
+        user_id = scim_id(create_user(localpart='entity-tags'))
     url = f'/api/scim/v2/Users/{user_id}'
     version = client.get(url, headers=auth_headers(app)).headers['ETag']
     payload = {
@@ -403,13 +494,14 @@ def test_scim_if_match_supports_lists_and_wildcard_but_rejects_weak_tags(app, cl
 def test_scim_user_if_match_rejects_stale_without_changes(app, client, method):
     with app.app_context():
         user = create_user()
-        user_id = user.email
+        user_id = scim_id(user)
+        user_name = user.email
 
     initial = client.get(f'/api/scim/v2/Users/{user_id}', headers=auth_headers(app))
     stale_version = initial.get_json()['meta']['version']
 
     with app.app_context():
-        user = models.db.session.get(models.User, user_id)
+        user = scim_user(user_id)
         user.displayed_name = 'Concurrent user update'
         models.db.session.commit()
         expected_password = user.password
@@ -425,7 +517,7 @@ def test_scim_user_if_match_rejects_stale_without_changes(app, client, method):
             json={
                 'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
                 'id': user_id,
-                'userName': user_id,
+                'userName': user_name,
                 'active': False,
                 'displayName': 'Rejected stale replacement',
             },
@@ -448,7 +540,7 @@ def test_scim_user_if_match_rejects_stale_without_changes(app, client, method):
 
     assert_precondition_failed(response)
     with app.app_context():
-        user = models.db.session.get(models.User, user_id)
+        user = scim_user(user_id)
         assert user.enabled is True
         assert user.displayed_name == 'Concurrent user update'
         assert user.password == expected_password
@@ -460,7 +552,7 @@ def test_scim_user_if_match_rejects_stale_without_changes(app, client, method):
             json={
                 'schemas': ['urn:ietf:params:scim:schemas:core:2.0:User'],
                 'id': user_id,
-                'userName': user_id,
+                'userName': user_name,
                 'active': False,
                 'displayName': 'Accepted replacement',
             },
@@ -488,15 +580,16 @@ def test_scim_user_if_match_rejects_stale_without_changes(app, client, method):
 def test_scim_group_if_match_rejects_stale_without_changes(app, client, method):
     with app.app_context():
         group = create_group()
-        group_id = group.email
+        group_id = scim_id(group)
+        alias_address = group.email
 
     initial = client.get(f'/api/scim/v2/Groups/{group_id}', headers=auth_headers(app))
     stale_version = initial.get_json()['meta']['version']
 
     with app.app_context():
-        group = models.db.session.get(models.Alias, group_id)
+        group = scim_group(group_id)
+        models.permit_scim_managed_alias_edit(group)
         group.comment = 'Concurrent group update'
-        group.destination = ['current@example.net']
         models.db.session.commit()
 
     current = client.get(f'/api/scim/v2/Groups/{group_id}', headers=auth_headers(app))
@@ -507,12 +600,11 @@ def test_scim_group_if_match_rejects_stale_without_changes(app, client, method):
     if method == 'PUT':
         response = client.put(
             f'/api/scim/v2/Groups/{group_id}',
-            json={
-                'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
-                'id': group_id,
-                'displayName': 'Rejected stale replacement',
-                'members': [{'value': 'rejected@example.net'}],
-            },
+            json=group_payload(
+                alias_address,
+                display_name='Rejected stale replacement',
+                external_destinations=['rejected@example.net'],
+            ),
             headers=headers,
         )
     elif method == 'PATCH':
@@ -523,8 +615,10 @@ def test_scim_group_if_match_rejects_stale_without_changes(app, client, method):
                 'Operations': [
                     {
                         'op': 'replace',
-                        'path': 'members',
-                        'value': [{'value': 'rejected@example.net'}],
+                        'path': (
+                            f'{GROUP_EXTENSION}:externalDestinations'
+                        ),
+                        'value': ['rejected@example.net'],
                     }
                 ],
             },
@@ -535,20 +629,19 @@ def test_scim_group_if_match_rejects_stale_without_changes(app, client, method):
 
     assert_precondition_failed(response)
     with app.app_context():
-        group = models.db.session.get(models.Alias, group_id)
+        group = scim_group(group_id)
         assert group.comment == 'Concurrent group update'
-        assert group.destination == ['current@example.net']
+        assert group.destination == ['original@example.net']
 
     current_headers = {**auth_headers(app), 'If-Match': current_version}
     if method == 'PUT':
         response = client.put(
             f'/api/scim/v2/Groups/{group_id}',
-            json={
-                'schemas': ['urn:ietf:params:scim:schemas:core:2.0:Group'],
-                'id': group_id,
-                'displayName': 'Accepted replacement',
-                'members': [{'value': 'accepted@example.net'}],
-            },
+            json=group_payload(
+                alias_address,
+                display_name='Accepted replacement',
+                external_destinations=['accepted@example.net'],
+            ),
             headers=current_headers,
         )
         assert response.status_code == 200
@@ -561,15 +654,19 @@ def test_scim_group_if_match_rejects_stale_without_changes(app, client, method):
                 'Operations': [
                     {
                         'op': 'replace',
-                        'path': 'members',
-                        'value': [{'value': 'accepted@example.net'}],
+                        'path': (
+                            f'{GROUP_EXTENSION}:externalDestinations'
+                        ),
+                        'value': ['accepted@example.net'],
                     }
                 ],
             },
             headers=current_headers,
         )
         assert response.status_code == 200
-        assert [member['value'] for member in response.get_json()['members']] == ['accepted@example.net']
+        assert response.get_json()[GROUP_EXTENSION][
+            'externalDestinations'
+        ] == ['accepted@example.net']
     else:
         response = client.delete(f'/api/scim/v2/Groups/{group_id}', headers=current_headers)
         assert response.status_code == 204
@@ -578,7 +675,7 @@ def test_scim_group_if_match_rejects_stale_without_changes(app, client, method):
 def test_scim_user_patch_rejects_password_change_without_side_effects(app, client, monkeypatch):
     with app.app_context():
         user = create_user(localpart='patch-password')
-        user_id = user.email
+        user_id = scim_id(user)
         original_password = user.password
 
     pruned_users = []
@@ -603,7 +700,7 @@ def test_scim_user_patch_rejects_password_change_without_side_effects(app, clien
     assert response.get_json()['scimType'] == 'mutability'
     assert pruned_users == []
     with app.app_context():
-        user = models.db.session.get(models.User, user_id)
+        user = scim_user(user_id)
         assert user.password == original_password
 
 
@@ -615,7 +712,9 @@ def test_scim_deprovisioning_prunes_existing_sessions_after_commit(
     method,
 ):
     with app.app_context():
-        user_id = create_user(localpart=f'deprovision-{method.lower()}').email
+        user = create_user(localpart=f'deprovision-{method.lower()}')
+        user_id = scim_id(user)
+        user_email = user.email
 
     pruned_users = []
     monkeypatch.setattr(
@@ -629,7 +728,7 @@ def test_scim_deprovisioning_prunes_existing_sessions_after_commit(
             url,
             json={
                 'schemas': [USER_SCHEMA],
-                'userName': user_id,
+                'userName': user_email,
                 'active': False,
             },
             headers=auth_headers(app),
@@ -651,9 +750,9 @@ def test_scim_deprovisioning_prunes_existing_sessions_after_commit(
         response = client.delete(url, headers=auth_headers(app))
 
     assert response.status_code == (204 if method == 'DELETE' else 200)
-    assert pruned_users == [user_id]
+    assert pruned_users == [user_email]
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is False
+        assert scim_user(user_id).enabled is False
 
 
 def test_scim_stale_deprovision_precondition_does_not_prune_sessions(
@@ -662,11 +761,11 @@ def test_scim_stale_deprovision_precondition_does_not_prune_sessions(
     monkeypatch,
 ):
     with app.app_context():
-        user_id = create_user(localpart='stale-deprovision').email
+        user_id = scim_id(create_user(localpart='stale-deprovision'))
     url = f'/api/scim/v2/Users/{user_id}'
     stale_version = client.get(url, headers=auth_headers(app)).headers['ETag']
     with app.app_context():
-        user = models.db.session.get(models.User, user_id)
+        user = scim_user(user_id)
         user.displayed_name = 'Concurrent change'
         models.db.session.commit()
 
@@ -692,16 +791,16 @@ def test_scim_stale_deprovision_precondition_does_not_prune_sessions(
     assert_precondition_failed(response)
     assert pruned_users == []
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is True
+        assert scim_user(user_id).enabled is True
 
 
-def test_scim_session_revocation_failure_rolls_back_user_change(
+def test_scim_session_revocation_failure_does_not_roll_back_committed_user_change(
     app,
     client,
     monkeypatch,
 ):
     with app.app_context():
-        user_id = create_user(localpart='revoke-failure').email
+        user_id = scim_id(create_user(localpart='revoke-failure'))
 
     def fail_revocation(**_kwargs):
         raise RuntimeError('session store unavailable')
@@ -724,11 +823,11 @@ def test_scim_session_revocation_failure_rolls_back_user_change(
         headers=auth_headers(app),
     )
 
-    assert response.status_code == 500
+    assert response.status_code == 200
     assert response.content_type == 'application/scim+json'
-    assert response.get_json()['detail'] == 'Existing sessions could not be revoked'
+    assert response.get_json()['active'] is False
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is True
+        assert scim_user(user_id).enabled is False
 
 
 def test_scim_lock_failure_returns_scim_error_without_mutation(
@@ -737,15 +836,15 @@ def test_scim_lock_failure_returns_scim_error_without_mutation(
     monkeypatch,
 ):
     with app.app_context():
-        user_id = create_user(localpart='lock-failure').email
-    original_get_for_update = scim._get_for_update
+        user_id = scim_id(create_user(localpart='lock-failure'))
+    original_get_scim_for_update = scim._get_scim_for_update
 
-    def fail_user_lock(model, resource_id):
-        if model is models.User and resource_id == user_id:
+    def fail_user_lock(resource_id, resource_type):
+        if resource_type == 'User' and resource_id == user_id:
             raise scim.SQLAlchemyError('lock unavailable')
-        return original_get_for_update(model, resource_id)
+        return original_get_scim_for_update(resource_id, resource_type)
 
-    monkeypatch.setattr(scim, '_get_for_update', fail_user_lock)
+    monkeypatch.setattr(scim, '_get_scim_for_update', fail_user_lock)
     response = client.patch(
         f'/api/scim/v2/Users/{user_id}',
         json={
@@ -761,30 +860,33 @@ def test_scim_lock_failure_returns_scim_error_without_mutation(
 
     assert response.status_code == 500
     assert response.content_type == 'application/scim+json'
-    assert response.get_json()['detail'] == 'The SCIM resource could not be locked'
+    assert response.get_json()['detail'] == 'The SCIM User could not be patched'
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is True
+        assert scim_user(user_id).enabled is True
 
 
 def test_scim_sqlite_lock_refreshes_an_unexpired_identity(app):
     with app.app_context():
-        user_id = create_user(localpart='stale-identity').email
+        user = create_user(localpart='stale-identity')
+        user_id = scim_id(user)
+        user_email = user.email
         session = models.db.session()
-        cached = session.get(models.User, user_id)
+        cached = session.get(models.User, user_email)
         session.commit()
         assert cached.displayed_name == 'Original user'
 
         concurrent_session = Session(models.db.engine)
         try:
-            concurrent = concurrent_session.get(models.User, user_id)
+            concurrent = concurrent_session.get(models.User, user_email)
             concurrent.displayed_name = 'Concurrent user'
             concurrent_session.commit()
         finally:
             concurrent_session.close()
 
-        locked = scim._get_for_update(models.User, user_id)
-        assert locked is cached
-        assert locked.displayed_name == 'Concurrent user'
+        models.lock_scim_graph()
+        locked = scim._get_scim_for_update(user_id, 'User')
+        assert locked.user is cached
+        assert locked.user.displayed_name == 'Concurrent user'
         models.db.session.rollback()
 
 
@@ -794,7 +896,7 @@ def test_scim_bulk_continues_after_session_revocation_failure(
     monkeypatch,
 ):
     with app.app_context():
-        user_id = create_user(localpart='bulk-revoke-failure').email
+        user_id = scim_id(create_user(localpart='bulk-revoke-failure'))
 
     def fail_revocation(**_kwargs):
         raise RuntimeError('session store unavailable')
@@ -835,9 +937,9 @@ def test_scim_bulk_continues_after_session_revocation_failure(
         headers=auth_headers(app),
     )
 
-    assert [item['status'] for item in response.get_json()['Operations']] == ['500', '201']
+    assert [item['status'] for item in response.get_json()['Operations']] == ['200', '201']
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is True
+        assert scim_user(user_id).enabled is False
         assert models.db.session.get(models.User, 'after-revocation-error@example.com') is not None
 
 
@@ -855,7 +957,8 @@ def test_scim_create_and_get_user(app, client):
 
     assert rv.status_code == 201
     data = rv.get_json()
-    assert data['id'] == 'alice@example.com'
+    assert data['id'] != 'alice@example.com'
+    assert data['id']
     assert data['userName'] == 'alice@example.com'
     assert data['active'] is True
     assert data['displayName'] == 'Alice Example'
@@ -867,7 +970,10 @@ def test_scim_create_and_get_user(app, client):
         assert user.enabled is True
         assert user.displayed_name == 'Alice Example'
 
-    rv = client.get('/api/scim/v2/Users/alice@example.com', headers=auth_headers(app))
+    rv = client.get(
+        f'/api/scim/v2/Users/{data["id"]}',
+        headers=auth_headers(app),
+    )
     assert rv.status_code == 200
     assert rv.get_json()['userName'] == 'alice@example.com'
 
@@ -890,6 +996,7 @@ def test_scim_filter_user_by_username(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     rv = client.get('/api/scim/v2/Users?filter=userName eq "bob@example.com"', headers=auth_headers(app))
 
@@ -906,6 +1013,7 @@ def test_scim_patch_active_and_display_name(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     payload = {
         'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
@@ -914,7 +1022,11 @@ def test_scim_patch_active_and_display_name(app, client):
             {'op': 'replace', 'path': 'displayName', 'value': 'Carol Disabled'},
         ],
     }
-    rv = client.patch('/api/scim/v2/Users/carol@example.com', json=payload, headers=auth_headers(app))
+    rv = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json=payload,
+        headers=auth_headers(app),
+    )
 
     assert rv.status_code == 200
     data = rv.get_json()
@@ -929,7 +1041,7 @@ def test_scim_patch_active_and_display_name(app, client):
 
 def test_scim_patch_accepts_schema_qualified_core_path(app, client):
     with app.app_context():
-        user_id = create_user(localpart='qualified-path').email
+        user_id = scim_id(create_user(localpart='qualified-path'))
 
     response = client.patch(
         f'/api/scim/v2/Users/{user_id}',
@@ -952,7 +1064,7 @@ def test_scim_patch_accepts_schema_qualified_core_path(app, client):
 
 def test_scim_resource_attribute_names_are_case_insensitive(app, client):
     with app.app_context():
-        user_id = create_user(localpart='attribute-case').email
+        user_id = scim_id(create_user(localpart='attribute-case'))
 
     response = client.patch(
         f'/api/scim/v2/Users/{user_id}',
@@ -978,10 +1090,18 @@ def test_scim_delete_disables_user_without_removing_mailbox(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
-    rv = client.delete('/api/scim/v2/Users/dave@example.com', headers=auth_headers(app))
+    rv = client.delete(
+        f'/api/scim/v2/Users/{user_id}',
+        headers=auth_headers(app),
+    )
 
     assert rv.status_code == 204
+    assert client.get(
+        f'/api/scim/v2/Users/{user_id}',
+        headers=auth_headers(app),
+    ).status_code == 404
     with app.app_context():
         user = models.db.session.get(models.User, 'dave@example.com')
         assert user is not None
@@ -1002,7 +1122,7 @@ def test_scim_delete_missing_resource_returns_scim_404(app, client, resource_typ
 
 def test_scim_repeated_group_delete_returns_scim_404(app, client):
     with app.app_context():
-        group_id = create_group(localpart='delete-twice').email
+        group_id = scim_id(create_group(localpart='delete-twice'))
     url = f'/api/scim/v2/Groups/{group_id}'
 
     assert client.delete(url, headers=auth_headers(app)).status_code == 204
@@ -1054,12 +1174,17 @@ def test_scim_patch_rejects_invalid_active_value(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     payload = {
         'schemas': ['urn:ietf:params:scim:api:messages:2.0:PatchOp'],
         'Operations': [{'op': 'replace', 'path': 'active', 'value': 'maybe'}],
     }
-    rv = client.patch('/api/scim/v2/Users/frank@example.com', json=payload, headers=auth_headers(app))
+    rv = client.patch(
+        f'/api/scim/v2/Users/{user_id}',
+        json=payload,
+        headers=auth_headers(app),
+    )
 
     assert rv.status_code == 400
     assert rv.get_json()['scimType'] == 'invalidValue'
@@ -1075,9 +1200,10 @@ def test_scim_patch_rejects_non_object_operations(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     rv = client.patch(
-        '/api/scim/v2/Users/grace@example.com',
+        f'/api/scim/v2/Users/{user_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': ['not-an-object'],
@@ -1114,9 +1240,10 @@ def test_scim_patch_rejects_non_string_op_and_path(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     rv = client.patch(
-        '/api/scim/v2/Users/heidi@example.com',
+        f'/api/scim/v2/Users/{user_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': [{'op': 7, 'path': 9, 'value': 'ignored'}],
@@ -1138,9 +1265,10 @@ def test_scim_patch_remove_clears_optional_display_name(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     rv = client.patch(
-        '/api/scim/v2/Users/ivan@example.com',
+        f'/api/scim/v2/Users/{user_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': [{'op': 'remove', 'path': 'displayName'}],
@@ -1161,9 +1289,10 @@ def test_scim_patch_rejects_unknown_path(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     rv = client.patch(
-        '/api/scim/v2/Users/judy@example.com',
+        f'/api/scim/v2/Users/{user_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': [{
@@ -1203,9 +1332,10 @@ def test_scim_patch_rejects_empty_operations(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     rv = client.patch(
-        '/api/scim/v2/Users/mallory@example.com',
+        f'/api/scim/v2/Users/{user_id}',
         json={'schemas': [PATCH_SCHEMA], 'Operations': []},
         headers=auth_headers(app),
     )
@@ -1241,9 +1371,10 @@ def test_scim_patch_rejects_existing_password_changes(app, client):
         user.set_password('secret')
         models.db.session.add(user)
         models.db.session.commit()
+        user_id = scim_id(user)
 
     rv = client.patch(
-        '/api/scim/v2/Users/olivia@example.com',
+        f'/api/scim/v2/Users/{user_id}',
         json={
             'schemas': [PATCH_SCHEMA],
             'Operations': [{
@@ -1292,11 +1423,11 @@ def test_scim_bulk_creates_user_and_group(app, client):
                 'method': 'POST',
                 'path': '/Groups',
                 'bulkId': 'group1',
-                'data': {
-                    'schemas': [GROUP_SCHEMA],
-                    'displayName': 'bulkgroup@example.com',
-                    'members': [{'value': 'bulkId:user1'}],
-                },
+                'data': group_payload(
+                    'bulkgroup@example.com',
+                    display_name='Bulk group',
+                    members=['bulkId:user1'],
+                ),
             },
         ],
     }
@@ -1328,11 +1459,11 @@ def test_scim_bulk_resolves_forward_bulk_id_dependencies(app, client):
                     'method': 'POST',
                     'path': '/Groups',
                     'bulkId': 'group-first',
-                    'data': {
-                        'schemas': [GROUP_SCHEMA],
-                        'displayName': 'forward-group@example.com',
-                        'members': [{'value': 'bulkId:user-later'}],
-                    },
+                    'data': group_payload(
+                        'forward-group@example.com',
+                        display_name='Forward group',
+                        members=['bulkId:user-later'],
+                    ),
                 },
                 {
                     'method': 'POST',
@@ -1371,24 +1502,24 @@ def test_scim_bulk_rejects_circular_bulk_id_dependencies_without_partial_commit(
                     'method': 'POST',
                     'path': '/Groups',
                     'bulkId': 'group-a',
-                    'data': {
-                        'schemas': [GROUP_SCHEMA],
-                        'displayName': 'group-a@example.com',
-                        'members': [{'value': 'bulkId:group-b'}],
-                    },
+                    'data': group_payload(
+                        'group-a@example.com',
+                        display_name='Group A',
+                        members=['bulkId:group-b'],
+                    ),
                 },
                 {
                     'method': 'POST',
                     'path': '/Groups',
                     'bulkId': 'group-b',
-                    'data': {
-                        'schemas': [GROUP_SCHEMA],
-                        'displayName': 'group-b@example.com',
-                        'members': [
-                            {'value': 'bulkId:group-a'},
-                            {'value': 'not-an-email'},
+                    'data': group_payload(
+                        'group-b@example.com',
+                        display_name='Group B',
+                        members=[
+                            'bulkId:group-a',
+                            'not-an-id',
                         ],
-                    },
+                    ),
                 },
             ],
         },
@@ -1440,16 +1571,17 @@ def test_scim_bulk_stops_after_fail_on_errors(app, client):
 def test_scim_bulk_version_rejects_stale_resource_without_changes(app, client, resource_type):
     with app.app_context():
         resource = create_user() if resource_type == 'Users' else create_group()
-        resource_id = resource.email
+        resource_id = scim_id(resource)
     url = f'/api/scim/v2/{resource_type}/{resource_id}'
     stale_version = client.get(url, headers=auth_headers(app)).headers['ETag']
 
     with app.app_context():
         if resource_type == 'Users':
-            resource = models.db.session.get(models.User, resource_id)
+            resource = scim_user(resource_id)
             resource.displayed_name = 'Concurrent user'
         else:
-            resource = models.db.session.get(models.Alias, resource_id)
+            resource = scim_group(resource_id)
+            models.permit_scim_managed_alias_edit(resource)
             resource.comment = 'Concurrent group'
         models.db.session.commit()
 
@@ -1467,8 +1599,8 @@ def test_scim_bulk_version_rejects_stale_resource_without_changes(app, client, r
             'schemas': [PATCH_SCHEMA],
             'Operations': [{
                 'op': 'replace',
-                'path': 'members',
-                'value': [{'value': 'rejected@example.net'}],
+                'path': f'{GROUP_EXTENSION}:externalDestinations',
+                'value': ['rejected@example.net'],
             }],
         }
     response = client.post(
@@ -1493,16 +1625,16 @@ def test_scim_bulk_version_rejects_stale_resource_without_changes(app, client, r
     assert operation['location'].endswith(f'/{resource_type}/{resource_id}')
     with app.app_context():
         if resource_type == 'Users':
-            assert models.db.session.get(models.User, resource_id).displayed_name == 'Concurrent user'
+            assert scim_user(resource_id).displayed_name == 'Concurrent user'
         else:
-            group = models.db.session.get(models.Alias, resource_id)
+            group = scim_group(resource_id)
             assert group.comment == 'Concurrent group'
             assert group.destination == ['original@example.net']
 
 
 def test_scim_bulk_delete_response_includes_resource_location(app, client):
     with app.app_context():
-        group_id = create_group(localpart='bulk-delete-location').email
+        group_id = scim_id(create_group(localpart='bulk-delete-location'))
 
     response = client.post(
         '/api/scim/v2/Bulk',
@@ -1520,12 +1652,20 @@ def test_scim_bulk_delete_response_includes_resource_location(app, client):
     assert operation['status'] == '204'
     assert operation['location'].endswith(f'/Groups/{group_id}')
     with app.app_context():
-        assert models.db.session.get(models.Alias, group_id) is None
+        assert scim_group(group_id) is None
 
 
 def test_scim_bulk_does_not_leak_failed_operation_state_into_later_commit(app, client):
     with app.app_context():
-        group_id = create_group(localpart='bulk-rollback').email
+        group = create_group(localpart='bulk-rollback')
+        group_id = scim_id(group)
+        group_email = group.email
+    invalid_group = group_payload(
+        group_email,
+        display_name='Must roll back',
+    )
+    invalid_group['id'] = group_id
+    invalid_group['members'] = [{}]
 
     response = client.post(
         '/api/scim/v2/Bulk',
@@ -1535,12 +1675,7 @@ def test_scim_bulk_does_not_leak_failed_operation_state_into_later_commit(app, c
                 {
                     'method': 'PUT',
                     'path': f'/Groups/{group_id}',
-                    'data': {
-                        'schemas': [GROUP_SCHEMA],
-                        'id': group_id,
-                        'displayName': 'Must roll back',
-                        'members': [{}],
-                    },
+                    'data': invalid_group,
                 },
                 {
                     'method': 'POST',
@@ -1558,7 +1693,7 @@ def test_scim_bulk_does_not_leak_failed_operation_state_into_later_commit(app, c
 
     assert [item['status'] for item in response.get_json()['Operations']] == ['400', '201']
     with app.app_context():
-        group = models.db.session.get(models.Alias, group_id)
+        group = scim_group(group_id)
         assert group.comment == 'Original group'
         assert group.destination == ['original@example.net']
         assert models.db.session.get(models.User, 'committed@example.com') is not None
@@ -1566,7 +1701,7 @@ def test_scim_bulk_does_not_leak_failed_operation_state_into_later_commit(app, c
 
 def test_scim_bulk_ignores_outer_if_match_and_preserves_absent_version_behavior(app, client):
     with app.app_context():
-        user_id = create_user(localpart='bulk-outer-header').email
+        user_id = scim_id(create_user(localpart='bulk-outer-header'))
 
     response = client.post(
         '/api/scim/v2/Bulk',
@@ -1687,7 +1822,9 @@ def test_scim_bulk_accepts_canonical_percent_encoded_resource_paths(
     method,
 ):
     with app.app_context():
-        user_id = create_user(localpart=f'bulk-{method.lower()}#question?percent%').email
+        user = create_user(localpart=f'bulk-{method.lower()}#question?percent%')
+        user_id = scim_id(user)
+        user_email = user.email
     direct_path = f'/api/scim/v2/Users/{urllib.parse.quote(user_id, safe="@")}'
     direct = client.get(direct_path, headers=auth_headers(app))
     location = direct.get_json()['meta']['location']
@@ -1695,7 +1832,7 @@ def test_scim_bulk_accepts_canonical_percent_encoded_resource_paths(
     if method == 'PUT':
         data = {
             'schemas': [USER_SCHEMA],
-            'userName': user_id,
+            'userName': user_email,
             'displayName': 'Bulk encoded PUT',
         }
     elif method == 'PATCH':
@@ -1729,7 +1866,7 @@ def test_scim_bulk_accepts_canonical_percent_encoded_resource_paths(
     assert result['status'] == ('204' if method == 'DELETE' else '200')
     assert result['location'] == location
     with app.app_context():
-        user = models.db.session.get(models.User, user_id)
+        user = scim_user(user_id)
         if method == 'DELETE':
             assert user.enabled is False
         else:
@@ -1761,35 +1898,39 @@ def test_scim_bulk_rejects_non_relative_resource_paths(app, client, path):
 
 
 @pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
-def test_scim_malformed_resource_id_returns_scim_error(app, client, resource_type):
+def test_scim_unknown_opaque_resource_id_returns_scim_404(app, client, resource_type):
     response = client.get(
         f'/api/scim/v2/{resource_type}/not-an-email',
         headers=auth_headers(app),
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert response.content_type == 'application/scim+json'
-    assert response.get_json()['scimType'] == 'invalidValue'
+    assert response.get_json()['status'] == '404'
 
 
 def test_scim_filters_validate_syntax_and_group_display_name_semantics(app, client):
     with app.app_context():
-        create_group(localpart='filter-label', comment='Operations Team')
-        create_group(localpart='filter-address', comment='')
+        label_id = scim_id(
+            create_group(localpart='filter-label', comment='Operations Team')
+        )
+        address_id = scim_id(
+            create_group(localpart='filter-address', comment='')
+        )
 
     label = client.get(
         '/api/scim/v2/Groups?filter=displayName%20eq%20%22operations%20team%22',
         headers=auth_headers(app),
     )
     assert label.status_code == 200
-    assert [group['id'] for group in label.get_json()['Resources']] == ['filter-label@example.com']
+    assert [group['id'] for group in label.get_json()['Resources']] == [label_id]
 
     address = client.get(
         '/api/scim/v2/Groups?filter=displayName%20eq%20%22filter-address@example.com%22',
         headers=auth_headers(app),
     )
     assert address.status_code == 200
-    assert [group['id'] for group in address.get_json()['Resources']] == ['filter-address@example.com']
+    assert [group['id'] for group in address.get_json()['Resources']] == [address_id]
 
     malformed = client.get(
         '/api/scim/v2/Users?filter=userName%20eq%20not-an-email',
@@ -1805,10 +1946,10 @@ def test_scim_rejects_user_alias_address_collisions(app, client):
 
     group_collision = client.post(
         '/api/scim/v2/Groups',
-        json={
-            'schemas': [GROUP_SCHEMA],
-            'displayName': 'user-first@example.com',
-        },
+        json=group_payload(
+            'user-first@example.com',
+            display_name='User collision',
+        ),
         headers=auth_headers(app),
     )
     assert group_collision.status_code == 409
@@ -1834,31 +1975,33 @@ def test_scim_rejects_user_alias_address_collisions(app, client):
 
 def test_scim_external_group_destination_has_no_dangling_user_reference(app, client):
     with app.app_context():
-        group_id = create_group(localpart='external-member').email
+        group_id = scim_id(create_group(localpart='external-member'))
 
     response = client.get(
         f'/api/scim/v2/Groups/{group_id}',
         headers=auth_headers(app),
     )
-    member = response.get_json()['members'][0]
-    assert member == {
-        'value': 'original@example.net',
-        'display': 'original@example.net',
-    }
+    payload = response.get_json()
+    assert payload['members'] == []
+    assert payload[GROUP_EXTENSION]['externalDestinations'] == [
+        'original@example.net',
+    ]
 
 
 @pytest.mark.parametrize('resource_type', ['Users', 'Groups'])
 def test_scim_put_requires_complete_identity_fields_without_mutation(app, client, resource_type):
     with app.app_context():
         resource = create_user() if resource_type == 'Users' else create_group()
-        resource_id = resource.email
+        resource_id = scim_id(resource)
 
     response = client.put(
         f'/api/scim/v2/{resource_type}/{resource_id}',
         json={
-            'schemas': [
-                USER_SCHEMA if resource_type == 'Users' else GROUP_SCHEMA
-            ],
+            'schemas': (
+                [USER_SCHEMA]
+                if resource_type == 'Users'
+                else [GROUP_SCHEMA, GROUP_EXTENSION]
+            ),
         },
         headers=auth_headers(app),
     )
@@ -1866,24 +2009,26 @@ def test_scim_put_requires_complete_identity_fields_without_mutation(app, client
     assert response.get_json()['scimType'] == 'invalidValue'
     with app.app_context():
         if resource_type == 'Users':
-            user = models.db.session.get(models.User, resource_id)
+            user = scim_user(resource_id)
             assert user.displayed_name == 'Original user'
             assert user.enabled is True
         else:
-            group = models.db.session.get(models.Alias, resource_id)
+            group = scim_group(resource_id)
             assert group.comment == 'Original group'
             assert group.destination == ['original@example.net']
 
 
 def test_scim_user_put_rejects_conflicting_immutable_email_identity(app, client):
     with app.app_context():
-        user_id = create_user(localpart='identity-conflict').email
+        user = create_user(localpart='identity-conflict')
+        user_id = scim_id(user)
+        user_email = user.email
 
     response = client.put(
         f'/api/scim/v2/Users/{user_id}',
         json={
             'schemas': [USER_SCHEMA],
-            'userName': user_id,
+            'userName': user_email,
             'emails': [{'value': 'different@example.com'}],
             'active': False,
         },
@@ -1893,7 +2038,7 @@ def test_scim_user_put_rejects_conflicting_immutable_email_identity(app, client)
     assert response.status_code == 400
     assert response.get_json()['scimType'] == 'mutability'
     with app.app_context():
-        user = models.db.session.get(models.User, user_id)
+        user = scim_user(user_id)
         assert user.enabled is True
         assert user.displayed_name == 'Original user'
 
@@ -1902,7 +2047,7 @@ def test_scim_user_put_rejects_conflicting_immutable_email_identity(app, client)
 def test_scim_patch_requires_explicit_operation(app, client, resource_type):
     with app.app_context():
         resource = create_user() if resource_type == 'Users' else create_group()
-        resource_id = resource.email
+        resource_id = scim_id(resource)
 
     response = client.patch(
         f'/api/scim/v2/{resource_type}/{resource_id}',
@@ -1921,7 +2066,7 @@ def test_scim_patch_requires_explicit_operation(app, client, resource_type):
 
 def test_scim_rejects_incorrect_schema_envelope_without_mutation(app, client):
     with app.app_context():
-        user_id = create_user(localpart='wrong-schema').email
+        user_id = scim_id(create_user(localpart='wrong-schema'))
 
     response = client.patch(
         f'/api/scim/v2/Users/{user_id}',
@@ -1939,7 +2084,7 @@ def test_scim_rejects_incorrect_schema_envelope_without_mutation(app, client):
     assert response.status_code == 400
     assert response.get_json()['scimType'] == 'invalidValue'
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is True
+        assert scim_user(user_id).enabled is True
 
 
 def test_scim_discovery_self_links_are_retrievable_and_schemas_are_not_empty(app, client):
@@ -1958,6 +2103,7 @@ def test_scim_discovery_self_links_are_retrievable_and_schemas_are_not_empty(app
     assert schema.status_code == 200
     assert schema.get_json()['schemas'] == ['urn:ietf:params:scim:schemas:core:2.0:Schema']
     assert {attribute['name'] for attribute in schema.get_json()['attributes']} == {
+        'externalId',
         'displayName',
         'members',
     }
@@ -1990,8 +2136,8 @@ def test_scim_authentication_failure_uses_scim_error_envelope(app, client):
 
 def test_scim_attributes_projection_applies_to_single_and_list_resources(app, client):
     with app.app_context():
-        user_id = create_user(localpart='project-user').email
-        group_id = create_group(localpart='project-group').email
+        user_id = scim_id(create_user(localpart='project-user'))
+        group_id = scim_id(create_group(localpart='project-group'))
 
     user = client.get(
         f'/api/scim/v2/Users/{user_id}?attributes=userName',
@@ -2017,8 +2163,13 @@ def test_scim_attributes_projection_applies_to_single_and_list_resources(app, cl
     )
     group_payload = group.get_json()
     assert group.status_code == 200
-    assert set(group_payload) == {'schemas', 'id', 'members'}, group_payload
-    assert group_payload['members'] == [{'value': 'original@example.net'}]
+    assert set(group_payload) == {
+        'schemas',
+        'id',
+        'displayName',
+        'members',
+    }, group_payload
+    assert group_payload['members'] == []
     assert group.headers['ETag']
 
     groups = client.get(
@@ -2029,13 +2180,21 @@ def test_scim_attributes_projection_applies_to_single_and_list_resources(app, cl
         resource for resource in groups.get_json()['Resources']
         if resource['id'] == group_id
     )
-    assert set(projected_group) == {'schemas', 'id'}
+    assert set(projected_group) == {
+        'schemas',
+        'id',
+        'displayName',
+        GROUP_EXTENSION,
+    }
+    assert projected_group[GROUP_EXTENSION]['externalDestinations'] == [
+        'original@example.net',
+    ]
 
     id_only = client.get(
         f'/api/scim/v2/Users/{user_id}?attributes=id',
         headers=auth_headers(app),
     )
-    assert set(id_only.get_json()) == {'schemas', 'id'}
+    assert set(id_only.get_json()) == {'schemas', 'id', 'userName'}
 
 
 @pytest.mark.parametrize('query', [
@@ -2062,7 +2221,9 @@ def test_scim_projection_parent_dominates_children_and_never_returns_password(
     client,
 ):
     with app.app_context():
-        user_id = create_user(localpart='projection-tree').email
+        user = create_user(localpart='projection-tree')
+        user_id = scim_id(user)
+        user_email = user.email
 
     parent = client.get(
         f'/api/scim/v2/Users/{user_id}?attributes=emails.value,emails',
@@ -2070,7 +2231,7 @@ def test_scim_projection_parent_dominates_children_and_never_returns_password(
     )
     assert parent.status_code == 200
     assert parent.get_json()['emails'] == [{
-        'value': user_id,
+        'value': user_email,
         'primary': True,
         'type': 'work',
     }]
@@ -2079,28 +2240,30 @@ def test_scim_projection_parent_dominates_children_and_never_returns_password(
         f'/api/scim/v2/Users/{user_id}?attributes=password',
         headers=auth_headers(app),
     )
-    assert set(password.get_json()) == {'schemas', 'id'}
+    assert set(password.get_json()) == {'schemas', 'id', 'userName'}
 
 
 def test_scim_projection_applies_to_mutation_responses_but_not_discovery(app, client):
     with app.app_context():
-        user_id = create_user(localpart='project-mutation').email
+        user = create_user(localpart='project-mutation')
+        user_id = scim_id(user)
+        user_email = user.email
 
     replaced = client.put(
         f'/api/scim/v2/Users/{user_id}?attributes=id',
         json={
             'schemas': [USER_SCHEMA],
-            'userName': user_id,
+            'userName': user_email,
             'displayName': 'Projected mutation',
         },
         headers=auth_headers(app),
     )
     assert replaced.status_code == 200
-    assert set(replaced.get_json()) == {'schemas', 'id'}
+    assert set(replaced.get_json()) == {'schemas', 'id', 'userName'}
     assert replaced.headers['ETag']
     assert replaced.headers['Content-Location']
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).displayed_name == 'Projected mutation'
+        assert scim_user(user_id).displayed_name == 'Projected mutation'
 
     discovery = client.get(
         '/api/scim/v2/Schemas?attributes=&excludedAttributes=id',
@@ -2119,7 +2282,7 @@ def test_scim_projection_applies_to_mutation_responses_but_not_discovery(app, cl
         for attribute in user_schema['attributes']
         if attribute['name'] == 'userName'
     )
-    assert user_name['returned'] == 'default'
+    assert user_name['returned'] == 'always'
 
 
 @pytest.mark.parametrize('schemas', [
@@ -2170,11 +2333,13 @@ def test_scim_schema_uri_matching_is_case_insensitive(app, client):
 
 def test_scim_put_patch_and_bulk_require_their_schema_envelopes(app, client):
     with app.app_context():
-        user_id = create_user(localpart='schema-envelope').email
+        user = create_user(localpart='schema-envelope')
+        user_id = scim_id(user)
+        user_email = user.email
 
     put_response = client.put(
         f'/api/scim/v2/Users/{user_id}',
-        json={'userName': user_id, 'displayName': 'Must not change'},
+        json={'userName': user_email, 'displayName': 'Must not change'},
         headers=auth_headers(app),
     )
     patch_response = client.patch(
@@ -2211,22 +2376,22 @@ def test_scim_put_patch_and_bulk_require_their_schema_envelopes(app, client):
     assert patch_response.status_code == 400
     assert bulk_response.status_code == 400
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).displayed_name == 'Original user'
+        assert scim_user(user_id).displayed_name == 'Original user'
 
 
 @pytest.mark.parametrize('method', ['post', 'put'])
 def test_scim_user_create_and_replace_require_explicit_username(app, client, method):
     with app.app_context():
         create_domain()
+        user_id = 'required-username@example.com'
         if method == 'put':
-            create_user(localpart='required-username')
+            user_id = scim_id(create_user(localpart='required-username'))
 
-    user_id = 'required-username@example.com'
     response = getattr(client, method)(
         '/api/scim/v2/Users' if method == 'post' else f'/api/scim/v2/Users/{user_id}',
         json={
             'schemas': [USER_SCHEMA],
-            'emails': [{'value': user_id}],
+            'emails': [{'value': 'required-username@example.com'}],
             'active': False,
         },
         headers=auth_headers(app),
@@ -2236,9 +2401,9 @@ def test_scim_user_create_and_replace_require_explicit_username(app, client, met
     assert response.get_json()['scimType'] == 'invalidValue'
     with app.app_context():
         if method == 'post':
-            assert models.db.session.get(models.User, user_id) is None
+            assert scim_user(user_id) is None
         else:
-            user = models.db.session.get(models.User, user_id)
+            user = scim_user(user_id)
             assert user.enabled is True
             assert user.displayed_name == 'Original user'
 
@@ -2277,7 +2442,7 @@ def test_scim_rejects_case_equivalent_attribute_collisions_without_mutation(
 
 def test_scim_rejects_case_equivalent_patch_and_bulk_keys_without_mutation(app, client):
     with app.app_context():
-        user_id = create_user(localpart='ambiguous-operation').email
+        user_id = scim_id(create_user(localpart='ambiguous-operation'))
 
     patch_response = client.patch(
         f'/api/scim/v2/Users/{user_id}',
@@ -2318,7 +2483,7 @@ def test_scim_rejects_case_equivalent_patch_and_bulk_keys_without_mutation(app, 
     assert bulk_response.status_code == 400
     assert bulk_response.get_json()['scimType'] == 'invalidSyntax'
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is True
+        assert scim_user(user_id).enabled is True
 
 
 @pytest.mark.parametrize('duplicate_name', ['userName', r'user\u004eame'])
@@ -2350,7 +2515,7 @@ def test_scim_rejects_exact_duplicate_json_names_without_mutation(
 
 def test_scim_rejects_nested_exact_duplicate_json_names_without_mutation(app, client):
     with app.app_context():
-        user_id = create_user(localpart='nested-duplicate').email
+        user_id = scim_id(create_user(localpart='nested-duplicate'))
 
     response = client.post(
         '/api/scim/v2/Bulk',
@@ -2368,7 +2533,7 @@ def test_scim_rejects_nested_exact_duplicate_json_names_without_mutation(app, cl
     assert response.content_type == 'application/scim+json'
     assert response.get_json()['scimType'] == 'invalidSyntax'
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is True
+        assert scim_user(user_id).enabled is True
 
 
 @pytest.mark.parametrize(
@@ -2387,7 +2552,7 @@ def test_scim_rejects_malformed_if_match_without_mutation(
     malformed,
 ):
     with app.app_context():
-        user_id = create_user(localpart=f'malformed-{malformed}').email
+        user_id = scim_id(create_user(localpart=f'malformed-{malformed}'))
 
     url = f'/api/scim/v2/Users/{user_id}'
     version = client.get(url, headers=auth_headers(app)).headers['ETag']
@@ -2415,12 +2580,12 @@ def test_scim_rejects_malformed_if_match_without_mutation(
     assert response.content_type == 'application/scim+json'
     assert response.get_json()['scimType'] == 'invalidValue'
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).displayed_name == 'Original user'
+        assert scim_user(user_id).displayed_name == 'Original user'
 
 
 def test_scim_rejects_malformed_if_none_match(app, client):
     with app.app_context():
-        user_id = create_user(localpart='malformed-if-none-match').email
+        user_id = scim_id(create_user(localpart='malformed-if-none-match'))
 
     url = f'/api/scim/v2/Users/{user_id}'
     version = client.get(url, headers=auth_headers(app)).headers['ETag']
@@ -2436,7 +2601,7 @@ def test_scim_rejects_malformed_if_none_match(app, client):
 
 def test_scim_accepts_empty_entity_tag_list_elements(app, client):
     with app.app_context():
-        user_id = create_user(localpart='empty-etag-elements').email
+        user_id = scim_id(create_user(localpart='empty-etag-elements'))
 
     url = f'/api/scim/v2/Users/{user_id}'
     version = client.get(url, headers=auth_headers(app)).headers['ETag']
@@ -2487,7 +2652,7 @@ def test_scim_accepts_empty_entity_tag_list_elements(app, client):
 
 def test_scim_accepts_ows_around_entity_tag_field_values(app, client):
     with app.app_context():
-        user_id = create_user(localpart='etag-ows').email
+        user_id = scim_id(create_user(localpart='etag-ows'))
 
     url = f'/api/scim/v2/Users/{user_id}'
     version = client.get(url, headers=auth_headers(app)).headers['ETag']
@@ -2518,7 +2683,7 @@ def test_scim_accepts_ows_around_entity_tag_field_values(app, client):
 
 def test_scim_rejects_large_malformed_bulk_version_in_linear_time(app, client):
     with app.app_context():
-        user_id = create_user(localpart='large-malformed-version').email
+        user_id = scim_id(create_user(localpart='large-malformed-version'))
 
     started = time.monotonic()
     response = client.post(
@@ -2541,7 +2706,7 @@ def test_scim_rejects_large_malformed_bulk_version_in_linear_time(app, client):
     assert operation['status'] == '400'
     assert operation['response']['scimType'] == 'invalidValue'
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).enabled is True
+        assert scim_user(user_id).enabled is True
 
 
 def test_scim_validates_if_none_match_before_missing_resource(app, client):
@@ -2561,7 +2726,7 @@ def test_scim_validates_if_none_match_before_missing_resource(app, client):
 
 def test_scim_bulk_rejects_malformed_version_without_mutation(app, client):
     with app.app_context():
-        user_id = create_user(localpart='malformed-bulk-version').email
+        user_id = scim_id(create_user(localpart='malformed-bulk-version'))
 
     url = f'/api/scim/v2/Users/{user_id}'
     version = client.get(url, headers=auth_headers(app)).headers['ETag']
@@ -2591,7 +2756,7 @@ def test_scim_bulk_rejects_malformed_version_without_mutation(app, client):
     assert operation['status'] == '400'
     assert operation['response']['scimType'] == 'invalidValue'
     with app.app_context():
-        assert models.db.session.get(models.User, user_id).displayed_name == 'Original user'
+        assert scim_user(user_id).displayed_name == 'Original user'
 
 
 def test_scim_bulk_rejects_empty_operations_with_invalid_value(app, client):

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -222,7 +222,7 @@ def test_scim_create_handles_non_string_username_and_name(app, client):
     assert rv.get_json()['scimType'] == 'invalidValue'
 
 
-def test_scim_patch_handles_non_string_op_and_path(app, client):
+def test_scim_patch_rejects_non_string_op_and_path(app, client):
     with app.app_context():
         domain = create_domain()
         user = models.User(localpart='heidi', domain=domain)
@@ -236,7 +236,44 @@ def test_scim_patch_handles_non_string_op_and_path(app, client):
         headers=auth_headers(app),
     )
 
-    assert rv.status_code == 200
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'mutability'
     with app.app_context():
         user = models.db.session.get(models.User, 'heidi@example.com')
         assert user.enabled is True
+
+
+def test_scim_patch_rejects_remove_operation(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='ivan', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.patch(
+        '/api/scim/v2/Users/ivan@example.com',
+        json={'Operations': [{'op': 'remove', 'path': 'displayName'}]},
+        headers=auth_headers(app),
+    )
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'mutability'
+
+
+def test_scim_patch_rejects_unknown_path(app, client):
+    with app.app_context():
+        domain = create_domain()
+        user = models.User(localpart='judy', domain=domain)
+        user.set_password('secret')
+        models.db.session.add(user)
+        models.db.session.commit()
+
+    rv = client.patch(
+        '/api/scim/v2/Users/judy@example.com',
+        json={'Operations': [{'op': 'replace', 'path': 'title', 'value': 'Boss'}]},
+        headers=auth_headers(app),
+    )
+
+    assert rv.status_code == 400
+    assert rv.get_json()['scimType'] == 'invalidPath'

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -2,6 +2,7 @@ import time
 import urllib.parse
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.orm import Session
 
 from mailu import models
@@ -20,6 +21,22 @@ def auth_headers(app):
         'Authorization': f'Bearer {app.config["API_TOKEN"]}',
         'Content-Type': 'application/scim+json',
     }
+
+
+def scim_get_with_statements(app, client, path):
+    models.db.session.remove()
+    engine = models.db.engine
+    statements = []
+
+    def capture(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    event.listen(engine, 'before_cursor_execute', capture)
+    try:
+        response = client.get(path, headers=auth_headers(app))
+    finally:
+        event.remove(engine, 'before_cursor_execute', capture)
+    return response, statements
 
 
 def create_domain(name='example.com'):
@@ -86,6 +103,133 @@ def scim_group(resource_id):
     if resource is not None:
         return resource.alias
     return models.db.session.get(models.Alias, resource_id)
+
+
+@pytest.mark.parametrize('page_size', [1, 2])
+def test_scim_user_list_statement_count_is_page_size_independent(
+    app,
+    client,
+    page_size,
+):
+    create_user('query-user-one')
+    create_user('query-user-two')
+
+    response, statements = scim_get_with_statements(
+        app,
+        client,
+        f'/api/scim/v2/Users?count={page_size}',
+    )
+
+    assert response.status_code == 200
+    assert response.json['itemsPerPage'] == page_size
+    assert len(response.json['Resources']) == page_size
+    assert len(statements) == 2, '\n\n'.join(statements)
+
+
+@pytest.mark.parametrize('page_size', [1, 2])
+def test_scim_group_list_statement_count_is_page_size_independent(
+    app,
+    client,
+    page_size,
+):
+    users = [
+        create_user('query-member-one'),
+        create_user('query-member-two'),
+    ]
+    groups = [
+        create_group('query-group-one'),
+        create_group('query-group-two'),
+    ]
+    for index, (group, user) in enumerate(zip(groups, users), start=1):
+        models.replace_scim_group_graph(
+            group.scim_resource,
+            member_ids=[scim_id(user)],
+            external_destinations=[f'external-{index}@example.net'],
+        )
+    models.db.session.commit()
+
+    response, statements = scim_get_with_statements(
+        app,
+        client,
+        f'/api/scim/v2/Groups?count={page_size}',
+    )
+
+    assert response.status_code == 200
+    assert response.json['itemsPerPage'] == page_size
+    assert len(response.json['Resources']) == page_size
+    assert all(
+        len(resource['members']) == 1
+        for resource in response.json['Resources']
+    )
+    assert all(
+        len(resource[GROUP_EXTENSION]['externalDestinations']) == 1
+        for resource in response.json['Resources']
+    )
+    assert len(statements) == 4, '\n\n'.join(statements)
+
+
+@pytest.mark.parametrize(
+    ('collection', 'expected_statement_count'),
+    [('Users', 1), ('Groups', 3)],
+)
+def test_scim_single_get_statement_count(
+    app,
+    client,
+    collection,
+    expected_statement_count,
+):
+    user = create_user('query-single-member')
+    resource_id = scim_id(user)
+    if collection == 'Groups':
+        group = create_group('query-single-group')
+        models.replace_scim_group_graph(
+            group.scim_resource,
+            member_ids=[resource_id],
+            external_destinations=['single-external@example.net'],
+        )
+        models.db.session.commit()
+        resource_id = scim_id(group)
+
+    response, statements = scim_get_with_statements(
+        app,
+        client,
+        f'/api/scim/v2/{collection}/{resource_id}',
+    )
+
+    assert response.status_code == 200
+    assert response.json['id'] == resource_id
+    assert len(statements) == expected_statement_count, '\n\n'.join(statements)
+
+
+@pytest.mark.parametrize('collection', ['Users', 'Groups'])
+def test_scim_single_get_rejects_wrong_case_opaque_id(
+    app,
+    client,
+    monkeypatch,
+    collection,
+):
+    resource_id = 'abcdef01-2345-6789-abcd-ef0123456789'
+    monkeypatch.setattr(models, 'new_scim_id', lambda: resource_id)
+    subject = (
+        create_user('query-exact-user')
+        if collection == 'Users'
+        else create_group('query-exact-group')
+    )
+
+    assert scim_id(subject) == resource_id
+    assert client.get(
+        f'/api/scim/v2/{collection}/{resource_id}',
+        headers=auth_headers(app),
+    ).status_code == 200
+
+    wrong_case = client.get(
+        f'/api/scim/v2/{collection}/{resource_id.upper()}',
+        headers=auth_headers(app),
+    )
+
+    assert wrong_case.status_code == 404
+    assert wrong_case.content_type == 'application/scim+json'
+    assert wrong_case.get_json()['status'] == '404'
 
 
 def group_payload(
@@ -1126,6 +1270,7 @@ def test_scim_repeated_group_delete_returns_scim_404(app, client):
     url = f'/api/scim/v2/Groups/{group_id}'
 
     assert client.delete(url, headers=auth_headers(app)).status_code == 204
+    assert client.get(url, headers=auth_headers(app)).status_code == 404
     repeated = client.delete(url, headers=auth_headers(app))
 
     assert repeated.status_code == 404

--- a/tests/scim_test.py
+++ b/tests/scim_test.py
@@ -3,6 +3,7 @@ import urllib.parse
 
 import pytest
 from sqlalchemy import event
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from mailu import models
@@ -252,6 +253,179 @@ def group_payload(
             'externalDestinations': external_destinations or [],
         },
     }
+
+
+@pytest.mark.parametrize('population', [1, 8])
+@pytest.mark.parametrize(
+    ('method', 'expected_status'),
+    [('POST', 201), ('PUT', 200), ('PATCH', 200)],
+)
+def test_scim_group_mutation_post_commit_query_count_is_population_independent(
+    app,
+    client,
+    method,
+    expected_status,
+    population,
+):
+    create_domain()
+    members = [
+        create_user(f'write-query-{method.lower()}-{population}-{index}')
+        for index in range(population)
+    ]
+    member_ids = [scim_id(member) for member in members]
+    destinations = [
+        f'write-query-{method.lower()}-{population}-{index}@outside.test'
+        for index in range(population)
+    ]
+    alias_address = (
+        f'write-query-{method.lower()}-{population}@example.com'
+    )
+    resource_id = None
+    path = '/api/scim/v2/Groups'
+    request_payload = group_payload(
+        alias_address,
+        display_name='Measured Group',
+        members=member_ids,
+        external_destinations=destinations,
+    )
+    if method != 'POST':
+        group = create_group(
+            f'write-query-{method.lower()}-{population}',
+        )
+        resource_id = scim_id(group)
+        path = f'{path}/{resource_id}'
+    if method == 'PATCH':
+        request_payload = {
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'value': {
+                    'displayName': 'Measured Group',
+                    'members': [
+                        {'value': member_id}
+                        for member_id in member_ids
+                    ],
+                    GROUP_EXTENSION: {
+                        'externalDestinations': destinations,
+                    },
+                },
+            }],
+        }
+
+    models.db.session.remove()
+    engine = models.db.engine
+    after_commit_statements = []
+    phase = {'after_commit': False, 'commit_count': 0}
+
+    def mark_after_commit(_session):
+        phase['commit_count'] += 1
+        phase['after_commit'] = True
+
+    def capture(_conn, _cursor, statement, _parameters, _context, _executemany):
+        if phase['after_commit']:
+            after_commit_statements.append(statement)
+
+    event.listen(Session, 'after_commit', mark_after_commit)
+    event.listen(engine, 'before_cursor_execute', capture)
+    try:
+        response = client.open(
+            path,
+            method=method,
+            json=request_payload,
+            headers=auth_headers(app),
+        )
+    finally:
+        event.remove(engine, 'before_cursor_execute', capture)
+        event.remove(Session, 'after_commit', mark_after_commit)
+
+    assert response.status_code == expected_status
+    assert phase['commit_count'] == 1
+    assert len(after_commit_statements) == 3, '\n\n'.join(
+        after_commit_statements
+    )
+
+    payload = response.get_json()
+    resource_id = resource_id or payload['id']
+    assert sorted(member['value'] for member in payload['members']) == sorted(
+        member_ids
+    )
+    assert payload[GROUP_EXTENSION]['externalDestinations'] == sorted(
+        destinations
+    )
+    assert response.headers['ETag'] == payload['meta']['version']
+    assert response.headers['Content-Location'] == payload['meta']['location']
+    if method == 'POST':
+        assert response.headers['Location'] == payload['meta']['location']
+
+    cold = client.get(
+        f'/api/scim/v2/Groups/{resource_id}',
+        headers=auth_headers(app),
+    )
+    assert cold.status_code == 200
+    assert cold.data == response.data
+    assert cold.headers['ETag'] == response.headers['ETag']
+
+
+@pytest.mark.parametrize('reload_failure', ['missing', 'database'])
+@pytest.mark.parametrize('method', ['POST', 'PUT', 'PATCH'])
+def test_scim_group_mutation_post_commit_reload_failure_is_explicit(
+    app,
+    client,
+    monkeypatch,
+    method,
+    reload_failure,
+):
+    create_domain()
+    alias_address = f'reload-failure-{method.lower()}@example.com'
+    path = '/api/scim/v2/Groups'
+    request_payload = group_payload(
+        alias_address,
+        display_name='Committed despite reload failure',
+        external_destinations=['committed@outside.test'],
+    )
+    if method != 'POST':
+        group = create_group(f'reload-failure-{method.lower()}')
+        path = f'{path}/{scim_id(group)}'
+    if method == 'PATCH':
+        request_payload = {
+            'schemas': [PATCH_SCHEMA],
+            'Operations': [{
+                'op': 'replace',
+                'value': {
+                    'displayName': 'Committed despite reload failure',
+                    GROUP_EXTENSION: {
+                        'externalDestinations': ['committed@outside.test'],
+                    },
+                },
+            }],
+        }
+    if reload_failure == 'missing':
+        monkeypatch.setattr(scim, '_get_group', lambda _group_id: None)
+    else:
+        def fail_reload(_group_id):
+            raise SQLAlchemyError('injected committed reload failure')
+
+        monkeypatch.setattr(scim, '_get_group', fail_reload)
+
+    response = client.open(
+        path,
+        method=method,
+        json=request_payload,
+        headers=auth_headers(app),
+    )
+
+    assert response.status_code == 500
+    assert response.get_json() == {
+        'schemas': ['urn:ietf:params:scim:api:messages:2.0:Error'],
+        'status': '500',
+        'detail': 'The committed SCIM Group could not be reloaded',
+    }
+    models.db.session.remove()
+    group = models.db.session.get(models.Alias, alias_address)
+    assert group is not None
+    assert group.comment == 'Committed despite reload failure'
+    assert group.destination == ['committed@outside.test']
+    assert group.scim_resource is not None
 
 
 def assert_precondition_failed(response):

--- a/tests/session_authority_test.py
+++ b/tests/session_authority_test.py
@@ -1,0 +1,439 @@
+import flask
+import flask_login
+import pytest
+
+from mailu import models, utils
+from mailu.ui.views import users as user_views
+
+
+INITIAL_GENERATION = '0' * 32
+
+
+def create_user(localpart='session-user', *, enabled=True):
+    domain = models.db.session.get(models.Domain, 'example.com')
+    if domain is None:
+        domain = models.Domain(name='example.com')
+        models.db.session.add(domain)
+    user = models.User(localpart=localpart, domain=domain, enabled=enabled)
+    user.set_password('password', keep_sessions=True)
+    # Establish the migration generation explicitly; logical rotations are
+    # exercised by individual tests.
+    user.auth_generation = INITIAL_GENERATION
+    models.db.session.add(user)
+    models.db.session.commit()
+    return user
+
+
+def add_authority_probe(app):
+    @app.route('/_test/session-authority')
+    def session_authority_probe():
+        if not flask_login.current_user.is_authenticated:
+            return '', 401
+        return flask_login.current_user.email, 200
+
+
+def seed_browser_session(client, user_id, generation=INITIAL_GENERATION):
+    with client.session_transaction() as session:
+        session['_user_id'] = user_id
+        if generation is not None:
+            session['_auth_generation'] = generation
+
+
+def test_session_loader_rejects_generation_mismatch(app, client):
+    add_authority_probe(app)
+    with app.app_context():
+        user = create_user(localpart='stale-browser')
+        user_id = user.email
+        user.auth_generation = '1' * 32
+        models.db.session.commit()
+
+    seed_browser_session(client, user_id, INITIAL_GENERATION)
+    response = client.get('/_test/session-authority')
+
+    assert response.status_code == 401
+    with client.session_transaction() as session:
+        assert '_user_id' not in session
+        assert '_auth_generation' not in session
+
+
+def test_session_loader_rejects_missing_user(app, client):
+    add_authority_probe(app)
+    seed_browser_session(client, 'deleted-user@example.com')
+
+    response = client.get('/_test/session-authority')
+
+    assert response.status_code == 401
+    with client.session_transaction() as session:
+        assert '_user_id' not in session
+        assert '_auth_generation' not in session
+
+
+def test_session_loader_backfills_only_legacy_initial_generation(app, client):
+    add_authority_probe(app)
+    with app.app_context():
+        user = create_user(localpart='legacy-browser')
+        user_id = user.email
+        assert user.auth_generation == INITIAL_GENERATION
+
+    seed_browser_session(client, user_id, generation=None)
+    response = client.get('/_test/session-authority')
+
+    assert response.status_code == 200
+    with client.session_transaction() as session:
+        assert session['_auth_generation'] == INITIAL_GENERATION
+
+
+def test_session_loader_rejects_disabled_user_even_with_matching_generation(
+    app,
+    client,
+):
+    add_authority_probe(app)
+    with app.app_context():
+        user = create_user(localpart='disabled-browser', enabled=False)
+        user_id = user.email
+        generation = user.auth_generation
+
+    seed_browser_session(client, user_id, generation)
+    response = client.get('/_test/session-authority')
+
+    assert response.status_code == 401
+
+
+def test_session_loader_rejects_malformed_generation(app, client):
+    add_authority_probe(app)
+    with app.app_context():
+        user_id = create_user(localpart='malformed-browser').email
+
+    seed_browser_session(client, user_id, 'not-an-auth-generation')
+    response = client.get('/_test/session-authority')
+
+    assert response.status_code == 401
+
+
+def test_login_wrapper_stamps_generation_and_refuses_disabled_user(app):
+    with app.test_request_context('/'):
+        user = create_user(localpart='login-wrapper')
+        user.auth_generation = '2' * 32
+        models.db.session.commit()
+
+        assert utils.login_user(user) is True
+        assert flask.session['_user_id'] == user.email
+        assert flask.session['_auth_generation'] == '2' * 32
+
+        user.enabled = False
+        assert utils.login_user(user) is False
+
+
+def test_password_and_enablement_changes_rotate_model_authority(app):
+    with app.app_context():
+        user = create_user(localpart='model-authority')
+        assert user.auth_generation == INITIAL_GENERATION
+
+        user.set_password('replacement-password', keep_sessions=True)
+        password_generation = user.auth_generation
+        assert password_generation != INITIAL_GENERATION
+
+        user.enabled = False
+        disabled_generation = user.auth_generation
+        assert disabled_generation != password_generation
+
+        user.enabled = False
+        assert user.auth_generation == disabled_generation
+
+        user.enabled = True
+        assert user.auth_generation != disabled_generation
+
+
+def test_temp_webmail_token_is_bound_to_user_generation(app):
+    with app.app_context():
+        user = create_user(localpart='webmail-generation')
+        user.auth_generation = '3' * 32
+        models.db.session.commit()
+
+        browser_session = utils.MailuSession(app=app)
+        browser_session['_user_id'] = user.email
+        browser_session['_auth_generation'] = user.auth_generation
+        browser_session.save()
+        token = utils.gen_temp_token(user.email, browser_session)
+        browser_session.save()
+
+        assert utils.verify_temp_token(user, token) is True
+
+        user.auth_generation = '4' * 32
+        models.db.session.commit()
+        assert utils.verify_temp_token(user, token) is False
+
+        user.enabled = False
+        assert utils.verify_temp_token(user, token) is False
+
+
+def test_prune_sessions_removes_backing_session_and_webmail_token(app):
+    with app.app_context():
+        user = create_user(localpart='prune-webmail-token')
+        browser_session = utils.MailuSession(app=app)
+        browser_session['_user_id'] = user.email
+        browser_session['_auth_generation'] = user.auth_generation
+        browser_session.save()
+        token = utils.gen_temp_token(user.email, browser_session)
+        browser_session.save()
+
+        assert utils.want_bytes(token) in app.session_store.list()
+        assert browser_session.sid in app.session_store.list()
+        assert utils.MailuSessionExtension.prune_sessions(
+            uid=user.email,
+        ) == 1
+        assert utils.want_bytes(token) not in app.session_store.list()
+        assert browser_session.sid not in app.session_store.list()
+
+
+def test_stale_sessions_do_not_transfer_across_hard_delete_recreate(
+    app,
+    client,
+):
+    add_authority_probe(app)
+    with app.app_context():
+        old_user = create_user(localpart='recreated-authority')
+        old_user_id = old_user.email
+        old_generation = old_user.auth_generation
+
+        browser_session = utils.MailuSession(app=app)
+        browser_session['_user_id'] = old_user_id
+        browser_session['_auth_generation'] = old_generation
+        browser_session.save()
+        webmail_token = utils.gen_temp_token(old_user_id, browser_session)
+        browser_session.save()
+
+        models.db.session.delete(old_user)
+        models.db.session.commit()
+
+        domain = models.db.session.get(models.Domain, 'example.com')
+        replacement = models.User(
+            localpart='recreated-authority',
+            domain=domain,
+        )
+        replacement.set_password('replacement', keep_sessions=True)
+        models.db.session.add(replacement)
+        models.db.session.commit()
+
+        assert replacement.auth_generation != old_generation
+        assert utils.verify_temp_token(replacement, webmail_token) is False
+
+    seed_browser_session(client, old_user_id, old_generation)
+    response = client.get('/_test/session-authority')
+
+    assert response.status_code == 401
+    with client.session_transaction() as session:
+        assert '_user_id' not in session
+        assert '_auth_generation' not in session
+
+
+def test_finish_authority_change_regenerates_before_best_effort_prune(
+    app,
+    monkeypatch,
+):
+    events = []
+    with app.test_request_context('/'):
+        user = create_user(localpart='finish-authority')
+        user.auth_generation = '5' * 32
+        models.db.session.commit()
+        assert utils.login_user(user) is True
+        flask.session.save()
+        assert flask.session.saved is True
+
+        user.auth_generation = '6' * 32
+        models.db.session.commit()
+
+        def record_prune(uid=None, keep=None, app=None):
+            events.append(
+                ('prune', uid, flask.session.saved, flask.session.sid)
+            )
+            return 1
+
+        monkeypatch.setattr(
+            utils.MailuSessionExtension,
+            'prune_sessions',
+            record_prune,
+        )
+
+        result = utils.finish_session_authority_change(
+            user,
+            preserve_current=True,
+        )
+
+        assert result is True
+        assert flask.session['_auth_generation'] == '6' * 32
+        assert events == [('prune', user.email, False, None)]
+
+
+def test_finish_authority_change_rejects_concurrently_replaced_generation(
+    app,
+    monkeypatch,
+):
+    pruned = []
+    with app.test_request_context('/'):
+        user = create_user(localpart='concurrent-authority')
+        user.auth_generation = '5' * 32
+        models.db.session.commit()
+        assert utils.login_user(user) is True
+
+        # The caller committed generation 6, but a concurrent authority
+        # change won the database race before the current session was rebound.
+        user.auth_generation = '7' * 32
+        models.db.session.commit()
+
+        monkeypatch.setattr(
+            utils.MailuSessionExtension,
+            'prune_sessions',
+            lambda uid=None, **_kwargs: pruned.append(uid) or 1,
+        )
+
+        result = utils.finish_session_authority_change(
+            user,
+            preserve_current=True,
+            expected_generation='6' * 32,
+            uid=user.email,
+        )
+
+        assert result is True
+        assert '_user_id' not in flask.session
+        assert '_auth_generation' not in flask.session
+        assert pruned == [user.email]
+
+
+def test_post_commit_cleanup_failure_does_not_escape(app, monkeypatch):
+    with app.app_context():
+        user = create_user(localpart='cleanup-failure')
+
+        def fail_prune(**_kwargs):
+            raise RuntimeError('session store unavailable')
+
+        monkeypatch.setattr(
+            utils.MailuSessionExtension,
+            'prune_sessions',
+            fail_prune,
+        )
+
+        assert utils.finish_session_authority_change(user) is False
+
+
+class _Field:
+    def __init__(self, data):
+        self.data = data
+
+
+class _PasswordForm:
+    pw = _Field('replacement-password')
+    pw2 = _Field('replacement-password')
+    current_pw = _Field('password')
+    pwned = _Field(-1)
+
+    @staticmethod
+    def validate_on_submit():
+        return True
+
+
+def test_self_password_flow_commits_before_rebinding_session(
+    app,
+    monkeypatch,
+):
+    events = []
+    rebound = []
+    with app.test_request_context('/user/password', method='POST'):
+        user = create_user(localpart='password-order')
+        assert utils.login_user(user)
+
+        monkeypatch.setattr(
+            models.User,
+            'login',
+            classmethod(lambda _cls, _email, _password: user),
+        )
+
+        def set_password(_password, **_kwargs):
+            events.append('set-password')
+            user.auth_generation = '7' * 32
+
+        monkeypatch.setattr(user, 'set_password', set_password)
+        monkeypatch.setattr(
+            models.db.session,
+            'commit',
+            lambda: events.append('commit'),
+        )
+
+        def finish(changed_user, **kwargs):
+            events.append('finish')
+            rebound.append((changed_user, kwargs))
+
+        monkeypatch.setattr(
+            utils,
+            'finish_session_authority_change',
+            finish,
+        )
+        monkeypatch.setattr(flask, 'render_template', lambda *_a, **_k: '')
+
+        user_views._process_password_change(_PasswordForm(), None)
+
+    assert events == ['set-password', 'commit', 'finish']
+    assert rebound == [
+        (
+            user,
+            {
+                'preserve_current': True,
+                'expected_generation': '7' * 32,
+                'uid': user.email,
+            },
+        ),
+    ]
+
+
+def test_failed_password_commit_does_not_regenerate_or_prune(
+    app,
+    monkeypatch,
+):
+    events = []
+    with app.test_request_context('/user/password', method='POST'):
+        user = create_user(localpart='password-rollback')
+        assert utils.login_user(user)
+        flask.session.save()
+        original_key = flask.session._key
+
+        monkeypatch.setattr(
+            models.User,
+            'login',
+            classmethod(lambda _cls, _email, _password: user),
+        )
+        monkeypatch.setattr(
+            user,
+            'set_password',
+            lambda *_args, **_kwargs: events.append('set-password'),
+        )
+
+        def fail_commit():
+            events.append('commit')
+            raise RuntimeError('database unavailable')
+
+        monkeypatch.setattr(models.db.session, 'commit', fail_commit)
+        monkeypatch.setattr(
+            utils,
+            'finish_session_authority_change',
+            lambda *_args, **_kwargs: events.append('finish'),
+        )
+
+        with pytest.raises(RuntimeError, match='database unavailable'):
+            user_views._process_password_change(_PasswordForm(), None)
+
+        assert events == ['set-password', 'commit']
+        assert flask.session.saved is True
+        assert flask.session._key == original_key
+
+
+def test_user_app_tokens_remain_separate_from_browser_generation(app):
+    with app.app_context():
+        user = create_user(localpart='app-token-separation')
+        token = models.Token(user_email=user.email)
+        token.set_password('a' * 32)
+        models.db.session.add(token)
+        models.db.session.commit()
+
+        original_generation = user.auth_generation
+        assert utils.check_credentials_for_api(user, 'a' * 32, '127.0.0.1')
+        assert user.auth_generation == original_generation

--- a/towncrier/newsfragments/3708.feature
+++ b/towncrier/newsfragments/3708.feature
@@ -1,0 +1,1 @@
+Add SCIM 2.0 user provisioning endpoints for mailbox lifecycle automation.


### PR DESCRIPTION
## What type of PR?

Feature and enhancement.

## What does this PR do?

Adds a hardened SCIM 2.0 provisioning API for Mailu mailbox lifecycle
automation, including:

- SCIM Users and alias-backed Groups;
- persistent provider identities, `externalId`, tombstones, and ETags;
- database-enforced cross-resource address ownership;
- session-authority revocation and post-commit cleanup;
- Bulk request support and strict request/schema validation;
- native migration, rollback, concurrency, and mixed-writer handling across
  SQLite, PostgreSQL, and MariaDB/MySQL;
- bounded graph validation and full-scan cycle detection;
- operator documentation, CLI support, changelog entry, and backend tests.

### Related issue(s)

- Relates to #3708.

## Known upstream connector issue / draft status

This is deliberately opened as a draft. Mailu's source, image, documentation,
migration, correctness, graph, concurrency, and race gates pass, but the final
performance evidence matrix is incomplete because MariaDB Connector/Python
1.1.11 can deadlock in a threaded SQLAlchemy request path.

The reproduced failure is a four-request `PUT` workload at concurrency 4: one
transaction sleeps while owning the singleton `scim_state` row lock, another
waits on the same `UPDATE`, and the owning Python thread never resumes to
commit. MariaDB reports no InnoDB deadlock. The same test completes with
`mysqlconnector`, and isolated reruns reproduce the connector-specific stall.

MariaDB upstream issue CONPY-285 is the direct behavioral match. CONPY-302
affects 1.1.11 and its 1.1.12 fix removes the shared connection-owned
`PyThreadState` mechanism implicated by this failure. We have not yet claimed
that 1.1.12 fixes this exact Mailu reproduction; that diagnostic and the
remaining 47 mariadbconnector performance cells are still required before this
PR should be considered ready.

References:

- https://jira.mariadb.org/browse/CONPY-285
- https://jira.mariadb.org/browse/CONPY-302

## Verification completed

- SQLite admin suite: 353 passed, 9 backend-conditioned skips.
- PostgreSQL: 5 migration tests and 289 SCIM tests passed.
- MariaDB/mysqlconnector: 6 migration and 37 graph/race tests passed.
- MariaDB/mariadbconnector: 6 migration and 37 graph/race tests passed.
- Fresh admin and warning-fatal documentation images built from commit
  `d9c4a1221cd6542b93a84949374a3c5c723d7c7b`.
- Revision-matched code graph rebuilt and source impact verified.

The passing mariadbconnector correctness gates narrow the known defect to the
threaded throughput path; they do not waive it.

## Prerequisites

- [x] Documentation updated.
- [x] Changelog fragment added.
- [ ] Connector deadlock resolved or proven absent with the upstream fix.
- [ ] Remaining mariadbconnector performance cells and final admission review
  completed.
